### PR TITLE
ci: add AI PR review and Claude Code workflows

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,52 @@
+name: Claude Code
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: autops-kube
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,418 @@
+# Automated PR review for Launcher
+# Posts AI-generated code review comments on pull requests.
+# Ported from the GitLab mr-review.yml template (meta/ci-templates/mr-review.yml).
+#
+# Backend: claude-max-proxy (wende/claude-max-api-proxy) sidecar of the
+# openclaw StatefulSet, at http://openclaw-claude-proxy.openclaw.svc:3456.
+# The proxy exposes an OpenAI-compatible /v1/chat/completions endpoint but
+# ignores the request "model" field and always routes through Claude Code CLI
+# on the Max subscription. PR_REVIEW_MODEL / PR_REVIEW_ASSESS_MODEL are
+# cosmetic labels only.
+#
+# Two-pass review:
+#   Pass 1: Review pass analyzes the diff and posts findings
+#   Pass 2: Assessment pass fact-checks the review for hallucinations
+#   (Both passes now hit the same Claude instance — the "different model"
+#    second-opinion pattern is no longer enforced by the backend.)
+#
+# Requires a self-hosted runner (arc-runners) with in-cluster access to
+# claude-max-proxy. No API key secrets needed — the proxy uses the host's
+# Claude Max credentials.
+#
+# Optional overrides (repository variables):
+#   PR_REVIEW_MODEL             - Model label for the review pass (default: claude-opus-4)
+#   PR_REVIEW_MAX_DIFF_CHARS    - Max diff size in chars (default: 50000)
+#   PR_REVIEW_MAX_TOKENS        - Max response tokens (default: 1500)
+#   PR_REVIEW_CONTEXT           - Additional project context for system prompt
+#   PR_REVIEW_ASSESS_ENABLED    - Enable assessment pass (default: true)
+#   PR_REVIEW_ASSESS_MODEL      - Model for assessment (default: claude-sonnet-4-6)
+#   PR_REVIEW_ASSESS_MAX_TOKENS - Max tokens for assessment (default: 4096)
+#   PR_REVIEW_AGENTS_FILE       - Path to project context file (default: AGENTS.md)
+
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  pr-review:
+    name: AI Code Review
+    runs-on: autops-kube
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+
+    env:
+      CCPROXY_URL: "http://openclaw-claude-proxy.openclaw.svc:3456"
+      PR_REVIEW_MODEL: "claude-opus-4"
+      PR_REVIEW_MAX_DIFF_CHARS: "50000"
+      PR_REVIEW_MAX_TOKENS: "1500"
+      PR_REVIEW_CONTEXT: "OAM-native package manager for Kubernetes, shipped as the kurel CLI. Implements a two-config-set model: package config (app requirements) + site config (cluster capabilities), resolved at install time to produce Kubernetes manifests. Part of the Wharf platform."
+      PR_REVIEW_ASSESS_ENABLED: "true"
+      PR_REVIEW_ASSESS_MODEL: "claude-sonnet-4-6"
+      PR_REVIEW_ASSESS_MAX_TOKENS: "4096"
+      PR_REVIEW_AGENTS_FILE: "AGENTS.md"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup tools
+        run: |
+          for cmd in curl jq; do
+            if ! command -v "$cmd" &>/dev/null; then
+              if command -v sudo &>/dev/null; then
+                sudo apt-get update -qq && sudo apt-get install -y -qq curl jq
+              else
+                apt-get update -qq && apt-get install -y -qq curl jq
+              fi
+              break
+            fi
+          done
+
+      - name: Run review
+        id: review
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+
+          # --- Load project context (AGENTS.md) ---
+          PROJECT_AGENTS=""
+          if [ -n "${PR_REVIEW_AGENTS_FILE}" ] && [ -f "${PR_REVIEW_AGENTS_FILE}" ]; then
+            PROJECT_AGENTS=$(cat "${PR_REVIEW_AGENTS_FILE}")
+            AGENTS_LEN=$(printf '%s' "$PROJECT_AGENTS" | wc -c)
+            echo "Loaded project context from ${PR_REVIEW_AGENTS_FILE} (${AGENTS_LEN} chars)."
+          else
+            echo "No ${PR_REVIEW_AGENTS_FILE:-AGENTS.md} found, proceeding without project context."
+          fi
+
+          # --- Load project notes (.claude/CLAUDE.md) ---
+          PROJECT_CLAUDE_MD=""
+          if [ -f ".claude/CLAUDE.md" ]; then
+            PROJECT_CLAUDE_MD=$(cat ".claude/CLAUDE.md")
+            echo "Loaded .claude/CLAUDE.md ($(printf '%s' "$PROJECT_CLAUDE_MD" | wc -c) chars)."
+          fi
+
+          # --- Fetch PR diff ---
+          echo "Fetching PR diff for #${PR_NUMBER}..."
+          DIFF=$(curl -sf \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github.diff" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+
+          if [ -z "$DIFF" ]; then
+            echo "No diff found, skipping review."
+            exit 0
+          fi
+
+          # --- Fetch PR metadata ---
+          PR_DATA=$(curl -sf \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // "Untitled"')
+          PR_DESC=$(echo "$PR_DATA" | jq -r '.body // ""')
+
+          # --- Truncate if too large ---
+          DIFF_LEN=${#DIFF}
+          if [ "$DIFF_LEN" -gt "$PR_REVIEW_MAX_DIFF_CHARS" ]; then
+            echo "Diff is ${DIFF_LEN} chars, truncating to ${PR_REVIEW_MAX_DIFF_CHARS}..."
+            DIFF="${DIFF:0:$PR_REVIEW_MAX_DIFF_CHARS}
+          ... (diff truncated at ${PR_REVIEW_MAX_DIFF_CHARS} chars)"
+          fi
+
+          # --- Build system prompt ---
+          echo "Requesting review from ${PR_REVIEW_MODEL}..."
+
+          SYSTEM_PROMPT=$(cat <<'PROMPT'
+          You review GitHub pull requests for the Launcher project (OAM-native package manager for Kubernetes).
+
+          ANTI-HALLUCINATION RULES:
+          - Only flag issues you can point to with a specific file and line from the diff.
+          - Do NOT flag standards violations unless the standard text appears in the PROJECT STANDARDS section below.
+          - Do NOT invent or assume coding standards — only cite rules explicitly provided.
+            If no PROJECT STANDARDS section is present, do not flag any standards violations.
+          - If unsure whether something is a real issue, skip it. Precision matters more than recall.
+          - Never reference documentation, files, or code not present in the diff or context provided.
+
+          RULES:
+          - Report ONLY: bugs, security issues, incorrect error handling, logic errors, standards violations.
+          - Do NOT comment on: style preferences, naming opinions, missing tests, documentation,
+            code organization, or performance unless it causes a bug.
+          - Do NOT suggest adding complexity (interfaces, abstractions, design patterns) unless
+            the current code has a concrete defect.
+          - Do NOT duplicate what linters already enforce.
+          - Max 3 findings, ranked by severity (Critical > High > Medium).
+          - If no significant issues, output only the LGTM header line from the OUTPUT FORMAT below.
+
+          OUTPUT FORMAT:
+          Start with a one-line conclusion: "### N issue(s) found" (or "### LGTM -- no issues found" if clean).
+          Then list findings in a markdown table:
+
+          | # | Severity | Location | Issue | Fix |
+          |---|----------|----------|-------|-----|
+          | 1 | Critical | `file:line` | summary | fix |
+
+          If no issues, output only the LGTM header line. Nothing else.
+          No explanations, no reasoning, no verbose context.
+          PROMPT
+          )
+
+          if [ -n "${PR_REVIEW_CONTEXT}" ]; then
+            SYSTEM_PROMPT="${SYSTEM_PROMPT}
+
+          ADDITIONAL PROJECT CONTEXT:
+          ${PR_REVIEW_CONTEXT}"
+          fi
+
+          if [ -n "$PROJECT_AGENTS" ]; then
+            SYSTEM_PROMPT="${SYSTEM_PROMPT}
+
+          PROJECT DOCUMENTATION (AGENTS.md):
+          ${PROJECT_AGENTS}"
+          fi
+
+          if [ -n "$PROJECT_CLAUDE_MD" ]; then
+            SYSTEM_PROMPT="${SYSTEM_PROMPT}
+
+          PROJECT NOTES (.claude/CLAUDE.md):
+          ${PROJECT_CLAUDE_MD}"
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg model "$PR_REVIEW_MODEL" \
+            --arg diff "$DIFF" \
+            --arg title "$PR_TITLE" \
+            --arg desc "$PR_DESC" \
+            --arg system "$SYSTEM_PROMPT" \
+            --argjson max_tokens "${PR_REVIEW_MAX_TOKENS}" \
+            '{
+              model: $model,
+              max_tokens: $max_tokens,
+              messages: [
+                {
+                  role: "system",
+                  content: $system
+                },
+                {
+                  role: "user",
+                  content: ("Review this pull request.\n\nTitle: " + $title + "\nDescription: " + $desc + "\n\nDiff:\n```\n" + $diff + "\n```")
+                }
+              ]
+            }')
+
+          HTTP_CODE=$(curl -s -o /tmp/review_response.json -w '%{http_code}' \
+            -X POST "${CCPROXY_URL}/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          RESPONSE=$(cat /tmp/review_response.json)
+
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "ERROR: claude-max-proxy returned HTTP ${HTTP_CODE}"
+            echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+            exit 1
+          fi
+
+          REVIEW=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+          # Strip model reasoning traces (e.g. <thinking>...</thinking>)
+          REVIEW=$(printf '%s' "$REVIEW" | awk '
+            /<thinking>.*<\/thinking>/ { gsub(/<thinking>.*<\/thinking>/, ""); if (length($0) > 0) print; next }
+            /<thinking>/ { skip=1; next }
+            /<\/thinking>/ { sub(/.*<\/thinking>/, ""); skip=0; if (length($0) > 0) print; next }
+            skip==0 { print }
+          ')
+          # Trim leading blank lines
+          REVIEW=$(printf '%s' "$REVIEW" | sed '/./,$!d')
+
+          if [ -z "$REVIEW" ]; then
+            echo "ERROR: Empty response from model"
+            echo "$RESPONSE" | jq . 2>/dev/null || echo "$RESPONSE"
+            exit 1
+          fi
+
+          echo "Review received ($(printf '%s' "$REVIEW" | wc -c) chars)."
+
+          # --- Save review for comment and assessment steps ---
+          printf '%s' "$REVIEW" > /tmp/review_body.txt
+          printf '%s' "$DIFF" > /tmp/pr_diff.txt
+          printf '%s' "$PR_TITLE" > /tmp/pr_title.txt
+          printf '%s' "$PROJECT_AGENTS" > /tmp/project_agents.txt
+          printf '%s' "$PROJECT_CLAUDE_MD" > /tmp/project_claude_md.txt
+
+          # --- Build comment body ---
+          {
+            printf '## AI Code Review (%s)\n\n' "$PR_REVIEW_MODEL"
+            cat /tmp/review_body.txt
+            printf '\n\n---\n*Automated review — this is advisory only.*'
+          } > /tmp/review_comment.md
+
+          # --- Check if LGTM ---
+          if printf '%s' "$REVIEW" | grep -qi 'LGTM'; then
+            echo "is_lgtm=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_lgtm=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post review comment
+        if: steps.review.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d "$(jq -n --rawfile body /tmp/review_comment.md '{body: $body}')"
+
+      - name: Run assessment
+        if: steps.review.outcome == 'success' && steps.review.outputs.is_lgtm != 'true' && env.PR_REVIEW_ASSESS_ENABLED == 'true'
+        id: assessment
+        run: |
+          set -eu
+
+          echo "Requesting review assessment from ${PR_REVIEW_ASSESS_MODEL}..."
+
+          REVIEW=$(cat /tmp/review_body.txt)
+          DIFF=$(cat /tmp/pr_diff.txt)
+          PR_TITLE=$(cat /tmp/pr_title.txt)
+          PROJECT_AGENTS=$(cat /tmp/project_agents.txt)
+          PROJECT_CLAUDE_MD=$(cat /tmp/project_claude_md.txt)
+
+          ASSESS_SYSTEM=$(cat <<'ASSESS_PROMPT'
+          You fact-check AI-generated code reviews against the actual pull request diff
+          and the full project context provided below.
+
+          The review was produced by an automated system that sometimes hallucinates —
+          it may reference code that does not exist in the diff, misunderstand language
+          idioms, or flag correct patterns as bugs.
+
+          Use the PROJECT CONTEXT (if provided) to understand the project's architecture,
+          design decisions, coding patterns, and interfaces. This context describes the
+          codebase beyond what is visible in the diff alone — use it to determine whether
+          a reviewer's concern is valid given the broader project design.
+
+          For each finding in the review:
+          1. Verify the referenced file, line range, and code actually exist in the diff.
+          2. Cross-reference claims against the project context — does the reviewer
+             misunderstand a deliberate design pattern or architectural decision?
+          3. Determine if the claimed issue is a real bug or a false positive.
+          4. Classify as: VALID (real issue, should be fixed), FALSE POSITIVE (incorrect
+             claim or hallucination), or PARTIALLY VALID (core concern has merit but
+             details are wrong or overstated).
+
+          If a finding references code not present in the diff, flag it as a hallucination.
+
+          STANDARDS VERIFICATION:
+          When the reviewer claims a "standards violation," check whether the cited standard
+          actually appears in the PROJECT STANDARDS section below. If no PROJECT STANDARDS
+          are provided, or the cited rule does not appear in them, classify the finding as
+          FALSE POSITIVE with reason "cited standard not found in project standards."
+
+          OUTPUT FORMAT:
+          Start with: "### Assessment: N of M findings are actionable"
+          Then a table:
+
+          | # | Verdict | Reasoning |
+          |---|---------|-----------|
+          | 1 | FALSE POSITIVE | brief explanation |
+
+          No other text. No suggestions. No re-review of the code itself.
+          ASSESS_PROMPT
+          )
+
+          # Inject project context into assessment prompt
+          if [ -n "$PROJECT_AGENTS" ]; then
+            ASSESS_SYSTEM="${ASSESS_SYSTEM}
+
+          PROJECT CONTEXT:
+          ${PROJECT_AGENTS}"
+          fi
+
+          if [ -n "$PROJECT_CLAUDE_MD" ]; then
+            ASSESS_SYSTEM="${ASSESS_SYSTEM}
+
+          PROJECT NOTES (.claude/CLAUDE.md):
+          ${PROJECT_CLAUDE_MD}"
+          fi
+
+          ASSESS_PAYLOAD=$(jq -n \
+            --arg model "$PR_REVIEW_ASSESS_MODEL" \
+            --arg diff "$DIFF" \
+            --arg review "$REVIEW" \
+            --arg title "$PR_TITLE" \
+            --arg system "$ASSESS_SYSTEM" \
+            --argjson max_tokens "${PR_REVIEW_ASSESS_MAX_TOKENS}" \
+            '{
+              model: $model,
+              max_tokens: $max_tokens,
+              messages: [
+                {
+                  role: "system",
+                  content: $system
+                },
+                {
+                  role: "user",
+                  content: ("Assess this AI-generated review against the actual diff and project context.\n\nPR Title: " + $title + "\n\n--- REVIEW ---\n" + $review + "\n\n--- DIFF ---\n```\n" + $diff + "\n```")
+                }
+              ]
+            }')
+
+          ASSESS_HTTP=$(curl -s -o /tmp/assess_response.json -w '%{http_code}' \
+            -X POST "${CCPROXY_URL}/v1/chat/completions" \
+            -H "Content-Type: application/json" \
+            -d "$ASSESS_PAYLOAD")
+          ASSESS_RESP=$(cat /tmp/assess_response.json)
+
+          if [ "$ASSESS_HTTP" -lt 200 ] || [ "$ASSESS_HTTP" -ge 300 ]; then
+            echo "WARNING: Assessment request failed (HTTP ${ASSESS_HTTP}), skipping."
+            echo "$ASSESS_RESP" | jq . 2>/dev/null || echo "$ASSESS_RESP"
+            exit 0
+          fi
+
+          ASSESSMENT=$(echo "$ASSESS_RESP" | jq -r '.choices[0].message.content // empty')
+
+          # Strip reasoning traces
+          ASSESSMENT=$(printf '%s' "$ASSESSMENT" | awk '
+            /<thinking>.*<\/thinking>/ { gsub(/<thinking>.*<\/thinking>/, ""); if (length($0) > 0) print; next }
+            /<thinking>/ { skip=1; next }
+            /<\/thinking>/ { sub(/.*<\/thinking>/, ""); skip=0; if (length($0) > 0) print; next }
+            skip==0 { print }
+          ')
+          ASSESSMENT=$(printf '%s' "$ASSESSMENT" | sed '/./,$!d')
+
+          if [ -n "$ASSESSMENT" ]; then
+            echo "Assessment received ($(printf '%s' "$ASSESSMENT" | wc -c) chars)."
+
+            {
+              printf '## Review Assessment (%s)\n\n' "$PR_REVIEW_ASSESS_MODEL"
+              printf '%s' "$ASSESSMENT"
+              printf '\n\n---\n*Automated assessment of the AI review above — advisory only.*'
+            } > /tmp/assess_comment.md
+            echo "has_comment=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "WARNING: Empty assessment response, skipping."
+            exit 0
+          fi
+
+      - name: Post assessment comment
+        if: steps.assessment.outputs.has_comment == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          curl -sf -X POST \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Content-Type: application/json" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d "$(jq -n --rawfile body /tmp/assess_comment.md '{body: $body}')"


### PR DESCRIPTION
## Summary

- Adds `pr-review.yml`: automated two-pass AI code review on every non-draft PR via the internal `claude-max-proxy`
- Adds `claude.yml`: Claude Code interactive action, triggered automatically on PRs and by `@claude` mentions in comments/issues/reviews

Mirrors the setup already running in the kure repo.

## Test plan

- [ ] Open a non-draft PR and confirm the `AI Code Review` job runs and posts a comment
- [ ] Confirm `@claude` mention in a PR comment triggers the Claude Code action