### PR TITLE
fix(docs): add CHANGELOG.md to check-mounts verification

### DIFF
--- a/site/scripts/check-mounts.sh
+++ b/site/scripts/check-mounts.sh
@@ -13,6 +13,7 @@ LAUNCHER_ROOT="${1:-$(cd "$SITE_DIR/.." && pwd)}"
 MOUNTED_FILES=(
   "README.md"
   "DEVELOPMENT.md"
+  "CHANGELOG.md"
   "docs/design.md"
 )
 


### PR DESCRIPTION
## Summary

`site/scripts/inject-frontmatter.sh` mounts `CHANGELOG.md` as `changelog/releases.md`, but `site/scripts/check-mounts.sh` did not include it in its verification list. If CHANGELOG.md went missing, the validation gate would pass but the Hugo build would silently skip that page.

## Test plan

- [ ] `bash site/scripts/check-mounts.sh` passes locally
- [ ] CI `docs-build` job passes