### PR TITLE
ci: route cache through in-cluster server (fix timeouts)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
   validate:
     name: lint
     runs-on: autops-kube
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -171,7 +171,7 @@ jobs:
   test:
     name: test
     runs-on: autops-kube
-    timeout-minutes: 15
+    timeout-minutes: 25
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -200,12 +200,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps
@@ -401,12 +399,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps
@@ -579,12 +575,10 @@ jobs:
     - name: Cache Go modules
       uses: actions/cache@v5
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-
+          ${{ runner.os }}-gomod-
 
     - name: Install dependencies
       run: make deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ env:
   # Go version is read from mise.toml (single source of truth)
   # GO_VERSION is set dynamically in each job that needs it
   GOLANGCI_LINT_VERSION: 'v2.10.1'
+  # Force actions/cache to use the legacy REST API (v1) so it reads ACTIONS_CACHE_URL
+  # from the runner pod env, routing cache traffic through the in-cluster cache server.
+  # Without this, cache@v5 uses the twirp API via ACTIONS_RESULTS_URL which GitHub's
+  # job dispatch overwrites with its own URL, bypassing the local cache server entirely.
+  ACTIONS_CACHE_SERVICE_V2: 'false'
 
 # Avoid duplicate runs on the same commit
 concurrency:


### PR DESCRIPTION
## Summary

- Forces `actions/cache@v5` to use the legacy REST API (v1) via `ACTIONS_CACHE_SERVICE_V2: 'false'`
- Also drops the `~/.cache/go-build` compiler cache from caching (only `~/go/pkg/mod` cached) and bumps job timeouts

## Root cause

GitHub's job dispatch **overwrites** `ACTIONS_RESULTS_URL` in the runner container env when it dispatches a job. This means `actions/cache@v5` (which defaults to the twirp/v2 API that reads `ACTIONS_RESULTS_URL`) always routes to GitHub's cloud cache, bypassing the in-cluster falcondev cache server entirely.

`ACTIONS_CACHE_URL` is **not** overwritten by GitHub's job dispatch. The runner pod already has this set to the local server. By forcing the legacy API, `actions/cache@v5` reads `ACTIONS_CACHE_URL` and routes all traffic in-cluster.

A paired change in opsmaster adds `ACTIONS_CACHE_URL` explicitly to the runner pod env (alongside the existing `ACTIONS_RESULTS_URL`).

## Test plan

- [ ] CI runs complete without timeout
- [ ] Cache hits appear on subsequent runs (speedup)
- [ ] Garage S3 `actions-cache` bucket starts receiving writes