### PR TITLE
ci: expand workflow path filter and fix coverage comment threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             - 'go.mod'
             - 'go.sum'
             - 'Makefile'
-            - '.github/workflows/ci.yml'
+            - '.github/workflows/**'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -376,7 +376,7 @@ jobs:
 
           **Total Coverage:** ${{ steps.coverage.outputs.coverage }}%
 
-          Coverage threshold: 85%
+          Coverage threshold: 80%
 
   # =============================================================================
   # Stage 4: Build (parallel with coverage-check)


### PR DESCRIPTION
## Summary

- **Fix 5**: Expand `go:` path filter from `ci.yml` only → `.github/workflows/**` so PRs that only touch workflow files also trigger lint/test/security/build.
- **Fix 6**: Fix sticky PR comment that claimed "Coverage threshold: 85%" when the enforced threshold is 80%.

## Test plan

- [ ] PR that only modifies a workflow file triggers lint/test jobs (previously skipped)
- [ ] Coverage PR comment shows "Coverage threshold: 80%"