### PR TITLE
ci: expand workflow path filter and fix coverage comment threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
             - 'go.mod'
             - 'go.sum'
             - 'Makefile'
-            - '.github/workflows/ci.yml'
+            - '.github/workflows/**'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -376,7 +376,7 @@ jobs:
 
           **Total Coverage:** ${{ steps.coverage.outputs.coverage }}%
 
-          Coverage threshold: 85%
+          Coverage threshold: 80%
 
   # =============================================================================
   # Stage 4: Build (parallel with coverage-check)


### PR DESCRIPTION
## Summary

- Broaden the `go` path filter to match all files under `.github/workflows/**` (not just `ci.yml`) so changes to any workflow file trigger the CI pipeline
- Lower the coverage comment threshold from 85% to 80% to match actual enforcement level

## Test plan

- [ ] Verify CI triggers when other workflow files are modified
- [ ] Verify coverage comment reports 80% threshold