### PR TITLE
docs: add Organization Resources section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,6 +256,20 @@ When implementing a GitHub issue, follow this checklist in order:
 6. **Verify the diff** — before committing, review the full working-tree diff. If there are more changes than expected, ask the user what should be committed.
 7. **Commit, push, PR** — commit with a conventional-commit message, push, and open a PR with `gh pr create`.
 
+## Organization Resources
+
+The go-kure org governance, design documents, and community files are maintained in
+[go-kure/.github](https://github.com/go-kure/.github).
+
+- **Design documents** (`docs/design/`):
+  - [OAM Runtime](https://github.com/go-kure/.github/blob/main/docs/design/oam-runtime.md) — kurel design and architecture
+  - [Package Structure](https://github.com/go-kure/.github/blob/main/docs/design/package-structure.md) — kure + launcher organization
+  - [API Stability Contract](https://github.com/go-kure/.github/blob/main/docs/design/api-stability.md) — versioning, deprecation policy
+  - [OCI Artifact Layout](https://github.com/go-kure/.github/blob/main/docs/design/oci-layout.md) — layout tree conventions
+- **Standards**: [docs/standards.md](https://github.com/go-kure/.github/blob/main/docs/standards.md)
+- **Contributing**: [CONTRIBUTING.md](https://github.com/go-kure/.github/blob/main/CONTRIBUTING.md)
+- **Reusable workflows**: release, auto-rebase, pr-review, claude — all hosted in go-kure/.github
+
 ## Questions?
 
 Refer to:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,10 +32,8 @@ launcher/
 ├── pkg/
 │   ├── launcher/     # Package launcher core (to be migrated from kure)
 │   ├── patch/        # JSONPath-based patching (to be migrated from kure)
-│   ├── cmd/
-│   │   └── kurel/    # kurel command implementations
-│   ├── errors/       # Error handling
-│   └── logger/       # Structured logging
+│   └── cmd/
+│       └── kurel/    # kurel command implementations
 ├── docs/             # Documentation
 │   └── design.md     # Full design document and vision
 ├── .github/


### PR DESCRIPTION
## Summary

- Adds an "Organization Resources" section to `AGENTS.md` pointing to `go-kure/.github` for
  design docs, org standards, contributing guidelines, and reusable workflows

Depends on: go-kure/.github#8 (should be merged first)

## Test plan

- [ ] Links to go-kure/.github resolve correctly after PR #8 merges