### PR TITLE
docs: Phase 0 OAM runtime design documents

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -175,23 +175,23 @@ Launcher targets teams committed to a GitOps-first workflow who want OAM semanti
 **Phase 0 (current): Extraction, design, and housekeeping**
 - Move prototype code from kure — *done*
 - Establish module structure and CI — *done*
-- Design the launcher-native application model — *in progress (PR #58)*
-  - GVK: `launcher.gokure.dev/v1alpha1` for Application, Package, ClusterProfile
-  - ClusterProfile format (`design-cluster-profile.md`)
-  - Parameter syntax options (`options-param-syntax.md`)
-  - Package composition options (`options-package-composition.md`)
-  - Policy interface options (`options-policy-interface.md`)
-  - Package spec (`design-kurel-package.md`) — on hold until param syntax decided
+- Design the launcher-native application model — *in progress (PR #58, closes #36 #37 #38)*
+  - GVK: `launcher.gokure.dev/v1alpha1` for Application, Package, ClusterProfile — *decided*
+  - ClusterProfile format (`design-cluster-profile.md`) — *decided*
+  - Parameter syntax: Option A — `${var}` placeholders with typed schema in `kurel.yaml` — *decided*
+  - Policy interface: Option A — typed accessor interface — *decided*
+  - Package composition: no optional sections in Phase 1; deferred to Phase 2 — *decided*
+  - Package spec (`design-kurel-package.md`) — to be completed in this PR
 
 **Phase 1: OAM-native package format**
 - Implement the launcher Application, Package, and ClusterProfile types
-- Implement parameter resolution (`${var}` placeholders or values overlay — decision pending)
+- Implement parameter resolution — `${var}` placeholders; scalar, node, and inline-string substitution
 - Implement ClusterProfile rendering (capability key resolution, merge semantics)
 - Implement policy enforcement (`--policy` flag, `NoopPolicy`, crane compatibility)
 - CLI: `kurel build` with `--profile`, `--values`, `--policy`, `--set` flags
 
 **Phase 2: Conditional composition (issue #39)**
-- Optional component and trait inclusion
+- Optional component and trait inclusion (boolean gates declared in `kurel.yaml`)
 - Policy-based conditionality
 - Multi-instance component patterns
 
@@ -201,44 +201,38 @@ Launcher targets teams committed to a GitOps-first workflow who want OAM semanti
 
 ---
 
-## 9. Pending Decisions (PR #58 — blocks final design)
+## 9. Phase 0 Design Decisions (PR #58 closes #36, #37, #38)
 
-The following decisions must be made and recorded before `design-kurel-package.md` and
-`design-policy-interface.md` can be completed and PR #58 merged. Options documents for
-each are in `docs/oam/`.
+PR #58 is the single PR that completes all Phase 0 design. It is not merged until all
+three issues are fully resolved and every design document is final. No Phase 1
+implementation work begins before this PR merges.
 
-| Decision | Options doc | Blocks |
+**Decision rule:** launcher is a semantically richer Helm alternative. Explicit package
+API contract and compiler-verified correctness take precedence over YAML validity at rest.
+
+| Concern | Decision | Document |
 |---|---|---|
-| Parameter syntax — `${var}` placeholders vs values overlay | `options-param-syntax.md` | `design-kurel-package.md` §6 |
-| Package composition — how optional sections are declared and enabled | `options-package-composition.md` | `design-kurel-package.md` §4–5 |
-| Policy interface — typed accessors vs opaque marker | `options-policy-interface.md` | `design-policy-interface.md` |
+| API group and version | `launcher.gokure.dev/v1alpha1` for all native docs | `design-gvk.md` |
+| Parser strictness | Strict — unknown fields are a build error | `design-gvk.md` |
+| ClusterProfile format | `cluster.yaml` carries `rendering` only; no `parameters` | `design-cluster-profile.md` |
+| Parameter syntax | **Option A** — `${var}` placeholders; typed schema in `kurel.yaml` | `options-param-syntax.md` |
+| Policy interface | **Option A** — typed accessor interface (~19 methods) | `options-policy-interface.md` |
+| Package composition | **Deferred to Phase 2** — no optional sections in Phase 1 | `options-package-composition.md` |
 
-`design-cluster-profile.md` and `design-gvk.md` are complete and have no open decisions.
-Issue #37 (ClusterProfile) can be closed once PR #58 is approved.
+Issues closed by this PR: #36 (package spec), #37 (ClusterProfile), #38 (policy interface).
 
 ---
 
 ## 10. Open Questions
 
-1. **Conditional inclusion syntax** — How the package author marks optional components and
-   traits, and how the user enables/disables them, is a Phase 0 design question. Two
-   options are compared in `docs/oam/options-package-composition.md`. Deeper conditionality
-   (Phase 2) is tracked in issue #39.
+1. **Conditional inclusion syntax** — No optional sections in Phase 1. Package authors
+   publish always-on packages; separate packages cover distinct deployment variants.
+   Boolean on/off gates and multi-instance support are Phase 2 (issue #39).
 
-2. **Parameter syntax** — Two options compared in `docs/oam/options-param-syntax.md`:
-   - Option A: `${var}` placeholders in `app.yaml`, resolved before parse
-   - Option B: `values.yaml` overlay on a static `app.yaml`
-   Decision pending before `design-kurel-package.md` §6 can be completed.
+2. **Generic/raw YAML escape hatch** — A component type that passes through arbitrary
+   YAML would let package authors handle cases outside the built-in handler set. Not
+   in scope for Phase 1; tracked as future work.
 
-3. **Policy interface** — Two options compared in `docs/oam/options-policy-interface.md`:
-   - Option A: typed accessor interface (~19 methods); compiler-verified; no type assertions
-   - Option B: opaque marker interface; flexible; requires type assertions in handlers
-   Decision pending before `design-policy-interface.md` can be written.
-
-4. **Platform profile format** — Resolved. `ClusterProfile` is a `cluster.yaml` file under
-   `launcher.gokure.dev/v1alpha1`; it carries `rendering` values per capability type. See
-   `docs/oam/design-cluster-profile.md`.
-
-5. **Backwards compatibility with prototype** — The existing `pkg/launcher` pipeline
-   (file-based, patch-centric) is superseded by the new OAM-native design. The prototype
-   code remains in the repository as reference but is not the Phase 1 implementation target.
+3. **Package distribution** — How kurel packages are published, versioned, and referenced
+   by consumers. A standard local layout that lets `kurel build` run without extra flags
+   is the Phase 3 starting point.

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,6 +2,12 @@
 
 *Date: 2026-04-19 | Updated: 2026-05-14 | Status: Phase 0 design in progress (PR #58)*
 
+| Version | Date | Summary |
+|---|---|---|
+| 1.2 | 2026-05-14 | Record all Phase 0 decisions; add §9 decisions table; update roadmap; trim open questions |
+| 1.1 | 2026-05-14 | Update GVK, roadmap, and open questions for second design iteration |
+| 1.0 | 2026-04-19 | Initial draft |
+
 ---
 
 ## 1. Vision
@@ -191,7 +197,7 @@ Launcher targets teams committed to a GitOps-first workflow who want OAM semanti
 - CLI: `kurel build` with `--profile`, `--values`, `--policy`, `--set` flags
 
 **Phase 2: Conditional composition (issue #39)**
-- Optional component and trait inclusion (boolean gates declared in `kurel.yaml`)
+- Optional component and trait inclusion — mechanism TBD, designed in #39
 - Policy-based conditionality
 - Multi-instance component patterns
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,14 +1,16 @@
 # Launcher — Design Document
 
-*Date: 2026-04-19 | Status: Early design — work in progress*
+*Date: 2026-04-19 | Updated: 2026-05-14 | Status: Phase 0 design in progress (PR #58)*
 
 ---
 
 ## 1. Vision
 
-**Launcher** is an OAM-native package manager for Kubernetes — a semantically richer alternative to Helm.
+**Launcher** is an OAM-inspired package manager for Kubernetes — a semantically richer alternative to Helm.
 
-Where Helm templates Kubernetes manifests from Go template files and a flat `values.yaml`, launcher models deployments using the [Open Application Model (OAM)](https://oam.dev/) as its package format. The result is a tool where application structure is explicit and typed, platform implementation choices are separated from application choices, and output is always static, GitOps-ready Kubernetes manifests.
+Where Helm templates Kubernetes manifests from Go template files and a flat `values.yaml`, launcher models deployments using OAM concepts (Applications, Components, Traits) as its package format, under launcher's own API group. The result is a tool where application structure is explicit and typed, platform implementation choices are separated from application choices, and output is always static, GitOps-ready Kubernetes manifests.
+
+Launcher defines its own native application model under `launcher.gokure.dev/v1alpha1`. OAM is the conceptual inspiration, not the API contract — launcher does not claim native API compatibility with `core.oam.dev/v1beta1`.
 
 Launcher uses the [kure](https://github.com/go-kure/kure) library for Kubernetes resource generation.
 
@@ -38,11 +40,12 @@ A **kurel package** is a bundle of OAM specs that can be instantiated with param
 ```
 my-webservice/
 ├── kurel.yaml          # Package metadata and parameter schema
-├── app.yaml            # OAM Application template (parameterized)
-└── patches/            # Optional composition patches
+└── app.yaml            # Application template
 ```
 
-`app.yaml` is a standard OAM Application document with parameter placeholders. The package author defines what can be varied; consumers fill in the values.
+`kurel.yaml` is the package's public API — it declares the parameters (name, type, default, required) and the package version. `app.yaml` is a launcher Application document. The package author defines what can be varied; consumers fill in the values.
+
+The Application document uses `apiVersion: launcher.gokure.dev/v1alpha1`, kind `Application`. ClusterProfile documents (`cluster.yaml`) and Package documents (`kurel.yaml`) use the same API group and version. See `docs/oam/design-gvk.md` for the full GVK rationale.
 
 ### 3.2 Two Parameter Sets
 
@@ -169,20 +172,28 @@ Launcher targets teams committed to a GitOps-first workflow who want OAM semanti
 
 ## 8. Current Status and Roadmap
 
-**Phase 0 (current): Extraction and housekeeping**
-- Move prototype code from kure
-- Establish module structure and CI
-- Document what the prototype does and does not do
+**Phase 0 (current): Extraction, design, and housekeeping**
+- Move prototype code from kure — *done*
+- Establish module structure and CI — *done*
+- Design the launcher-native application model — *in progress (PR #58)*
+  - GVK: `launcher.gokure.dev/v1alpha1` for Application, Package, ClusterProfile
+  - ClusterProfile format (`design-cluster-profile.md`)
+  - Parameter syntax options (`options-param-syntax.md`)
+  - Package composition options (`options-package-composition.md`)
+  - Policy interface options (`options-policy-interface.md`)
+  - Package spec (`design-kurel-package.md`) — on hold until param syntax decided
 
 **Phase 1: OAM-native package format**
-- Define kurel package spec (kurel.yaml schema)
-- Define OAM Application template parameterization
-- Define platform profile contract
-- Implement parameter resolution for both sets
+- Implement the launcher Application, Package, and ClusterProfile types
+- Implement parameter resolution (`${var}` placeholders or values overlay — decision pending)
+- Implement ClusterProfile rendering (capability key resolution, merge semantics)
+- Implement policy enforcement (`--policy` flag, `NoopPolicy`, crane compatibility)
+- CLI: `kurel build` with `--profile`, `--values`, `--policy`, `--set` flags
 
-**Phase 2: Conditional composition**
-- OAM policy-based conditional inclusion (include component X only if trait Y is present)
-- Patch composition on top of OAM Application base
+**Phase 2: Conditional composition (issue #39)**
+- Optional component and trait inclusion
+- Policy-based conditionality
+- Multi-instance component patterns
 
 **Phase 3: Package distribution**
 - OCI-based package publishing and pulling (similar to Helm OCI repositories)
@@ -190,12 +201,44 @@ Launcher targets teams committed to a GitOps-first workflow who want OAM semanti
 
 ---
 
-## 9. Open Questions
+## 9. Pending Decisions (PR #58 — blocks final design)
 
-1. **Conditional inclusion syntax** — OAM does not natively support conditional sections. Proposed: use OAM `PolicyDefinition` with kurel-specific policy types to express conditionality. Needs explicit design.
+The following decisions must be made and recorded before `design-kurel-package.md` and
+`design-policy-interface.md` can be completed and PR #58 merged. Options documents for
+each are in `docs/oam/`.
 
-2. **Platform profile format** — How do platform operators express trait implementations? Options: YAML file, OAM WorkloadDefinition overrides, capability map. Needs design.
+| Decision | Options doc | Blocks |
+|---|---|---|
+| Parameter syntax — `${var}` placeholders vs values overlay | `options-param-syntax.md` | `design-kurel-package.md` §6 |
+| Package composition — how optional sections are declared and enabled | `options-package-composition.md` | `design-kurel-package.md` §4–5 |
+| Policy interface — typed accessors vs opaque marker | `options-policy-interface.md` | `design-policy-interface.md` |
 
-3. **Trait resolution contract** — How does the launcher runtime map "this component requests IngressTrait" to the concrete K8s objects to generate, given a platform profile? This is the core runtime design question.
+`design-cluster-profile.md` and `design-gvk.md` are complete and have no open decisions.
+Issue #37 (ClusterProfile) can be closed once PR #58 is approved.
 
-4. **Backwards compatibility with prototype** — The existing `pkg/launcher` pipeline (file-based, patch-centric) is the starting point. How much of the prototype survives into the new design, and how much is replaced?
+---
+
+## 10. Open Questions
+
+1. **Conditional inclusion syntax** — How the package author marks optional components and
+   traits, and how the user enables/disables them, is a Phase 0 design question. Two
+   options are compared in `docs/oam/options-package-composition.md`. Deeper conditionality
+   (Phase 2) is tracked in issue #39.
+
+2. **Parameter syntax** — Two options compared in `docs/oam/options-param-syntax.md`:
+   - Option A: `${var}` placeholders in `app.yaml`, resolved before parse
+   - Option B: `values.yaml` overlay on a static `app.yaml`
+   Decision pending before `design-kurel-package.md` §6 can be completed.
+
+3. **Policy interface** — Two options compared in `docs/oam/options-policy-interface.md`:
+   - Option A: typed accessor interface (~19 methods); compiler-verified; no type assertions
+   - Option B: opaque marker interface; flexible; requires type assertions in handlers
+   Decision pending before `design-policy-interface.md` can be written.
+
+4. **Platform profile format** — Resolved. `ClusterProfile` is a `cluster.yaml` file under
+   `launcher.gokure.dev/v1alpha1`; it carries `rendering` values per capability type. See
+   `docs/oam/design-cluster-profile.md`.
+
+5. **Backwards compatibility with prototype** — The existing `pkg/launcher` pipeline
+   (file-based, patch-centric) is superseded by the new OAM-native design. The prototype
+   code remains in the repository as reference but is not the Phase 1 implementation target.

--- a/docs/oam/design-cluster-profile.md
+++ b/docs/oam/design-cluster-profile.md
@@ -6,11 +6,11 @@
 
 ## 1. Purpose
 
-A `ClusterProfile` tells the launcher runtime how the platform implements each OAM trait.
+A `ClusterProfile` tells the launcher runtime how the platform implements each trait.
 It is an environment-level document, written once per cluster by the platform operator and
 shared across all applications deployed to that cluster.
 
-The separation it enforces: an OAM Application says "I need ingress" — the `ClusterProfile`
+The separation it enforces: an Application says "I need ingress" — the `ClusterProfile`
 says "ingress on this cluster means a Gateway API `HTTPRoute`." The application spec is
 portable; the profile is not.
 
@@ -19,19 +19,14 @@ portable; the profile is not.
 ## 2. Schema
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: ClusterProfile
 metadata:
-  name: <string>         # cluster identifier, e.g. "prod-eu-west"
+  name: <string>       # cluster identifier, e.g. "prod-eu-west"
 spec:
   capabilities:
-    <trait-type>:        # e.g. "expose", "certificate", "external-secret"
-      parameters:        # schema: what keys this capability accepts
-        <key>:
-          type: <string | integer | boolean | object | array>
-          required: <bool>      # default: false
-          description: <string> # optional, for documentation
-      rendering:         # values: injected into trait properties at build time
+    <trait-type>:      # e.g. "expose", "certificate", "external-secret"
+      rendering:       # values injected into trait properties at build time
         <key>: <value>
 ```
 
@@ -40,29 +35,41 @@ spec:
 | Field | Type | Description |
 |---|---|---|
 | `metadata.name` | string | Identifies the cluster; referenced in build tooling |
-| `spec.capabilities` | map | Keys are OAM trait types; values are capability definitions |
-| `capabilities.<type>.parameters` | map | Schema declaration: documents accepted keys and types |
-| `capabilities.<type>.rendering` | map | Platform values: merged into trait properties before handler invocation |
+| `spec.capabilities` | map | Keys are trait types; values are capability definitions |
+| `capabilities.<type>.rendering` | map | Platform values merged into trait properties before handler invocation |
+
+### Capability schema
+
+`cluster.yaml` does not carry capability schema — it only carries rendering values.
+The schema of what keys a given capability accepts (types, required fields, descriptions)
+is launcher built-in knowledge, not cluster operator input. Where this schema lives for
+built-in handlers is described in the launcher handler documentation; the design for
+custom capability schema is tracked separately (Q2 in the design backlog).
+
+### Strictness
+
+Launcher rejects unknown fields in `cluster.yaml`. A `ClusterProfile` with unrecognised
+keys is a build error. See `design-gvk.md` for the parser strictness rationale.
 
 ### What is NOT in a launcher ClusterProfile
 
-The following fields exist in crane's `ClusterProfile` but are crane-specific and must not
-appear in the launcher type:
+The following fields exist in crane's `ClusterProfile` but are crane-specific and must
+not appear in a launcher `cluster.yaml`:
 
-- `spec.gitops` — FluxCD/ArgoCD wiring; this is a delivery-layer concern, not an OAM runtime concern
+- `spec.gitops` — FluxCD/ArgoCD wiring; delivery-layer concern
 - `spec.componentCatalog` / `spec.catalog` — Harbor catalog references
 - `spec.componentVariants` — crane layer-3 variant selection
-- `spec.capabilities[*].parameters` is present but **not validated** in Phase 0 or Phase 1 — it is reserved for future schema enforcement
 
 ---
 
 ## 3. Capability Key Resolution
 
-At build time the runtime looks up a capability for each trait using a two-step key resolution:
+At build time the runtime looks up a capability for each trait using a two-step key
+resolution:
 
-1. **Scoped key** — `<type>.<scope>` where `scope` comes from the trait's `properties.scope`
-   field, if set. This allows a cluster to configure multiple implementations of the same
-   trait type (e.g. a public and an internal ingress).
+1. **Scoped key** — `<type>.<scope>` where `scope` comes from the trait's
+   `properties.scope` field, if set. Allows a cluster to configure multiple
+   implementations of the same trait type (e.g. public and internal ingress).
 2. **Bare key** — `<type>` — used when `scope` is absent or no scoped entry is found.
 
 ```
@@ -74,15 +81,15 @@ trait.properties.scope = "internal"
 → if not found, no capability is resolved (handler proceeds without platform values)
 ```
 
-Capability keys in the YAML file may be written in either form:
+Both key forms may be present in the same profile:
 
 ```yaml
 spec:
   capabilities:
-    expose:               # bare key — resolved for any expose trait without a scope
+    expose:            # bare key — matches any expose trait without a scope
       rendering:
         controllerType: ingress
-    expose.internal:      # scoped key — resolved only when trait.properties.scope = "internal"
+    expose.internal:   # scoped key — matched only when trait.properties.scope = "internal"
       rendering:
         controllerType: gateway
         gatewayName: internal-gateway
@@ -92,11 +99,11 @@ spec:
 
 ## 4. Merge Semantics
 
-Rendering values act as platform-provided defaults. OAM Application inline properties
-always take precedence:
+Rendering values are platform-provided defaults. Application inline properties always
+take precedence:
 
 ```
-resolved = rendering ∪ oam-properties   (OAM overwrites)
+resolved = rendering ∪ application-properties   (application overwrites)
 ```
 
 Example:
@@ -109,13 +116,13 @@ certificate:
       name: letsencrypt-prod
       kind: ClusterIssuer
 
-# OAM Application trait:
+# Application trait:
 traits:
 - type: certificate
   properties:
     secretName: my-app-tls
     dnsNames: [my-app.example.com]
-    # issuerRef not set — will come from platform
+    # issuerRef not set — comes from platform
 
 # Resolved trait properties (what the handler receives):
 {
@@ -125,84 +132,32 @@ traits:
 }
 ```
 
-If the OAM Application overrides an individual key within a nested map, only that key is
-overridden; unmentioned sibling keys from rendering are preserved.
+If the Application overrides an individual key within a nested map, only that key is
+overridden; sibling keys from rendering are preserved.
 
 ---
 
-## 5. Parameters Field
-
-The `parameters` field documents the schema of a capability — what keys it accepts, their
-types, and which are required. In Phase 0–1, this field is **informational only** — the
-runtime writes it but does not validate rendering or OAM trait properties against it.
-
-Its purpose in this phase is to give package authors a machine-readable description of what
-a capability provides, so tools (editors, linters) can validate `app.yaml` against the
-cluster's declared capability shape.
-
-Example:
-
-```yaml
-expose:
-  parameters:
-    controllerType:
-      type: string
-      required: true
-      description: "ingress or gateway"
-    ingressClassName:
-      type: string
-      required: false
-      description: "ingress class name; required when controllerType is ingress"
-    gatewayName:
-      type: string
-      required: false
-      description: "gateway name; required when controllerType is gateway"
-  rendering:
-    controllerType: ingress
-    ingressClassName: nginx
-```
-
----
-
-## 6. Example Cluster Profiles
+## 5. Example Cluster Profiles
 
 ### nginx ingress + cert-manager (Let's Encrypt) + Vault ESO
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: ClusterProfile
 metadata:
   name: prod-nginx
 spec:
   capabilities:
     expose:
-      parameters:
-        controllerType:
-          type: string
-          required: true
-        ingressClassName:
-          type: string
-          required: false
       rendering:
         controllerType: ingress
         ingressClassName: nginx
     certificate:
-      parameters:
-        issuerRef:
-          type: object
-          required: true
       rendering:
         issuerRef:
           name: letsencrypt-prod
           kind: ClusterIssuer
     external-secret:
-      parameters:
-        provider:
-          type: string
-          required: true
-        secretStoreRef:
-          type: object
-          required: false
       rendering:
         secretStoreRef:
           name: vault-backend
@@ -212,7 +167,7 @@ spec:
 ### Gateway API + cert-manager (internal CA) + AWS Secrets Manager
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: ClusterProfile
 metadata:
   name: prod-gateway
@@ -241,10 +196,10 @@ spec:
         refreshInterval: "1h"
 ```
 
-### Minimal (ingress only, no cert-manager, no ESO)
+### Minimal (ingress only)
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: ClusterProfile
 metadata:
   name: staging-minimal
@@ -258,11 +213,11 @@ spec:
 
 ---
 
-## 7. CapabilityAware handlers
+## 6. CapabilityAware handlers
 
 Some trait handlers require a capability to produce correct output — for example, the
-`expose` handler must know `controllerType` to dispatch to the right implementation. These
-handlers are marked with the `CapabilityAware` interface (defined in `pkg/oam`):
+`expose` handler must know `controllerType` to dispatch to the right implementation.
+These handlers implement the `CapabilityAware` interface (defined in `pkg/oam`):
 
 ```go
 type CapabilityAware interface {
@@ -271,27 +226,30 @@ type CapabilityAware interface {
 ```
 
 If `CapabilityRequired()` returns `true` and no capability resolves for the trait, the
-runtime returns `ErrMissingCapability` and the build fails with a clear message naming the
+runtime returns `ErrMissingCapability` and the build fails with a message naming the
 trait type and the cluster profile in use.
 
 Handlers that do not implement `CapabilityAware`, or whose `CapabilityRequired()` returns
-`false`, proceed without a capability — they rely solely on OAM inline properties.
+`false`, proceed without a capability and rely solely on Application inline properties.
 
 ---
 
-## 8. Relationship to crane's ClusterProfile
+## 7. Relationship to crane's ClusterProfile
 
-Crane's `ClusterProfile` type (`pkg/api.ClusterProfileSpec`) maps to this design as follows:
+Crane's `ClusterProfile` type (`pkg/api.ClusterProfileSpec`) maps to this design as
+follows:
 
 | crane field | launcher | Notes |
 |---|---|---|
 | `spec.capabilities` | `spec.capabilities` | Same structure, same semantics |
+| `spec.capabilities[*].rendering` | `spec.capabilities[*].rendering` | Same field, same semantics |
+| `spec.capabilities[*].parameters` | — | Removed; capability schema is not cluster operator input |
 | `spec.gitops` | — | Stays in crane |
 | `spec.catalog` | — | Stays in crane |
 | `spec.componentCatalog` | — | Stays in crane |
 | `spec.componentVariants` | — | Stays in crane |
-| `spec.capabilities[*].parameters` | `spec.capabilities[*].parameters` | Same field, informational only in Phase 0 |
-| `spec.capabilities[*].rendering` | `spec.capabilities[*].rendering` | Same field, same semantics |
 
-crane's `ClusterProfile` document can be used directly as a launcher `ClusterProfile` by
-dropping the crane-specific fields. The launcher runtime ignores unknown fields.
+Operators migrating a crane `ClusterProfile` to a launcher `cluster.yaml` must:
+1. Change `apiVersion` to `launcher.gokure.dev/v1alpha1`
+2. Remove `spec.gitops`, `spec.catalog`, `spec.componentCatalog`, `spec.componentVariants`
+3. Remove any `parameters:` blocks from capability entries

--- a/docs/oam/design-cluster-profile.md
+++ b/docs/oam/design-cluster-profile.md
@@ -1,6 +1,11 @@
 # Design: Platform Profile — ClusterProfile
 
-*Status: Draft | Issue: [#37](https://github.com/go-kure/launcher/issues/37)*
+*Status: Final | Issue: [#37](https://github.com/go-kure/launcher/issues/37)*
+
+| Version | Date | Summary |
+|---|---|---|
+| 1.1 | 2026-05-14 | Remove `parameters` field; update GVK to `launcher.gokure.dev/v1alpha1`; add strictness rule; add migration guide |
+| 1.0 | 2026-04-19 | Initial draft |
 
 ---
 

--- a/docs/oam/design-cluster-profile.md
+++ b/docs/oam/design-cluster-profile.md
@@ -49,7 +49,7 @@ spec:
 The schema of what keys a given capability accepts (types, required fields, descriptions)
 is launcher built-in knowledge, not cluster operator input. Where this schema lives for
 built-in handlers is described in the launcher handler documentation; the design for
-custom capability schema is tracked separately (Q2 in the design backlog).
+custom capability schema is tracked in issue #60.
 
 ### Strictness
 

--- a/docs/oam/design-cluster-profile.md
+++ b/docs/oam/design-cluster-profile.md
@@ -1,0 +1,297 @@
+# Design: Platform Profile — ClusterProfile
+
+*Status: Draft | Issue: [#37](https://github.com/go-kure/launcher/issues/37)*
+
+---
+
+## 1. Purpose
+
+A `ClusterProfile` tells the launcher runtime how the platform implements each OAM trait.
+It is an environment-level document, written once per cluster by the platform operator and
+shared across all applications deployed to that cluster.
+
+The separation it enforces: an OAM Application says "I need ingress" — the `ClusterProfile`
+says "ingress on this cluster means a Gateway API `HTTPRoute`." The application spec is
+portable; the profile is not.
+
+---
+
+## 2. Schema
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: <string>         # cluster identifier, e.g. "prod-eu-west"
+spec:
+  capabilities:
+    <trait-type>:        # e.g. "expose", "certificate", "external-secret"
+      parameters:        # schema: what keys this capability accepts
+        <key>:
+          type: <string | integer | boolean | object | array>
+          required: <bool>      # default: false
+          description: <string> # optional, for documentation
+      rendering:         # values: injected into trait properties at build time
+        <key>: <value>
+```
+
+### Field reference
+
+| Field | Type | Description |
+|---|---|---|
+| `metadata.name` | string | Identifies the cluster; referenced in build tooling |
+| `spec.capabilities` | map | Keys are OAM trait types; values are capability definitions |
+| `capabilities.<type>.parameters` | map | Schema declaration: documents accepted keys and types |
+| `capabilities.<type>.rendering` | map | Platform values: merged into trait properties before handler invocation |
+
+### What is NOT in a launcher ClusterProfile
+
+The following fields exist in crane's `ClusterProfile` but are crane-specific and must not
+appear in the launcher type:
+
+- `spec.gitops` — FluxCD/ArgoCD wiring; this is a delivery-layer concern, not an OAM runtime concern
+- `spec.componentCatalog` / `spec.catalog` — Harbor catalog references
+- `spec.componentVariants` — crane layer-3 variant selection
+- `spec.capabilities[*].parameters` is present but **not validated** in Phase 0 or Phase 1 — it is reserved for future schema enforcement
+
+---
+
+## 3. Capability Key Resolution
+
+At build time the runtime looks up a capability for each trait using a two-step key resolution:
+
+1. **Scoped key** — `<type>.<scope>` where `scope` comes from the trait's `properties.scope`
+   field, if set. This allows a cluster to configure multiple implementations of the same
+   trait type (e.g. a public and an internal ingress).
+2. **Bare key** — `<type>` — used when `scope` is absent or no scoped entry is found.
+
+```
+trait.type = "expose"
+trait.properties.scope = "internal"
+
+→ look up "expose.internal" in capabilities
+→ if not found, look up "expose" in capabilities
+→ if not found, no capability is resolved (handler proceeds without platform values)
+```
+
+Capability keys in the YAML file may be written in either form:
+
+```yaml
+spec:
+  capabilities:
+    expose:               # bare key — resolved for any expose trait without a scope
+      rendering:
+        controllerType: ingress
+    expose.internal:      # scoped key — resolved only when trait.properties.scope = "internal"
+      rendering:
+        controllerType: gateway
+        gatewayName: internal-gateway
+```
+
+---
+
+## 4. Merge Semantics
+
+Rendering values act as platform-provided defaults. OAM Application inline properties
+always take precedence:
+
+```
+resolved = rendering ∪ oam-properties   (OAM overwrites)
+```
+
+Example:
+
+```yaml
+# cluster.yaml capability rendering:
+certificate:
+  rendering:
+    issuerRef:
+      name: letsencrypt-prod
+      kind: ClusterIssuer
+
+# OAM Application trait:
+traits:
+- type: certificate
+  properties:
+    secretName: my-app-tls
+    dnsNames: [my-app.example.com]
+    # issuerRef not set — will come from platform
+
+# Resolved trait properties (what the handler receives):
+{
+  "secretName": "my-app-tls",
+  "dnsNames": ["my-app.example.com"],
+  "issuerRef": {"name": "letsencrypt-prod", "kind": "ClusterIssuer"}
+}
+```
+
+If the OAM Application overrides an individual key within a nested map, only that key is
+overridden; unmentioned sibling keys from rendering are preserved.
+
+---
+
+## 5. Parameters Field
+
+The `parameters` field documents the schema of a capability — what keys it accepts, their
+types, and which are required. In Phase 0–1, this field is **informational only** — the
+runtime writes it but does not validate rendering or OAM trait properties against it.
+
+Its purpose in this phase is to give package authors a machine-readable description of what
+a capability provides, so tools (editors, linters) can validate `app.yaml` against the
+cluster's declared capability shape.
+
+Example:
+
+```yaml
+expose:
+  parameters:
+    controllerType:
+      type: string
+      required: true
+      description: "ingress or gateway"
+    ingressClassName:
+      type: string
+      required: false
+      description: "ingress class name; required when controllerType is ingress"
+    gatewayName:
+      type: string
+      required: false
+      description: "gateway name; required when controllerType is gateway"
+  rendering:
+    controllerType: ingress
+    ingressClassName: nginx
+```
+
+---
+
+## 6. Example Cluster Profiles
+
+### nginx ingress + cert-manager (Let's Encrypt) + Vault ESO
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: prod-nginx
+spec:
+  capabilities:
+    expose:
+      parameters:
+        controllerType:
+          type: string
+          required: true
+        ingressClassName:
+          type: string
+          required: false
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+    certificate:
+      parameters:
+        issuerRef:
+          type: object
+          required: true
+      rendering:
+        issuerRef:
+          name: letsencrypt-prod
+          kind: ClusterIssuer
+    external-secret:
+      parameters:
+        provider:
+          type: string
+          required: true
+        secretStoreRef:
+          type: object
+          required: false
+      rendering:
+        secretStoreRef:
+          name: vault-backend
+          kind: ClusterSecretStore
+```
+
+### Gateway API + cert-manager (internal CA) + AWS Secrets Manager
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: prod-gateway
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: gateway
+        gatewayName: prod-gateway
+        gatewayNamespace: gateway-system
+    expose.internal:
+      rendering:
+        controllerType: gateway
+        gatewayName: internal-gateway
+        gatewayNamespace: gateway-system
+    certificate:
+      rendering:
+        issuerRef:
+          name: internal-ca
+          kind: ClusterIssuer
+    external-secret:
+      rendering:
+        secretStoreRef:
+          name: aws-secretsmanager
+          kind: ClusterSecretStore
+        refreshInterval: "1h"
+```
+
+### Minimal (ingress only, no cert-manager, no ESO)
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: staging-minimal
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: traefik
+```
+
+---
+
+## 7. CapabilityAware handlers
+
+Some trait handlers require a capability to produce correct output — for example, the
+`expose` handler must know `controllerType` to dispatch to the right implementation. These
+handlers are marked with the `CapabilityAware` interface (defined in `pkg/oam`):
+
+```go
+type CapabilityAware interface {
+    CapabilityRequired() bool
+}
+```
+
+If `CapabilityRequired()` returns `true` and no capability resolves for the trait, the
+runtime returns `ErrMissingCapability` and the build fails with a clear message naming the
+trait type and the cluster profile in use.
+
+Handlers that do not implement `CapabilityAware`, or whose `CapabilityRequired()` returns
+`false`, proceed without a capability — they rely solely on OAM inline properties.
+
+---
+
+## 8. Relationship to crane's ClusterProfile
+
+Crane's `ClusterProfile` type (`pkg/api.ClusterProfileSpec`) maps to this design as follows:
+
+| crane field | launcher | Notes |
+|---|---|---|
+| `spec.capabilities` | `spec.capabilities` | Same structure, same semantics |
+| `spec.gitops` | — | Stays in crane |
+| `spec.catalog` | — | Stays in crane |
+| `spec.componentCatalog` | — | Stays in crane |
+| `spec.componentVariants` | — | Stays in crane |
+| `spec.capabilities[*].parameters` | `spec.capabilities[*].parameters` | Same field, informational only in Phase 0 |
+| `spec.capabilities[*].rendering` | `spec.capabilities[*].rendering` | Same field, same semantics |
+
+crane's `ClusterProfile` document can be used directly as a launcher `ClusterProfile` by
+dropping the crane-specific fields. The launcher runtime ignores unknown fields.

--- a/docs/oam/design-gvk.md
+++ b/docs/oam/design-gvk.md
@@ -1,7 +1,11 @@
 # Design: API Group and Document Ownership
 
-*Status: Draft | Prerequisite for: design-cluster-profile.md, design-kurel-package.md,
-design-policy-interface.md*
+*Status: Final | Prerequisite for: design-cluster-profile.md, design-kurel-package.md,
+options-policy-interface.md*
+
+| Version | Date | Summary |
+|---|---|---|
+| 1.0 | 2026-05-14 | Initial — records GVK decision, rationale, strictness rule, OAM reuse |
 
 ---
 
@@ -104,7 +108,7 @@ silently ignoring them and producing incorrect output.
 
 Operators migrating crane `ClusterProfile` documents to launcher `cluster.yaml` must
 remove crane-specific fields before use. The fields to remove are documented in
-`design-cluster-profile.md §8`.
+`design-cluster-profile.md §7`.
 
 ---
 

--- a/docs/oam/design-gvk.md
+++ b/docs/oam/design-gvk.md
@@ -1,0 +1,137 @@
+# Design: API Group and Document Ownership
+
+*Status: Draft | Prerequisite for: design-cluster-profile.md, design-kurel-package.md,
+design-policy-interface.md*
+
+---
+
+## Design Statement
+
+Launcher defines its own native application model under `launcher.gokure.dev/v1alpha1`.
+The model is inspired by OAM concepts — applications, components, traits, and
+capability-driven rendering — but launcher does not claim native API compatibility with
+`core.oam.dev/v1beta1`. Standard OAM import/export compatibility may be supported later
+through a translation layer.
+
+---
+
+## Launcher-Native Documents
+
+All launcher-native input files share a single API group and version:
+
+| File | apiVersion | kind |
+|---|---|---|
+| `app.yaml` | `launcher.gokure.dev/v1alpha1` | `Application` |
+| `kurel.yaml` | `launcher.gokure.dev/v1alpha1` | `Package` |
+| `cluster.yaml` | `launcher.gokure.dev/v1alpha1` | `ClusterProfile` |
+
+These three documents form one coherent API family. They are not split across groups or
+versions because they belong to the same ownership and lifecycle domain:
+`Application` is what to run, `Package` is how it is packaged, `ClusterProfile` is how
+the target platform resolves capabilities for it.
+
+### Example document headers
+
+```yaml
+# app.yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+```
+
+```yaml
+# kurel.yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: webservice
+  version: "1.0.0"
+```
+
+```yaml
+# cluster.yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: prod-eu-west
+```
+
+---
+
+## Why `launcher.gokure.dev`
+
+**Not `core.oam.dev/v1beta1`**
+
+Using the upstream OAM GVK would signal:
+- runtime compatibility with KubeVela and other OAM implementations that does not exist
+- API ownership that launcher does not hold
+- stronger semantic alignment to upstream OAM than launcher intends
+
+Launcher's component and trait types (`webservice`, `expose`, `certificate`) are
+launcher-specific. No other OAM runtime understands them. The shared shape
+(components/traits/properties) is a design choice, not an API contract.
+
+**Not `wharf.zone`**
+
+`wharf.zone` is the Wharf platform zone. Launcher is a go-kure project — an
+open-source product that is not Wharf-internal. Using `wharf.zone` would make the
+application model look platform-specific when it is intended to be launcher-native and
+publicly usable beyond Wharf deployments.
+
+**Not `launcher.wharf.zone`**
+
+Same reasoning as `wharf.zone`. Embedding the Wharf zone in the group name ties the API
+to the Wharf platform identity rather than to launcher as a standalone product.
+
+**`launcher.gokure.dev`**
+
+Reflects the actual ownership (go-kure project), keeps launcher's API separate from both
+the Wharf platform APIs and the upstream OAM namespace, and is honest about what these
+documents are: launcher's native input format.
+
+---
+
+## Parser Strictness
+
+Launcher rejects unknown fields in all launcher-native documents. An `app.yaml`,
+`kurel.yaml`, or `cluster.yaml` with unrecognised keys is a build error.
+
+Rationale: unknown fields are most often typos or stale config carried over from a
+different tool (e.g. a `cluster.yaml` migrated from crane that still contains `gitops:` or
+`componentCatalog:`). Strict parsing surfaces these problems at build time rather than
+silently ignoring them and producing incorrect output.
+
+Operators migrating crane `ClusterProfile` documents to launcher `cluster.yaml` must
+remove crane-specific fields before use. The fields to remove are documented in
+`design-cluster-profile.md §8`.
+
+---
+
+## OAM Conceptual Reuse
+
+Launcher's native model borrows the following OAM concepts:
+
+| OAM concept | Launcher usage |
+|---|---|
+| Application | Top-level kind; same structure (components, policies) |
+| Component | Same shape (name, type, properties, traits) |
+| Component type | Dispatches to a registered `ComponentHandler` |
+| Trait | Same shape (type, properties); attached to components |
+| Trait type | Dispatches to a registered `TraitHandler` |
+| Policy | Present in Application spec; used for enforcement (Phase 1+) |
+
+Concepts not adopted in Phase 0:
+- OAM `WorkloadDefinition` / `ComponentDefinition` / `TraitDefinition` — launcher
+  handlers are Go code, not declarative definition files (future work)
+- OAM workflow semantics
+- OAM revision/rollout model
+
+---
+
+## Future: OAM Compatibility
+
+Support for reading `core.oam.dev/v1beta1` Applications as a launcher input format may
+be added later via an import/export layer. This would allow OAM/KubeVela documents to be
+used with `kurel build` without being launcher's native format. No timeline is set for
+this; it is not a Phase 0 concern.

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -1,0 +1,213 @@
+# Design: Kurel Package Spec
+
+*Status: Draft (partial) | Issue: [#36](https://github.com/go-kure/launcher/issues/36)*
+
+> **Note:** The parameter syntax section is deliberately omitted. See
+> `docs/oam/options-param-syntax.md` for the two options under consideration.
+> This document will be completed once that decision is made.
+
+---
+
+## 1. Purpose
+
+A kurel package is a distributable, reusable OAM application pattern. It bundles:
+
+- an OAM Application document (`app.yaml`) describing what workloads to run and what
+  platform capabilities they need
+- a package metadata file (`kurel.yaml`) with identity and parameter declarations
+- optionally, example value files for common deployment scenarios
+
+Packages are designed to be shared: a team defines a `webservice-with-ingress` package
+once and any project instantiates it by supplying their image, domain, and values.
+
+---
+
+## 2. Package Directory Layout
+
+```
+my-app/
+├── kurel.yaml        # package identity and parameter schema
+├── app.yaml          # OAM Application (standard core.oam.dev/v1beta1)
+└── examples/
+    ├── production.yaml   # example values for a production deployment
+    └── staging.yaml      # example values for a staging deployment
+```
+
+The OAM Application format replaces the prototype's `parameters.yaml + resources/ + patches/`
+layout. No coexistence or backward-compatible bridging is required.
+
+---
+
+## 3. kurel.yaml
+
+`kurel.yaml` declares the package identity and (when the parameter syntax is decided)
+the parameter schema.
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: Package
+metadata:
+  name: webservice        # package identifier
+  version: "1.0.0"        # semver
+  description: "A stateless web service with ingress, TLS, and optional autoscaling."
+  # Future: home, keywords, maintainers (informational only)
+spec:
+  # Parameter declarations — content TBD (see options-param-syntax.md)
+  parameters: []
+```
+
+---
+
+## 4. app.yaml — OAM Application
+
+`app.yaml` is a standard OAM Application document (`core.oam.dev/v1beta1`). The component
+and trait types must match the handler registry that the runtime is configured with.
+
+### 4.1 Basic structure
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice        # must match a registered ComponentHandler
+    properties:
+      image: myregistry/myapp:latest
+      port: 8080
+      replicas: 1
+    traits:
+    - type: expose          # must match a registered TraitHandler
+      properties:
+        rules:
+        - host: my-app.example.com
+          paths:
+          - path: /
+            port: 8080
+```
+
+### 4.2 Supported component types (Phase 1)
+
+Migrated from crane. Each type maps to a `ComponentHandler` implementation in
+`pkg/oam/builtin/`:
+
+| type | description |
+|---|---|
+| `webservice` | Long-running HTTP service: Deployment + Service |
+| `worker` | Long-running background worker: Deployment (no Service) |
+| `cronjob` | Scheduled task: CronJob |
+| `postgresql` | PostgreSQL instance (CNPG) |
+| `helmrelease` | FluxCD HelmRelease for third-party charts |
+| `daemonset` | DaemonSet for node-level agents |
+| `statefulset` | StatefulSet for ordered, persistent workloads |
+
+### 4.3 Supported trait types (Phase 1)
+
+Migrated from crane. Each type maps to a `TraitHandler` in `pkg/oam/builtin/`:
+
+| type | requires capability | description |
+|---|---|---|
+| `expose` | yes — `controllerType` | Dispatches to `ingress` or `httproute` based on platform |
+| `ingress` | no | Kubernetes Ingress |
+| `httproute` | no | Gateway API HTTPRoute |
+| `certificate` | yes — `issuerRef` | cert-manager Certificate |
+| `external-secret` | yes — `secretStoreRef` | ExternalSecrets ExternalSecret |
+| `configmap` | no | ConfigMap with optional volume mount |
+| `scaler` | no | HPA + optional PDB |
+| `backup` | no | crane-specific, stays in crane |
+
+Traits that remain in crane (not migrated to launcher): `fluxcd-postbuild`,
+`fluxcd-patches`, `prune-protection`, `rbac`. These depend on crane's delivery pipeline
+and have no meaning in a static manifest build.
+
+### 4.4 OAM policies
+
+OAM Application policies are parsed and passed to the runtime unchanged. The runtime
+does not interpret any policy type in Phase 1 (policy application via `Enforceable` is
+wired in Phase 1 but uses `NoopPolicy` by default). Policy handling is activated in
+Phase 1 via the `--policy` flag.
+
+```yaml
+spec:
+  # ...
+  policies:
+  - name: resource-limits
+    type: env-policy
+    properties:
+      # crane-style EnvironmentPolicy fields
+      enforced:
+        maxReplicas: 5
+```
+
+---
+
+## 5. Two-Parameter-Set Model
+
+Every kurel build receives exactly two parameter sets:
+
+**Set 1 — Platform profile (`--profile cluster.yaml`)**
+
+Describes how the platform implements each trait. This is an environment-level input,
+supplied by the platform operator and shared across all applications on a cluster.
+Represented as a `ClusterProfile` document. See `docs/oam/design-cluster-profile.md`.
+
+**Set 2 — Application values**
+
+Describes what this specific deployment needs: image, replica count, domain names, etc.
+This is a per-deployment input, supplied by the application team at build time.
+
+The two sets are merged at different stages:
+- Platform profile rendering is merged into trait properties before handler invocation
+  (capability resolution, see ClusterProfile design)
+- Application values are merged into component and trait properties
+  (parameter resolution — syntax TBD)
+
+### Separation of concerns
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Application team provides:                                     │
+│  - app.yaml (OAM Application — what to run, what capabilities)  │
+│  - values  (image, replicas, domains — per deployment)          │
+└─────────────────────┬───────────────────────────────────────────┘
+                      │
+┌─────────────────────▼───────────────────────────────────────────┐
+│  kurel build                                                    │
+│  1. Resolve application values into OAM Application             │
+│  2. Load ClusterProfile (platform profile)                      │
+│  3. For each trait: merge capability rendering into properties  │
+│  4. Dispatch to component and trait handlers                    │
+│  5. Output: static Kubernetes manifests                         │
+└─────────────────────┬───────────────────────────────────────────┘
+                      │
+┌─────────────────────▼───────────────────────────────────────────┐
+│  Platform operator provides:                                    │
+│  - cluster.yaml (ClusterProfile — how traits are implemented)   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. Parameter Syntax [TBD]
+
+*This section will describe how application values are expressed in `kurel.yaml` and
+`app.yaml`, and how `kurel build` accepts them. See `docs/oam/options-param-syntax.md`
+for the options under consideration.*
+
+---
+
+## 7. Build Invocation
+
+```sh
+kurel build <package-dir> \
+    --profile cluster.yaml \
+    [--values values.yaml | --set key=value]
+```
+
+Output is static Kubernetes manifests on stdout (YAML, multi-document). Pipe into
+`kubectl apply`, a GitOps repo, or a CI artifact store.
+
+The `--profile` flag is required. Without a profile, capability-aware traits will fail
+with `ErrMissingCapability`.

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -27,7 +27,7 @@ once and any project instantiates it by supplying their image, domain, and value
 ```
 my-app/
 ├── kurel.yaml        # package identity and parameter schema
-├── app.yaml          # OAM Application (standard core.oam.dev/v1beta1)
+├── app.yaml          # launcher Application (launcher.gokure.dev/v1alpha1)
 └── examples/
     ├── production.yaml   # example values for a production deployment
     └── staging.yaml      # example values for a staging deployment
@@ -44,7 +44,7 @@ layout. No coexistence or backward-compatible bridging is required.
 the parameter schema.
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Package
 metadata:
   name: webservice        # package identifier
@@ -60,13 +60,14 @@ spec:
 
 ## 4. app.yaml — OAM Application
 
-`app.yaml` is a standard OAM Application document (`core.oam.dev/v1beta1`). The component
-and trait types must match the handler registry that the runtime is configured with.
+`app.yaml` is a launcher Application document (`launcher.gokure.dev/v1alpha1`, kind
+`Application`). The component and trait types must match the handler registry that the
+runtime is configured with. See `docs/oam/design-gvk.md` for the GVK rationale.
 
 ### 4.1 Basic structure
 
 ```yaml
-apiVersion: core.oam.dev/v1beta1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
   name: my-app

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -1,10 +1,11 @@
 # Design: Kurel Package Spec
 
-*Status: Draft (partial) | Issue: [#36](https://github.com/go-kure/launcher/issues/36)*
+*Status: Draft | Issue: [#36](https://github.com/go-kure/launcher/issues/36)*
 
-> **Note:** The parameter syntax section is deliberately omitted. See
-> `docs/oam/options-param-syntax.md` for the two options under consideration.
-> This document will be completed once that decision is made.
+| Version | Date | Summary |
+|---|---|---|
+| 1.1 | 2026-05-14 | Complete §6 (parameter syntax — Option A); fix GVK references; remove `backup` from Phase 1 trait table; fix §5 diagram label |
+| 1.0 | 2026-04-19 | Initial draft — parameter syntax section omitted pending decision |
 
 ---
 
@@ -52,8 +53,19 @@ metadata:
   description: "A stateless web service with ingress, TLS, and optional autoscaling."
   # Future: home, keywords, maintainers (informational only)
 spec:
-  # Parameter declarations — content TBD (see options-param-syntax.md)
-  parameters: []
+  parameters:
+  - name: image
+    type: string
+    required: true
+    description: "Container image with tag, e.g. registry/app:v1.2.3"
+  - name: domain
+    type: string
+    required: true
+    description: "Primary hostname, e.g. app.example.com"
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
 ```
 
 ---
@@ -61,8 +73,10 @@ spec:
 ## 4. app.yaml — OAM Application
 
 `app.yaml` is a launcher Application document (`launcher.gokure.dev/v1alpha1`, kind
-`Application`). The component and trait types must match the handler registry that the
-runtime is configured with. See `docs/oam/design-gvk.md` for the GVK rationale.
+`Application`). It contains `${var}` parameter placeholders that the resolver substitutes
+using the values supplied at build time. The component and trait types must match the
+handler registry that the runtime is configured with. See `docs/oam/design-gvk.md` for
+the GVK rationale and `docs/oam/options-param-syntax.md` for the parameter syntax spec.
 
 ### 4.1 Basic structure
 
@@ -117,9 +131,8 @@ Migrated from crane. Each type maps to a `TraitHandler` in `pkg/oam/builtin/`:
 | `external-secret` | yes — `secretStoreRef` | ExternalSecrets ExternalSecret |
 | `configmap` | no | ConfigMap with optional volume mount |
 | `scaler` | no | HPA + optional PDB |
-| `backup` | no | crane-specific, stays in crane |
 
-Traits that remain in crane (not migrated to launcher): `fluxcd-postbuild`,
+Traits that remain in crane (not migrated to launcher): `backup`, `fluxcd-postbuild`,
 `fluxcd-patches`, `prune-protection`, `rbac`. These depend on crane's delivery pipeline
 and have no meaning in a static manifest build.
 
@@ -163,22 +176,22 @@ The two sets are merged at different stages:
 - Platform profile rendering is merged into trait properties before handler invocation
   (capability resolution, see ClusterProfile design)
 - Application values are merged into component and trait properties
-  (parameter resolution — syntax TBD)
+  (`${var}` placeholder substitution — see §6)
 
 ### Separation of concerns
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  Application team provides:                                     │
-│  - app.yaml (OAM Application — what to run, what capabilities)  │
+│  - app.yaml (launcher Application — what to run, what capabilities)  │
 │  - values  (image, replicas, domains — per deployment)          │
 └─────────────────────┬───────────────────────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────────────────────┐
 │  kurel build                                                    │
 │  1. Resolve application values into OAM Application             │
-│  2. Load ClusterProfile (platform profile)                      │
-│  3. For each trait: merge capability rendering into properties  │
+│  2. Load ClusterProfile (platform profile)                         │
+│  3. For each trait: merge capability rendering into properties     │
 │  4. Dispatch to component and trait handlers                    │
 │  5. Output: static Kubernetes manifests                         │
 └─────────────────────┬───────────────────────────────────────────┘
@@ -191,11 +204,112 @@ The two sets are merged at different stages:
 
 ---
 
-## 6. Parameter Syntax [TBD]
+## 6. Parameter Syntax
 
-*This section will describe how application values are expressed in `kurel.yaml` and
-`app.yaml`, and how `kurel build` accepts them. See `docs/oam/options-param-syntax.md`
-for the options under consideration.*
+Application values are expressed as `${name}` placeholders in `app.yaml`. The resolver
+substitutes all placeholders using the values supplied at build time before the Application
+is parsed or dispatched to handlers. For the full design rationale see
+`docs/oam/options-param-syntax.md`.
+
+### 6.1 Parameter declarations in kurel.yaml
+
+Each parameter has a name, type, required flag, optional default, and optional description.
+
+```yaml
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+    description: "Container image with tag, e.g. registry/app:v1.2.3"
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+  - name: domain
+    type: string
+    required: true
+  - name: tlsSecret
+    type: string
+    required: false
+    default: "${name}-tls"   # may reference other parameters
+  - name: env
+    type: array
+    required: false
+    default: []
+    description: "Extra environment variables as [{name, value}] objects"
+```
+
+Supported types: `string`, `integer`, `boolean`, `array`, `object`.
+
+### 6.2 Placeholder syntax in app.yaml
+
+```yaml
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "${image}"          # scalar substitution — resolves to string
+      replicas: ${replicas}      # scalar substitution — resolves to integer
+      env: ${env}                # node substitution — resolves to YAML list
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "${domain}"
+    - type: certificate
+      properties:
+        secretName: "${tlsSecret}"
+        dnsNames:
+        - "${domain}"
+```
+
+### 6.3 Resolver behaviour
+
+**Scalar substitution** — when `${name}` is the entire value of a YAML field, the resolver
+replaces it with the typed value from the parameter declaration:
+- `image: "${image}"` → `image: "myregistry/app:v1.2.3"` (string)
+- `replicas: ${replicas}` → `replicas: 3` (integer, not string `"3"`)
+
+**Node substitution** — when the parameter type is `array` or `object`, the resolver
+replaces the placeholder with the full YAML node:
+- `env: ${env}` → `env: [{name: LOG_LEVEL, value: info}, ...]`
+
+**Inline string embedding** — when `${name}` is embedded inside a larger string value:
+- `secretName: "${name}-tls"` → `secretName: "webservice-tls"` (always a string)
+
+### 6.4 Supplying values at build time
+
+```sh
+# values.yaml — flat scalars or structured (for array/object parameters)
+kurel build . --profile cluster.yaml --values values.yaml
+
+# --set flags — scalars only
+kurel build . --profile cluster.yaml \
+    --set image=myregistry/app:v1.2.3 \
+    --set replicas=3 \
+    --set domain=app.example.com
+```
+
+```yaml
+# values.yaml — with structured array parameter
+image: myregistry/app:v1.2.3
+replicas: 3
+domain: app.example.com
+env:
+- name: LOG_LEVEL
+  value: info
+- name: DB_HOST
+  value: postgres.svc
+```
+
+### 6.5 Validation
+
+- Missing required parameter → build error naming the parameter before any resolution
+- Optional parameter with no value → default value used
+- `default` may itself contain `${name}` references to other parameters; these are
+  resolved in declaration order
 
 ---
 

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -1,6 +1,6 @@
 # Design: Kurel Package Spec
 
-*Status: Draft | Issue: [#36](https://github.com/go-kure/launcher/issues/36)*
+*Status: Final | Issue: [#36](https://github.com/go-kure/launcher/issues/36)*
 
 | Version | Date | Summary |
 |---|---|---|
@@ -41,8 +41,7 @@ layout. No coexistence or backward-compatible bridging is required.
 
 ## 3. kurel.yaml
 
-`kurel.yaml` declares the package identity and (when the parameter syntax is decided)
-the parameter schema.
+`kurel.yaml` declares the package identity and the parameter schema.
 
 ```yaml
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/docs/oam/options-package-composition.md
+++ b/docs/oam/options-package-composition.md
@@ -1,0 +1,388 @@
+# Options: Package Composition — Optional Sections, Multi-Instance, Split Files
+
+*Status: Decision required | Blocks: `design-kurel-package.md` §4–5, issue #36*
+
+This document compares two candidate mechanisms for package composition: how a package
+author marks components or traits as optional, how the user enables or disables optional
+sections at build time, and how multi-instance patterns work.
+
+**Scope:** package-level composition decisions made before the Application is resolved.
+Runtime conditionality (e.g. "include this component only if another trait is present") is a
+Phase 2 concern and is tracked in issue #39. That axis is out of scope here.
+
+**Parameter syntax** (placeholder vs overlay) is a separate design axis. See
+`options-param-syntax.md`. This document assumes the parameter syntax decision has been
+made but is written to be compatible with either option.
+
+---
+
+## What needs to be designed
+
+1. **Optional traits** — a package may include a `certificate` trait or an `external-secret`
+   trait that only applies when the user wants TLS or external secret injection. The user
+   must be able to leave these out without forking the package.
+
+2. **Optional components** — a package may include a worker component, a migration job, or a
+   Redis sidecar component that is not always needed.
+
+3. **Multi-instance** — a package may define a logical component pattern (e.g. a "worker")
+   that can be instantiated multiple times with different names and values
+   (worker-fast, worker-slow). Can the user add instances beyond what the package declares?
+
+4. **Split files** — can a package split `app.yaml` into per-component files
+   (e.g. `components/web.yaml`, `components/worker.yaml`) to keep large packages
+   manageable?
+
+---
+
+## Option A — `optional:` list in kurel.yaml + boolean values
+
+### How it works
+
+`kurel.yaml` declares an `optional` list naming components and traits that are inactive by
+default. The user enables them via boolean values (a `values.yaml` key or a `--set` flag).
+
+The resolver reads the optional list, evaluates the enable flags, and strips
+inactive sections from the Application before parameter resolution and ClusterProfile
+rendering proceed.
+
+### kurel.yaml
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: webservice
+  version: "1.0.0"
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+  - name: domain
+    type: string
+    required: true
+  - name: tlsEnabled
+    type: boolean
+    required: false
+    default: false
+  - name: workerEnabled
+    type: boolean
+    required: false
+    default: false
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+  optional:
+  - kind: trait
+    component: web
+    traitType: certificate
+    enabledBy: tlsEnabled
+  - kind: component
+    name: worker
+    enabledBy: workerEnabled
+```
+
+### app.yaml
+
+`app.yaml` contains all components and traits, including the optional ones. The resolver
+strips sections that are disabled before any further processing.
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "${image}"
+      replicas: ${replicas}
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "${domain}"
+    - type: certificate          # optional — stripped when tlsEnabled=false
+      properties:
+        secretName: "${domain}-tls"
+        dnsNames:
+        - "${domain}"
+  - name: worker                 # optional — stripped when workerEnabled=false
+    type: worker
+    properties:
+      image: "${image}"
+      replicas: 1
+```
+
+### Supplying values
+
+With Option A param syntax:
+
+```sh
+# Default — TLS and worker disabled
+kurel build . --profile cluster.yaml --set image=myregistry/app:v1 --set domain=app.example.com
+
+# With TLS enabled
+kurel build . --profile cluster.yaml \
+    --set image=myregistry/app:v1 \
+    --set domain=app.example.com \
+    --set tlsEnabled=true
+```
+
+With Option B param syntax (values.yaml overlay):
+
+```yaml
+# values.yaml
+components:
+- name: web
+  properties:
+    image: myregistry/app:v1
+    replicas: 2
+```
+
+The optional list mechanism would need to be fed via a separate top-level key:
+
+```yaml
+# values.yaml
+enable:
+  web.certificate: true
+components:
+- name: web
+  properties:
+    image: myregistry/app:v1
+```
+
+This is an awkward fit for Option B, because the values file structure mirrors app.yaml
+but the `enable` flags reference structural paths, not property paths.
+
+### Multi-instance
+
+Option A does not natively support multi-instance. The package declares a fixed set of
+components. If a user needs two worker instances, they either:
+
+- Use multiple packages (one per worker configuration)
+- Wait for Phase 2 conditional composition (#39)
+- Use `--set` flags to parameterize a single worker's properties
+
+### Split files
+
+Not addressed by Option A. `app.yaml` remains a single file. Large packages must fit in one
+document. Split-file support is a separate concern.
+
+### Implications
+
+- Optional sections are declared in `kurel.yaml`, not inline in `app.yaml` — `app.yaml`
+  reads as a complete superset and the optional declarations are the gate.
+- The boolean parameter mechanism integrates cleanly with the Option A param syntax
+  (parameters with `type: boolean` are first-class parameter types).
+- Awkward with Option B param syntax: the `enable` flags don't fit the overlay structure.
+- The resolver must run optional-section stripping before parameter resolution, so that
+  stripped sections do not produce "missing required parameter" errors for their properties.
+- Required parameters on optional components create a problem: the user must only supply
+  required values for enabled components. This requires per-component required-parameter
+  evaluation, which adds resolver complexity.
+
+### Pros
+
+- Clear separation: optional declarations are in `kurel.yaml` (public API); `app.yaml`
+  contains the full superset of what a package can produce
+- Enable flags are strongly typed parameters — schema-validated, discoverable
+- Integrates with `--set` flags and the Option A parameter schema
+- Optional traits and components are explicit in the package's public API
+
+### Cons
+
+- `app.yaml` must include all optional sections; browsing it shows disabled content mixed
+  with enabled content
+- Poor fit with Option B param syntax
+- No multi-instance support
+- No split-file support
+- Resolver must handle per-section parameter validation (complex)
+
+---
+
+## Option B — Inline annotations in app.yaml
+
+### How it works
+
+Optional components and traits carry a launcher annotation directly in `app.yaml`. No
+`optional:` list in `kurel.yaml`. The annotation specifies the condition under which the
+section is included; the user controls it via values or `--set` flags.
+
+The annotation uses a launcher-reserved key in the component or trait block.
+
+### kurel.yaml
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: webservice
+  version: "1.0.0"
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+  - name: domain
+    type: string
+    required: true
+  - name: tls
+    type: boolean
+    required: false
+    default: false
+  - name: worker
+    type: boolean
+    required: false
+    default: false
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+```
+
+### app.yaml with inline annotations
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "${image}"
+      replicas: ${replicas}
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "${domain}"
+    - type: certificate
+      launcher.gokure.dev/include-if: "${tls}"  # inline gate
+      properties:
+        secretName: "${domain}-tls"
+        dnsNames:
+        - "${domain}"
+  - name: worker
+    type: worker
+    launcher.gokure.dev/include-if: "${worker}" # inline gate
+    properties:
+      image: "${image}"
+      replicas: 1
+```
+
+`launcher.gokure.dev/include-if` is a launcher-reserved field. Its value is a parameter
+reference that resolves to a boolean. The resolver evaluates these gates after parameter
+substitution and strips sections where the gate evaluates to false before ClusterProfile
+rendering.
+
+### Implications
+
+- `app.yaml` remains the single source of truth; the gate is co-located with the section
+  it controls.
+- The launcher API group prefix on `include-if` signals that this is not an Application
+  property but a resolver directive — it must be explicitly excluded from strict parsing
+  of the Application document body.
+- The same `${...}` substitution machinery (Option A param syntax) is required to evaluate
+  the gate expression. This option is incompatible with Option B param syntax as specified
+  because `${...}` placeholders are not used there.
+
+### Strict-parsing interaction
+
+`launcher.gokure.dev/include-if` is a meta-directive on a component or trait, not a
+property value. Under the strict parsing rule (see `design-gvk.md`), the Application parser
+must either:
+
+- Explicitly whitelist `launcher.gokure.dev/*` annotation keys on components and traits, or
+- Process these directives before the Application document is parsed against the Application
+  schema, removing them first
+
+This adds a pre-processing step before the schema-validated parse.
+
+### Multi-instance
+
+Not addressed by this option either. The package still declares a fixed set of named
+components.
+
+### Split files
+
+Could be combined with a split-file mechanism (each component file carries its own
+`include-if`), but this is independent of the annotation mechanism.
+
+### Pros
+
+- Gate co-located with the section it controls — easier to read for package authors
+- `kurel.yaml` stays clean; no parallel `optional:` list to keep in sync with `app.yaml`
+- A future extension (`include-if` with richer expressions) follows naturally from the
+  same mechanism
+
+### Cons
+
+- `app.yaml` contains non-Application syntax (resolver directives) — technically not a
+  valid Application document even before parameter resolution
+- Strict-parsing interaction adds a pre-processing requirement
+- Only compatible with Option A param syntax (requires `${...}` evaluation)
+- `kurel.yaml` no longer enumerates the enable/disable surface of the package — consumers
+  must read `app.yaml` to discover what can be toggled
+- The annotation key prefix is verbose; alternatives (`x-include-if`, `_if`) trade clarity
+  for brevity
+
+---
+
+## Open Questions
+
+These questions are not answered here and must be resolved before `design-kurel-package.md`
+§4–5 can be written:
+
+**Q1 — Where does optionality belong?**
+Is optional section declaration:
+- Package metadata (`kurel.yaml` — Option A)
+- Inline in `app.yaml` (`include-if` annotation — Option B)
+- Both (annotations in `app.yaml` are the mechanism; `kurel.yaml` enumerates them for
+  discoverability)?
+- Deferred entirely to Phase 2 conditional composition (issue #39)?
+
+If optionality is deferred, Phase 1 packages have no optional sections. Users compose via
+multiple packages or via a fixed superset (all sections always present).
+
+**Q2 — Per-section required parameters**
+If optional components or traits have required parameters, how are they validated? Options:
+- Required-if: parameter is only required when the section is enabled
+- Explicit group: parameters belong to a section; the group is validated or skipped
+  together
+- User responsibility: no framework validation; missing parameters fail at render time with
+  a property-level error
+
+**Q3 — Multi-instance scope**
+Is multi-instance a Phase 1 concern? The use case (multiple worker instances from one
+component pattern) exists in crane. Options:
+- Not Phase 1: users instantiate the same package multiple times with different names
+- Phase 1: package declares a component pattern; `values.yaml` provides a list of instances
+- Phase 2 (issue #39): conditional composition handles this
+
+**Q4 — Split files**
+Should `app.yaml` be splittable into per-component files in Phase 1? This is a package
+organization concern independent of optionality. It is not needed for correctness but
+affects developer experience for large packages.
+
+---
+
+## Summary Comparison
+
+| Aspect | Option A: kurel.yaml optional list | Option B: Inline annotation |
+|---|---|---|
+| Gate location | `kurel.yaml` — explicit public API | `app.yaml` co-located with section |
+| `app.yaml` is valid Application at rest | Yes (all sections present, some inactive) | No (contains resolver directives) |
+| `kurel.yaml` enumerates enable surface | **Yes** | No — must read `app.yaml` |
+| Param syntax compatibility | **Both A and B** | Option A only |
+| Strict-parsing interaction | None | Requires pre-processing step |
+| Multi-instance support | None | None |
+| Split-file support | None | None |
+| Resolver complexity | Medium (per-section param validation) | Medium (pre-processing + gate eval) |

--- a/docs/oam/options-package-composition.md
+++ b/docs/oam/options-package-composition.md
@@ -1,6 +1,6 @@
 # Options: Package Composition — Optional Sections, Multi-Instance, Split Files
 
-*Status: Decision required | Blocks: `design-kurel-package.md` §4–5, issue #36*
+*Status: **Decided — deferred to Phase 2 (issue #39)** | Issue #36*
 
 This document compares two candidate mechanisms for package composition: how a package
 author marks components or traits as optional, how the user enables or disables optional

--- a/docs/oam/options-package-composition.md
+++ b/docs/oam/options-package-composition.md
@@ -1,22 +1,25 @@
-# Options: Package Composition — Optional Sections, Multi-Instance, Split Files
+# Design: Package Composition — Optional Sections, Multi-Instance, Split Files
 
-*Status: **Decided — deferred to Phase 2 (issue #39)** | Issue #36*
+*Status: **Final — deferred to Phase 2 (issue #39)** | Issue #36*
 
-This document compares two candidate mechanisms for package composition: how a package
-author marks components or traits as optional, how the user enables or disables optional
-sections at build time, and how multi-instance patterns work.
+| Version | Date | Summary |
+|---|---|---|
+| 1.1 | 2026-05-14 | Record decision (Phase 2 deferral); remove mechanism sections; keep background and open questions for #39 |
+| 1.0 | 2026-05-14 | Initial draft — compared kurel.yaml optional list (Option A) and inline include-if annotation (Option B) |
+
+**Decision:** No optional sections, multi-instance, or split-file support in Phase 1.
+Package authors publish always-on packages. Users who need deployment variants instantiate
+separate packages. Composition mechanism is designed in Phase 2 (issue #39).
 
 **Scope:** package-level composition decisions made before the Application is resolved.
-Runtime conditionality (e.g. "include this component only if another trait is present") is a
-Phase 2 concern and is tracked in issue #39. That axis is out of scope here.
-
-**Parameter syntax** (placeholder vs overlay) is a separate design axis. See
-`options-param-syntax.md`. This document assumes the parameter syntax decision has been
-made but is written to be compatible with either option.
+Runtime conditionality (e.g. "include this component only if another trait is present") is
+a Phase 2 concern and is tracked in issue #39.
 
 ---
 
-## What needs to be designed
+## What is deferred
+
+The following questions are explicitly out of scope for Phase 1 and belong to issue #39:
 
 1. **Optional traits** — a package may include a `certificate` trait or an `external-secret`
    trait that only applies when the user wants TLS or external secret injection. The user
@@ -26,363 +29,30 @@ made but is written to be compatible with either option.
    Redis sidecar component that is not always needed.
 
 3. **Multi-instance** — a package may define a logical component pattern (e.g. a "worker")
-   that can be instantiated multiple times with different names and values
-   (worker-fast, worker-slow). Can the user add instances beyond what the package declares?
+   that can be instantiated multiple times with different names and values.
 
-4. **Split files** — can a package split `app.yaml` into per-component files
-   (e.g. `components/web.yaml`, `components/worker.yaml`) to keep large packages
-   manageable?
+4. **Split files** — splitting `app.yaml` into per-component files for large packages.
 
 ---
 
-## Option A — `optional:` list in kurel.yaml + boolean values
-
-### How it works
-
-`kurel.yaml` declares an `optional` list naming components and traits that are inactive by
-default. The user enables them via boolean values (a `values.yaml` key or a `--set` flag).
-
-The resolver reads the optional list, evaluates the enable flags, and strips
-inactive sections from the Application before parameter resolution and ClusterProfile
-rendering proceed.
-
-### kurel.yaml
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Package
-metadata:
-  name: webservice
-  version: "1.0.0"
-spec:
-  parameters:
-  - name: image
-    type: string
-    required: true
-  - name: domain
-    type: string
-    required: true
-  - name: tlsEnabled
-    type: boolean
-    required: false
-    default: false
-  - name: workerEnabled
-    type: boolean
-    required: false
-    default: false
-  - name: replicas
-    type: integer
-    required: false
-    default: 1
-  optional:
-  - kind: trait
-    component: web
-    traitType: certificate
-    enabledBy: tlsEnabled
-  - kind: component
-    name: worker
-    enabledBy: workerEnabled
-```
-
-### app.yaml
-
-`app.yaml` contains all components and traits, including the optional ones. The resolver
-strips sections that are disabled before any further processing.
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: "${image}"
-      replicas: ${replicas}
-    traits:
-    - type: expose
-      properties:
-        rules:
-        - host: "${domain}"
-    - type: certificate          # optional — stripped when tlsEnabled=false
-      properties:
-        secretName: "${domain}-tls"
-        dnsNames:
-        - "${domain}"
-  - name: worker                 # optional — stripped when workerEnabled=false
-    type: worker
-    properties:
-      image: "${image}"
-      replicas: 1
-```
-
-### Supplying values
-
-With Option A param syntax:
-
-```sh
-# Default — TLS and worker disabled
-kurel build . --profile cluster.yaml --set image=myregistry/app:v1 --set domain=app.example.com
-
-# With TLS enabled
-kurel build . --profile cluster.yaml \
-    --set image=myregistry/app:v1 \
-    --set domain=app.example.com \
-    --set tlsEnabled=true
-```
-
-With Option B param syntax (values.yaml overlay):
-
-```yaml
-# values.yaml
-components:
-- name: web
-  properties:
-    image: myregistry/app:v1
-    replicas: 2
-```
-
-The optional list mechanism would need to be fed via a separate top-level key:
-
-```yaml
-# values.yaml
-enable:
-  web.certificate: true
-components:
-- name: web
-  properties:
-    image: myregistry/app:v1
-```
-
-This is an awkward fit for Option B, because the values file structure mirrors app.yaml
-but the `enable` flags reference structural paths, not property paths.
-
-### Multi-instance
-
-Option A does not natively support multi-instance. The package declares a fixed set of
-components. If a user needs two worker instances, they either:
-
-- Use multiple packages (one per worker configuration)
-- Wait for Phase 2 conditional composition (#39)
-- Use `--set` flags to parameterize a single worker's properties
-
-### Split files
-
-Not addressed by Option A. `app.yaml` remains a single file. Large packages must fit in one
-document. Split-file support is a separate concern.
-
-### Implications
-
-- Optional sections are declared in `kurel.yaml`, not inline in `app.yaml` — `app.yaml`
-  reads as a complete superset and the optional declarations are the gate.
-- The boolean parameter mechanism integrates cleanly with the Option A param syntax
-  (parameters with `type: boolean` are first-class parameter types).
-- Awkward with Option B param syntax: the `enable` flags don't fit the overlay structure.
-- The resolver must run optional-section stripping before parameter resolution, so that
-  stripped sections do not produce "missing required parameter" errors for their properties.
-- Required parameters on optional components create a problem: the user must only supply
-  required values for enabled components. This requires per-component required-parameter
-  evaluation, which adds resolver complexity.
-
-### Pros
-
-- Clear separation: optional declarations are in `kurel.yaml` (public API); `app.yaml`
-  contains the full superset of what a package can produce
-- Enable flags are strongly typed parameters — schema-validated, discoverable
-- Integrates with `--set` flags and the Option A parameter schema
-- Optional traits and components are explicit in the package's public API
-
-### Cons
-
-- `app.yaml` must include all optional sections; browsing it shows disabled content mixed
-  with enabled content
-- Poor fit with Option B param syntax
-- No multi-instance support
-- No split-file support
-- Resolver must handle per-section parameter validation (complex)
-
----
-
-## Option B — Inline annotations in app.yaml
-
-### How it works
-
-Optional components and traits carry a launcher annotation directly in `app.yaml`. No
-`optional:` list in `kurel.yaml`. The annotation specifies the condition under which the
-section is included; the user controls it via values or `--set` flags.
-
-The annotation uses a launcher-reserved key in the component or trait block.
-
-### kurel.yaml
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Package
-metadata:
-  name: webservice
-  version: "1.0.0"
-spec:
-  parameters:
-  - name: image
-    type: string
-    required: true
-  - name: domain
-    type: string
-    required: true
-  - name: tls
-    type: boolean
-    required: false
-    default: false
-  - name: worker
-    type: boolean
-    required: false
-    default: false
-  - name: replicas
-    type: integer
-    required: false
-    default: 1
-```
-
-### app.yaml with inline annotations
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: "${image}"
-      replicas: ${replicas}
-    traits:
-    - type: expose
-      properties:
-        rules:
-        - host: "${domain}"
-    - type: certificate
-      launcher.gokure.dev/include-if: "${tls}"  # inline gate
-      properties:
-        secretName: "${domain}-tls"
-        dnsNames:
-        - "${domain}"
-  - name: worker
-    type: worker
-    launcher.gokure.dev/include-if: "${worker}" # inline gate
-    properties:
-      image: "${image}"
-      replicas: 1
-```
-
-`launcher.gokure.dev/include-if` is a launcher-reserved field. Its value is a parameter
-reference that resolves to a boolean. The resolver evaluates these gates after parameter
-substitution and strips sections where the gate evaluates to false before ClusterProfile
-rendering.
-
-### Implications
-
-- `app.yaml` remains the single source of truth; the gate is co-located with the section
-  it controls.
-- The launcher API group prefix on `include-if` signals that this is not an Application
-  property but a resolver directive — it must be explicitly excluded from strict parsing
-  of the Application document body.
-- The same `${...}` substitution machinery (Option A param syntax) is required to evaluate
-  the gate expression. This option is incompatible with Option B param syntax as specified
-  because `${...}` placeholders are not used there.
-
-### Strict-parsing interaction
-
-`launcher.gokure.dev/include-if` is a meta-directive on a component or trait, not a
-property value. Under the strict parsing rule (see `design-gvk.md`), the Application parser
-must either:
-
-- Explicitly whitelist `launcher.gokure.dev/*` annotation keys on components and traits, or
-- Process these directives before the Application document is parsed against the Application
-  schema, removing them first
-
-This adds a pre-processing step before the schema-validated parse.
-
-### Multi-instance
-
-Not addressed by this option either. The package still declares a fixed set of named
-components.
-
-### Split files
-
-Could be combined with a split-file mechanism (each component file carries its own
-`include-if`), but this is independent of the annotation mechanism.
-
-### Pros
-
-- Gate co-located with the section it controls — easier to read for package authors
-- `kurel.yaml` stays clean; no parallel `optional:` list to keep in sync with `app.yaml`
-- A future extension (`include-if` with richer expressions) follows naturally from the
-  same mechanism
-
-### Cons
-
-- `app.yaml` contains non-Application syntax (resolver directives) — technically not a
-  valid Application document even before parameter resolution
-- Strict-parsing interaction adds a pre-processing requirement
-- Only compatible with Option A param syntax (requires `${...}` evaluation)
-- `kurel.yaml` no longer enumerates the enable/disable surface of the package — consumers
-  must read `app.yaml` to discover what can be toggled
-- The annotation key prefix is verbose; alternatives (`x-include-if`, `_if`) trade clarity
-  for brevity
-
----
-
-## Open Questions
-
-These questions are not answered here and must be resolved before `design-kurel-package.md`
-§4–5 can be written:
+## Open questions for issue #39
 
 **Q1 — Where does optionality belong?**
-Is optional section declaration:
-- Package metadata (`kurel.yaml` — Option A)
-- Inline in `app.yaml` (`include-if` annotation — Option B)
-- Both (annotations in `app.yaml` are the mechanism; `kurel.yaml` enumerates them for
-  discoverability)?
-- Deferred entirely to Phase 2 conditional composition (issue #39)?
-
-If optionality is deferred, Phase 1 packages have no optional sections. Users compose via
-multiple packages or via a fixed superset (all sections always present).
+- Package metadata (`kurel.yaml` optional list) — keeps optionality in the public API surface
+- Inline in `app.yaml` (`include-if` annotation) — co-located with the section it controls,
+  but introduces non-Application syntax into app.yaml and conflicts with strict parsing
+- Both (annotations as mechanism; `kurel.yaml` as discovery index)
 
 **Q2 — Per-section required parameters**
-If optional components or traits have required parameters, how are they validated? Options:
+If optional components or traits have required parameters, how are they validated?
 - Required-if: parameter is only required when the section is enabled
-- Explicit group: parameters belong to a section; the group is validated or skipped
-  together
-- User responsibility: no framework validation; missing parameters fail at render time with
-  a property-level error
+- Explicit group: parameters belong to a section; the group is validated or skipped together
+- User responsibility: no framework validation
 
 **Q3 — Multi-instance scope**
-Is multi-instance a Phase 1 concern? The use case (multiple worker instances from one
-component pattern) exists in crane. Options:
-- Not Phase 1: users instantiate the same package multiple times with different names
-- Phase 1: package declares a component pattern; `values.yaml` provides a list of instances
-- Phase 2 (issue #39): conditional composition handles this
+- Not Phase 2: users instantiate the same package multiple times with different names
+- Phase 2: package declares a component pattern; values provide a list of instances
 
 **Q4 — Split files**
-Should `app.yaml` be splittable into per-component files in Phase 1? This is a package
-organization concern independent of optionality. It is not needed for correctness but
-affects developer experience for large packages.
-
----
-
-## Summary Comparison
-
-| Aspect | Option A: kurel.yaml optional list | Option B: Inline annotation |
-|---|---|---|
-| Gate location | `kurel.yaml` — explicit public API | `app.yaml` co-located with section |
-| `app.yaml` is valid Application at rest | Yes (all sections present, some inactive) | No (contains resolver directives) |
-| `kurel.yaml` enumerates enable surface | **Yes** | No — must read `app.yaml` |
-| Param syntax compatibility | **Both A and B** | Option A only |
-| Strict-parsing interaction | None | Requires pre-processing step |
-| Multi-instance support | None | None |
-| Split-file support | None | None |
-| Resolver complexity | Medium (per-section param validation) | Medium (pre-processing + gate eval) |
+Independent of optionality. Affects developer experience for large packages but not
+correctness. May be addressed independently of Q1–Q3.

--- a/docs/oam/options-param-syntax.md
+++ b/docs/oam/options-param-syntax.md
@@ -1,21 +1,28 @@
-# Options: Parameter Syntax for OAM Packages
+# Design: Parameter Syntax for Kurel Packages
 
-*Status: **Decided — Option A** | Issue #36*
+*Status: **Final — Option A selected** | Issue #36*
 
-This document compares two options for how application-specific values (image, replicas,
-domain names, etc.) are expressed in a kurel package and supplied at build time.
+| Version | Date | Summary |
+|---|---|---|
+| 1.1 | 2026-05-14 | Record decision (Option A); remove Option B; add resolver behaviour section; correct env list claim |
+| 1.0 | 2026-04-19 | Initial draft — compared Option A (placeholders) and Option B (overlay) |
+
+**Decision:** Application values are expressed as `${var}` placeholders in `app.yaml`,
+with a typed parameter schema declared in `kurel.yaml`. Reason: launcher is a package
+manager; an explicit, machine-readable package API (schema, required fields, types,
+`--set` support) is more important than `app.yaml` being valid at rest.
 
 **Scope:** how values flow from the user into `component.properties` and
 `trait.properties`. Platform profile resolution (ClusterProfile rendering) is already
 decided and is out of scope here.
 
 **Optionality and package composition** (optional traits, optional components,
-multi-instance components) are a separate design axis and are not part of this decision.
+multi-instance components) are deferred to Phase 2 (issue #39).
 See `options-package-composition.md`.
 
 ---
 
-## Option A — `${var}` Placeholders in app.yaml
+## Parameter Syntax — `${var}` Placeholders
 
 ### How it works
 
@@ -189,179 +196,14 @@ replaces the placeholder with the full YAML node from values.yaml:
 
 ---
 
-## Option B — values.yaml Overlay on Static app.yaml
+## Why Not values.yaml Overlay
 
-### How it works
+The rejected alternative had `app.yaml` as a static document with sentinel strings
+(`"REQUIRED"`) for mandatory fields, and a `values.yaml` that deep-merges into the
+component/trait structure at build time. It was rejected because:
 
-`kurel.yaml` is metadata-only — no parameter schema. `app.yaml` is a complete, valid
-Application document with sensible defaults (or sentinel values for required fields).
-A `values.yaml` file (user-supplied) deep-merges into `app.yaml`'s component and trait
-properties at build time. The runtime receives the merged document.
-
-`app.yaml` is always valid and parseable as a launcher Application — before and after
-the overlay.
-
-### kurel.yaml (metadata only)
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Package
-metadata:
-  name: webservice
-  version: "1.0.0"
-  description: "A stateless web service with ingress, TLS, and optional autoscaling."
-spec:
-  # No parameter declarations
-```
-
-### app.yaml with defaults
-
-```yaml
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: "REQUIRED"     # sentinel — build fails if still present after overlay
-      port: 8080
-      replicas: 1           # default
-      resources:
-        requests:
-          cpu: "100m"
-          memory: "128Mi"
-    traits:
-    - type: expose
-      properties:
-        rules:
-        - host: "REQUIRED"
-          paths:
-          - path: /
-            port: 8080
-        tls:
-        - secretName: "REQUIRED"
-          hosts:
-          - "REQUIRED"
-    - type: certificate
-      properties:
-        secretName: "REQUIRED"
-        dnsNames:
-        - "REQUIRED"
-    - type: scaler
-      properties:
-        minReplicas: 1
-        maxReplicas: 10
-        cpuUtilization: 70
-```
-
-### values.yaml
-
-The overlay mirrors the component/trait structure of `app.yaml`. Merge is by component
-name and trait type (not index):
-
-```yaml
-# values.yaml
-components:
-- name: web
-  properties:
-    image: "myregistry/app:v1.2.3"
-    replicas: 3
-    env:
-    - name: LOG_LEVEL       # full list supplied directly — no type coercion needed
-      value: info
-    - name: DB_HOST
-      value: postgres.svc
-  traits:
-  - type: expose
-    properties:
-      rules:
-      - host: "app.example.com"
-        paths:
-        - path: /
-          port: 8080
-      tls:
-      - secretName: "my-app-tls"
-        hosts:
-        - "app.example.com"
-  - type: certificate
-    properties:
-      secretName: "my-app-tls"
-      dnsNames:
-      - "app.example.com"
-```
-
-### Supplying values at build time
-
-```sh
-# values.yaml is the only input mechanism — no --set flags
-kurel build . --profile cluster.yaml --values values.yaml
-```
-
-### Merge algorithm
-
-1. Components matched by `name`.
-2. Within a component, `properties` deep-merged: user keys override package keys;
-   unmentioned keys preserved.
-3. Traits matched by `type`. If multiple traits of the same type exist, matched by
-   index — this is a known limitation.
-4. Within a trait, `properties` deep-merged the same way.
-5. After merge, any property value equal to the sentinel string `"REQUIRED"` causes a
-   build error listing the component, trait, and property path.
-
-### What cannot be added via values.yaml
-
-- A new component not present in `app.yaml`
-- A new trait not present in `app.yaml`
-- Conditional inclusion/exclusion of components or traits (separate design axis)
-
-### Implications
-
-- `app.yaml` is always a valid launcher Application document. Readable as-is; serves as
-  documentation for the package's defaults and structure.
-- No explicit parameter schema: consumers must read `app.yaml` to discover what can be
-  overridden.
-- Required field enforcement is ad-hoc: sentinel strings work for string fields, but a
-  user who supplies `image: ""` passes the check and produces a broken manifest.
-- Trait index ambiguity: packages with multiple traits of the same type (e.g. two
-  `configmap` traits) require a deterministic resolution rule.
-
-### Pros
-
-- `app.yaml` is always a valid, readable Application document
-- Type-safe: YAML values in `values.yaml` retain types natively
-- No resolver complexity: deep-merge, no type coercion
-- `app.yaml` serves as living documentation with defaults visible
-
-### Cons
-
-- No machine-readable parameter schema — no way to enumerate what a package accepts
-  without reading app.yaml
-- Required enforcement is ad-hoc (sentinel strings)
-- No `--set` flags
-- Values file must mirror app.yaml structure — users need to know component/trait names
-- Trait-by-index matching is fragile
-
----
-
-## Summary Comparison
-
-| Aspect | Option A: Placeholders | Option B: Overlay |
-|---|---|---|
-| Explicit parameter schema | **Yes — in `kurel.yaml`** | No — read `app.yaml` |
-| Required parameters enforced | **Yes — schema validation** | Ad-hoc (sentinel strings) |
-| Parameter discovery | Single list in `kurel.yaml` | Must read `app.yaml` |
-| Type safety | Requires type-aware resolver | **Native YAML** |
-| Lists and maps as parameters | Yes (node substitution) | **Yes (native)** |
-| `--set` flags | **Yes (scalars)** | No |
-| Values file structure | By parameter name (flat/structured) | Mirrors app.yaml internals |
-| Resolver complexity | Higher (type coercion + node subst.) | **Lower (deep-merge)** |
-| `app.yaml` readable at rest | No (contains `${…}`) | **Yes** |
-| Prototype resolver reuse | Partial | No |
-
-Note on `app.yaml` readability: in Option A, `app.yaml` at rest contains placeholder
-syntax and is not a valid Application. In Option B it is valid and readable without
-tooling. This affects developer experience when browsing package source, but is not a
-runtime or correctness concern — both options produce identical resolved output.
+- No machine-readable parameter schema — consumers must read `app.yaml` to discover what can be overridden
+- Required field enforcement is ad-hoc: sentinel strings work for string fields, but `image: ""` passes the check and produces a broken manifest
+- No `--set` flags — scalars cannot be supplied on the command line
+- Values file must mirror `app.yaml` structure — users need to know component and trait names
+- Trait-by-index matching is fragile for packages with multiple traits of the same type

--- a/docs/oam/options-param-syntax.md
+++ b/docs/oam/options-param-syntax.md
@@ -2,13 +2,16 @@
 
 *Status: Decision required | Blocks: `design-kurel-package.md` §6, issue #36*
 
-This document fully designs both options for how application-specific values (image,
-replicas, domain names, etc.) are expressed in a kurel package and supplied at build time.
-Read both options completely before deciding.
+This document compares two options for how application-specific values (image, replicas,
+domain names, etc.) are expressed in a kurel package and supplied at build time.
 
-**Scope of this decision:** how values flow from the user into OAM Application
-`component.properties` and `trait.properties`. This does not cover platform profile
-resolution (that is ClusterProfile rendering, already decided) or handler implementation.
+**Scope:** how values flow from the user into `component.properties` and
+`trait.properties`. Platform profile resolution (ClusterProfile rendering) is already
+decided and is out of scope here.
+
+**Optionality and package composition** (optional traits, optional components,
+multi-instance components) are a separate design axis and are not part of this decision.
+See `options-package-composition.md`.
 
 ---
 
@@ -17,16 +20,16 @@ resolution (that is ClusterProfile rendering, already decided) or handler implem
 ### How it works
 
 `kurel.yaml` declares a parameter schema: a list of parameters the package accepts,
-their types, defaults, and whether they are required. `app.yaml` embeds `${name}`
-placeholders in property values. Before the OAM Application is parsed, the runtime
-resolves all placeholders by substituting parameter values supplied at build time.
+with types, defaults, and required flags. `app.yaml` embeds `${name}` placeholders in
+property values. Before the Application is parsed, the runtime resolves all placeholders
+by substituting the parameter values supplied at build time.
 
-The OAM runtime receives a fully-resolved Application document with no placeholders.
+The runtime receives a fully-resolved Application document with no placeholders.
 
 ### kurel.yaml parameter declarations
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Package
 metadata:
   name: webservice
@@ -49,12 +52,17 @@ spec:
     type: string
     required: false
     default: "${name}-tls"   # can reference other parameters
+  - name: env
+    type: array
+    required: false
+    default: []
+    description: "Extra environment variables as a list of {name, value} objects"
 ```
 
 ### app.yaml with placeholders
 
 ```yaml
-apiVersion: core.oam.dev/v1beta1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
   name: my-app
@@ -66,6 +74,7 @@ spec:
       image: "${image}"
       port: 8080
       replicas: ${replicas}
+      env: ${env}            # node substitution — resolved to a YAML list
       resources:
         requests:
           cpu: "100m"
@@ -87,7 +96,6 @@ spec:
         secretName: "${tlsSecret}"
         dnsNames:
         - "${domain}"
-        # issuerRef comes from ClusterProfile capability rendering
     - type: scaler
       properties:
         minReplicas: ${replicas}
@@ -97,11 +105,14 @@ spec:
 
 ### Supplying values at build time
 
+Values can be supplied as a file or via `--set` flags. The values file can be flat or
+structured — the parameter names in `kurel.yaml` are the keys:
+
 ```sh
-# Option 1: values.yaml (flat key=value map)
+# Option 1: values.yaml
 kurel build . --profile cluster.yaml --values values.yaml
 
-# Option 2: --set flags
+# Option 2: --set flags (scalars only)
 kurel build . --profile cluster.yaml \
     --set image=myregistry/app:v1.2.3 \
     --set replicas=3 \
@@ -109,99 +120,72 @@ kurel build . --profile cluster.yaml \
 ```
 
 ```yaml
-# values.yaml
+# values.yaml — flat scalars
 image: myregistry/app:v1.2.3
 replicas: 3
 domain: app.example.com
 # tlsSecret not set — uses default from kurel.yaml
+
+# values.yaml — with structured parameter (array type)
+image: myregistry/app:v1.2.3
+replicas: 3
+domain: app.example.com
+env:
+- name: LOG_LEVEL
+  value: info
+- name: DB_HOST
+  value: postgres.svc
 ```
 
-### What the OAM runtime receives (after resolution)
+### Resolver behaviour: scalars vs nodes
 
-```yaml
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: "myregistry/app:v1.2.3"  # substituted
-      port: 8080
-      replicas: 3                      # substituted, typed as integer
-    traits:
-    - type: expose
-      properties:
-        rules:
-        - host: "app.example.com"      # substituted
-          paths: [...]
-        tls:
-        - secretName: "my-app-tls"    # substituted (from default expression)
-          hosts: ["app.example.com"]
-    - type: certificate
-      properties:
-        secretName: "my-app-tls"
-        dnsNames: ["app.example.com"]
-```
+**Scalar substitution** — when the placeholder is the entire YAML value for a scalar
+field, the resolver substitutes the typed value directly:
+- `image: "${image}"` → `image: "myregistry/app:v1.2.3"` (string)
+- `replicas: ${replicas}` → `replicas: 3` (integer, not string)
+- The declared parameter `type` drives coercion; `type: integer` produces a YAML integer
 
-### Type handling
+**Node substitution** — when the parameter type is `array` or `object`, the resolver
+replaces the placeholder with the full YAML node from values.yaml:
+- `env: ${env}` → `env: [{name: LOG_LEVEL, value: info}, ...]` (list)
+- Requires a YAML-node-level resolver (not plain string replacement)
+- The existing prototype resolver does string substitution only; node substitution would
+  be an extension
 
-String substitution produces strings. The resolver must type-coerce values to match the
-declared parameter type:
-- `type: integer` — `"${replicas}"` in the YAML value → resolved to YAML integer `3`
-- `type: boolean` — `"${enabled}"` → resolved to YAML boolean `true` or `false`
-- `type: string` — no coercion needed
-
-This requires the resolver to understand YAML context (is `${replicas}` a scalar integer
-field or embedded in a string?) and produce correct output. The existing prototype
-resolver does string substitution only and would need extension for type-aware resolution.
+**Inline string embedding** — when the placeholder is embedded in a larger string:
+- `name: "prefix-${name}-suffix"` → `name: "prefix-webservice-suffix"`
+- Produces a string; not type-coerced
 
 ### What cannot be parameterized
 
-Placeholders only work in scalar positions. You cannot substitute a list, a map, or a
-block. The following is not supported:
-
-```yaml
-# NOT SUPPORTED — cannot substitute an entire env list
-env: "${envVars}"
-
-# NOT SUPPORTED — cannot conditionally include a trait block
-traits:
-- ${maybeScalerTrait}
-```
-
-Workarounds: hard-code structural elements in app.yaml; use conditional composition
-(Phase 2, issue #39) for structural variations.
+- Conditional inclusion of entire traits or components (separate design axis — see
+  `options-package-composition.md`)
+- Template-level structural variation (e.g. "repeat this trait N times")
 
 ### Implications
 
-- `app.yaml` is a **template**, not a valid standalone OAM document. It cannot be
-  processed by OAM tooling, validated by Kubernetes, or read by other tools without
-  first running through the kurel resolver.
-- The package maintainer defines the public API explicitly — consumers know exactly what
-  parameters a package accepts, with types and defaults.
-- Required parameters are enforced by the schema: build fails immediately if a required
-  parameter is missing, with a clear error message.
-- The resolver must be type-aware (see Type handling above). This is an implementation
-  cost not present in Option B.
+- `app.yaml` is a template: it contains unresolved `${…}` and cannot be used directly
+  as a valid launcher Application without running through the resolver first.
+- `kurel.yaml` is the explicit public API of the package: consumers see all parameter
+  names, types, defaults, and descriptions.
+- Required parameters are schema-enforced: build fails immediately with a clear error if
+  any required parameter is missing.
+- Node substitution for `array`/`object` parameters adds resolver implementation cost.
 
 ### Pros
 
-- Explicit contract: `kurel.yaml` is the package's public API, fully machine-readable
-- Enforced required parameters — clear error at build time, not runtime
-- Values file is flat — no need to know app.yaml's internal structure
-- `--set key=value` flags work naturally
-- Follows the existing prototype resolver convention — partial reuse possible
+- Explicit contract: `kurel.yaml` parameter list is the package's public API
+- Enforced required parameters — schema validation, not sentinel strings
+- Values file is flat/structured by parameter name — no need to know app.yaml internals
+- `--set` flags work for scalar parameters
+- Type declarations make parameter intent clear
 
 ### Cons
 
-- `app.yaml` is not valid standalone OAM
-- Type coercion adds resolver complexity (must produce integer/boolean YAML, not just strings)
-- Cannot parameterize structural elements (lists, maps, conditional blocks)
-- Placeholder escaping needed if property values legitimately contain `${...}`
-- Package consumers cannot read `app.yaml` directly to understand what the app does without resolving
+- `app.yaml` is not a valid launcher Application document at rest (template)
+- Type-aware resolver required (beyond simple string substitution)
+- Node substitution adds implementation complexity
+- Placeholder escaping needed if property values legitimately contain `${…}`
 
 ---
 
@@ -209,30 +193,31 @@ Workarounds: hard-code structural elements in app.yaml; use conditional composit
 
 ### How it works
 
-`kurel.yaml` is metadata-only — no parameter schema. `app.yaml` is a complete, valid OAM
-Application with sensible defaults. A `values.yaml` file (user-supplied) deep-merges into
-`app.yaml`'s component and trait properties at build time. The runtime receives the merged
-document.
+`kurel.yaml` is metadata-only — no parameter schema. `app.yaml` is a complete, valid
+Application document with sensible defaults (or sentinel values for required fields).
+A `values.yaml` file (user-supplied) deep-merges into `app.yaml`'s component and trait
+properties at build time. The runtime receives the merged document.
 
-`app.yaml` is always a valid, parseable OAM Application — before and after the overlay.
+`app.yaml` is always valid and parseable as a launcher Application — before and after
+the overlay.
 
 ### kurel.yaml (metadata only)
 
 ```yaml
-apiVersion: launcher.wharf.zone/v1alpha1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Package
 metadata:
   name: webservice
   version: "1.0.0"
   description: "A stateless web service with ingress, TLS, and optional autoscaling."
 spec:
-  # No parameter declarations — app.yaml is the source of truth for defaults
+  # No parameter declarations
 ```
 
 ### app.yaml with defaults
 
 ```yaml
-apiVersion: core.oam.dev/v1beta1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
   name: my-app
@@ -243,7 +228,7 @@ spec:
     properties:
       image: "REQUIRED"     # sentinel — build fails if still present after overlay
       port: 8080
-      replicas: 1           # default; user overrides in values.yaml
+      replicas: 1           # default
       resources:
         requests:
           cpu: "100m"
@@ -252,7 +237,7 @@ spec:
     - type: expose
       properties:
         rules:
-        - host: "REQUIRED"  # sentinel
+        - host: "REQUIRED"
           paths:
           - path: /
             port: 8080
@@ -275,7 +260,7 @@ spec:
 ### values.yaml
 
 The overlay mirrors the component/trait structure of `app.yaml`. Merge is by component
-name and trait type (not by index):
+name and trait type (not index):
 
 ```yaml
 # values.yaml
@@ -284,6 +269,11 @@ components:
   properties:
     image: "myregistry/app:v1.2.3"
     replicas: 3
+    env:
+    - name: LOG_LEVEL       # full list supplied directly — no type coercion needed
+      value: info
+    - name: DB_HOST
+      value: postgres.svc
   traits:
   - type: expose
     properties:
@@ -310,99 +300,49 @@ components:
 kurel build . --profile cluster.yaml --values values.yaml
 ```
 
-There is no `--set` equivalent: to override a value you must write `values.yaml`.
-
-### What the OAM runtime receives (after overlay)
-
-```yaml
-apiVersion: core.oam.dev/v1beta1
-kind: Application
-metadata:
-  name: my-app
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: "myregistry/app:v1.2.3"   # from values.yaml
-      port: 8080                         # from app.yaml (not overridden)
-      replicas: 3                        # from values.yaml
-      resources:                         # from app.yaml (not overridden)
-        requests:
-          cpu: "100m"
-          memory: "128Mi"
-    traits:
-    - type: expose
-      properties:
-        rules:
-        - host: "app.example.com"        # from values.yaml
-          ...
-    - type: certificate
-      properties:
-        secretName: "my-app-tls"         # from values.yaml
-        dnsNames: ["app.example.com"]
-    - type: scaler
-      properties:
-        minReplicas: 1                   # from app.yaml (not overridden)
-        maxReplicas: 10
-        cpuUtilization: 70
-```
-
 ### Merge algorithm
 
-1. Components are matched by `name` (not by index position in the list).
-2. Within a component, `properties` is deep-merged: user keys override package keys;
-   unmentioned package keys are preserved.
-3. Traits are matched by `type`. If multiple traits of the same type exist, they are
-   matched by index — this is a known limitation.
-4. Within a trait, `properties` is deep-merged the same way.
-5. After merge, any property value equal to the sentinel string `"REQUIRED"` causes the
-   build to fail with a clear error listing the component, trait, and property path.
+1. Components matched by `name`.
+2. Within a component, `properties` deep-merged: user keys override package keys;
+   unmentioned keys preserved.
+3. Traits matched by `type`. If multiple traits of the same type exist, matched by
+   index — this is a known limitation.
+4. Within a trait, `properties` deep-merged the same way.
+5. After merge, any property value equal to the sentinel string `"REQUIRED"` causes a
+   build error listing the component, trait, and property path.
 
-### What cannot be parameterized
+### What cannot be added via values.yaml
 
-- A user cannot **add** a new component or trait via `values.yaml` — only override
-  properties of existing ones.
-- A user cannot **remove** a component or trait — all components from `app.yaml` are
-  always present.
-- Structural variations (include scaler only in production) require a separate package
-  variant, or conditional composition (Phase 2, issue #39).
-
-```yaml
-# NOT SUPPORTED — cannot add a component that is not in app.yaml
-components:
-- name: new-sidecar   # not in app.yaml — ignored or error
-  type: worker
-```
+- A new component not present in `app.yaml`
+- A new trait not present in `app.yaml`
+- Conditional inclusion/exclusion of components or traits (separate design axis)
 
 ### Implications
 
-- `app.yaml` is always a **valid standalone OAM Application**. It can be used with OAM
-  tooling, validated, imported into editors, and read as documentation for what the
-  package does with its defaults.
-- There is no explicit parameter schema — consumers must read `app.yaml` to understand
-  what values are overridable.
-- "Required" enforcement relies on the sentinel convention (`"REQUIRED"`). This is
-  ad-hoc: a user who sets `image: ""` passes validation but produces a broken manifest.
-- Trait index ambiguity when multiple traits of the same type exist (rare but possible
-  with e.g. two `configmap` traits) requires a deterministic resolution rule.
+- `app.yaml` is always a valid launcher Application document. Readable as-is; serves as
+  documentation for the package's defaults and structure.
+- No explicit parameter schema: consumers must read `app.yaml` to discover what can be
+  overridden.
+- Required field enforcement is ad-hoc: sentinel strings work for string fields, but a
+  user who supplies `image: ""` passes the check and produces a broken manifest.
+- Trait index ambiguity: packages with multiple traits of the same type (e.g. two
+  `configmap` traits) require a deterministic resolution rule.
 
 ### Pros
 
-- `app.yaml` is always valid, standalone OAM — readable by any OAM tooling, editors, validators
-- Type-safe: YAML values in `values.yaml` retain their types natively (integers stay integers)
-- No resolver complexity: overlay is a structural deep-merge, no type coercion
-- `app.yaml` serves as living documentation — readers see the defaults without running a build
-- Familiar mental model for Helm users
+- `app.yaml` is always a valid, readable Application document
+- Type-safe: YAML values in `values.yaml` retain types natively
+- No resolver complexity: deep-merge, no type coercion
+- `app.yaml` serves as living documentation with defaults visible
 
 ### Cons
 
-- No explicit parameter schema — no machine-readable list of what a package accepts
-- "Required" enforcement is ad-hoc (sentinel strings, not schema validation)
-- No `--set key=value` flag — every override requires a `values.yaml` file
-- Values file mirrors app.yaml's internal structure — users must know component/trait names
-- Cannot remove or conditionally exclude components/traits
-- Trait-by-index matching is fragile for packages with multiple traits of the same type
+- No machine-readable parameter schema — no way to enumerate what a package accepts
+  without reading app.yaml
+- Required enforcement is ad-hoc (sentinel strings)
+- No `--set` flags
+- Values file must mirror app.yaml structure — users need to know component/trait names
+- Trait-by-index matching is fragile
 
 ---
 
@@ -410,12 +350,18 @@ components:
 
 | Aspect | Option A: Placeholders | Option B: Overlay |
 |---|---|---|
-| `app.yaml` is valid standalone OAM | **No** — template | **Yes** |
-| Explicit parameter schema in `kurel.yaml` | **Yes** | No |
-| Required parameters enforced | **Yes** — schema validation | Ad-hoc (sentinel strings) |
+| Explicit parameter schema | **Yes — in `kurel.yaml`** | No — read `app.yaml` |
+| Required parameters enforced | **Yes — schema validation** | Ad-hoc (sentinel strings) |
+| Parameter discovery | Single list in `kurel.yaml` | Must read `app.yaml` |
 | Type safety | Requires type-aware resolver | **Native YAML** |
-| `--set key=value` flags | **Yes** | No |
-| Values file complexity | Flat map | Mirrors app.yaml structure |
-| Structural parameterization | No | No |
-| Resolver implementation cost | Higher (type coercion) | **Lower** (deep-merge) |
-| Prototype compatibility | **Partial** (same resolver pattern) | No |
+| Lists and maps as parameters | Yes (node substitution) | **Yes (native)** |
+| `--set` flags | **Yes (scalars)** | No |
+| Values file structure | By parameter name (flat/structured) | Mirrors app.yaml internals |
+| Resolver complexity | Higher (type coercion + node subst.) | **Lower (deep-merge)** |
+| `app.yaml` readable at rest | No (contains `${…}`) | **Yes** |
+| Prototype resolver reuse | Partial | No |
+
+Note on `app.yaml` readability: in Option A, `app.yaml` at rest contains placeholder
+syntax and is not a valid Application. In Option B it is valid and readable without
+tooling. This affects developer experience when browsing package source, but is not a
+runtime or correctness concern — both options produce identical resolved output.

--- a/docs/oam/options-param-syntax.md
+++ b/docs/oam/options-param-syntax.md
@@ -1,6 +1,6 @@
 # Options: Parameter Syntax for OAM Packages
 
-*Status: Decision required | Blocks: `design-kurel-package.md` §6, issue #36*
+*Status: **Decided — Option A** | Issue #36*
 
 This document compares two options for how application-specific values (image, replicas,
 domain names, etc.) are expressed in a kurel package and supplied at build time.

--- a/docs/oam/options-param-syntax.md
+++ b/docs/oam/options-param-syntax.md
@@ -1,0 +1,421 @@
+# Options: Parameter Syntax for OAM Packages
+
+*Status: Decision required | Blocks: `design-kurel-package.md` §6, issue #36*
+
+This document fully designs both options for how application-specific values (image,
+replicas, domain names, etc.) are expressed in a kurel package and supplied at build time.
+Read both options completely before deciding.
+
+**Scope of this decision:** how values flow from the user into OAM Application
+`component.properties` and `trait.properties`. This does not cover platform profile
+resolution (that is ClusterProfile rendering, already decided) or handler implementation.
+
+---
+
+## Option A — `${var}` Placeholders in app.yaml
+
+### How it works
+
+`kurel.yaml` declares a parameter schema: a list of parameters the package accepts,
+their types, defaults, and whether they are required. `app.yaml` embeds `${name}`
+placeholders in property values. Before the OAM Application is parsed, the runtime
+resolves all placeholders by substituting parameter values supplied at build time.
+
+The OAM runtime receives a fully-resolved Application document with no placeholders.
+
+### kurel.yaml parameter declarations
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: Package
+metadata:
+  name: webservice
+  version: "1.0.0"
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+    description: "Container image with tag, e.g. registry/app:v1.2.3"
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+  - name: domain
+    type: string
+    required: true
+    description: "Primary hostname, e.g. app.example.com"
+  - name: tlsSecret
+    type: string
+    required: false
+    default: "${name}-tls"   # can reference other parameters
+```
+
+### app.yaml with placeholders
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "${image}"
+      port: 8080
+      replicas: ${replicas}
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "${domain}"
+          paths:
+          - path: /
+            port: 8080
+        tls:
+        - secretName: "${tlsSecret}"
+          hosts:
+          - "${domain}"
+    - type: certificate
+      properties:
+        secretName: "${tlsSecret}"
+        dnsNames:
+        - "${domain}"
+        # issuerRef comes from ClusterProfile capability rendering
+    - type: scaler
+      properties:
+        minReplicas: ${replicas}
+        maxReplicas: 10
+        cpuUtilization: 70
+```
+
+### Supplying values at build time
+
+```sh
+# Option 1: values.yaml (flat key=value map)
+kurel build . --profile cluster.yaml --values values.yaml
+
+# Option 2: --set flags
+kurel build . --profile cluster.yaml \
+    --set image=myregistry/app:v1.2.3 \
+    --set replicas=3 \
+    --set domain=app.example.com
+```
+
+```yaml
+# values.yaml
+image: myregistry/app:v1.2.3
+replicas: 3
+domain: app.example.com
+# tlsSecret not set — uses default from kurel.yaml
+```
+
+### What the OAM runtime receives (after resolution)
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "myregistry/app:v1.2.3"  # substituted
+      port: 8080
+      replicas: 3                      # substituted, typed as integer
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "app.example.com"      # substituted
+          paths: [...]
+        tls:
+        - secretName: "my-app-tls"    # substituted (from default expression)
+          hosts: ["app.example.com"]
+    - type: certificate
+      properties:
+        secretName: "my-app-tls"
+        dnsNames: ["app.example.com"]
+```
+
+### Type handling
+
+String substitution produces strings. The resolver must type-coerce values to match the
+declared parameter type:
+- `type: integer` — `"${replicas}"` in the YAML value → resolved to YAML integer `3`
+- `type: boolean` — `"${enabled}"` → resolved to YAML boolean `true` or `false`
+- `type: string` — no coercion needed
+
+This requires the resolver to understand YAML context (is `${replicas}` a scalar integer
+field or embedded in a string?) and produce correct output. The existing prototype
+resolver does string substitution only and would need extension for type-aware resolution.
+
+### What cannot be parameterized
+
+Placeholders only work in scalar positions. You cannot substitute a list, a map, or a
+block. The following is not supported:
+
+```yaml
+# NOT SUPPORTED — cannot substitute an entire env list
+env: "${envVars}"
+
+# NOT SUPPORTED — cannot conditionally include a trait block
+traits:
+- ${maybeScalerTrait}
+```
+
+Workarounds: hard-code structural elements in app.yaml; use conditional composition
+(Phase 2, issue #39) for structural variations.
+
+### Implications
+
+- `app.yaml` is a **template**, not a valid standalone OAM document. It cannot be
+  processed by OAM tooling, validated by Kubernetes, or read by other tools without
+  first running through the kurel resolver.
+- The package maintainer defines the public API explicitly — consumers know exactly what
+  parameters a package accepts, with types and defaults.
+- Required parameters are enforced by the schema: build fails immediately if a required
+  parameter is missing, with a clear error message.
+- The resolver must be type-aware (see Type handling above). This is an implementation
+  cost not present in Option B.
+
+### Pros
+
+- Explicit contract: `kurel.yaml` is the package's public API, fully machine-readable
+- Enforced required parameters — clear error at build time, not runtime
+- Values file is flat — no need to know app.yaml's internal structure
+- `--set key=value` flags work naturally
+- Follows the existing prototype resolver convention — partial reuse possible
+
+### Cons
+
+- `app.yaml` is not valid standalone OAM
+- Type coercion adds resolver complexity (must produce integer/boolean YAML, not just strings)
+- Cannot parameterize structural elements (lists, maps, conditional blocks)
+- Placeholder escaping needed if property values legitimately contain `${...}`
+- Package consumers cannot read `app.yaml` directly to understand what the app does without resolving
+
+---
+
+## Option B — values.yaml Overlay on Static app.yaml
+
+### How it works
+
+`kurel.yaml` is metadata-only — no parameter schema. `app.yaml` is a complete, valid OAM
+Application with sensible defaults. A `values.yaml` file (user-supplied) deep-merges into
+`app.yaml`'s component and trait properties at build time. The runtime receives the merged
+document.
+
+`app.yaml` is always a valid, parseable OAM Application — before and after the overlay.
+
+### kurel.yaml (metadata only)
+
+```yaml
+apiVersion: launcher.wharf.zone/v1alpha1
+kind: Package
+metadata:
+  name: webservice
+  version: "1.0.0"
+  description: "A stateless web service with ingress, TLS, and optional autoscaling."
+spec:
+  # No parameter declarations — app.yaml is the source of truth for defaults
+```
+
+### app.yaml with defaults
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "REQUIRED"     # sentinel — build fails if still present after overlay
+      port: 8080
+      replicas: 1           # default; user overrides in values.yaml
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "REQUIRED"  # sentinel
+          paths:
+          - path: /
+            port: 8080
+        tls:
+        - secretName: "REQUIRED"
+          hosts:
+          - "REQUIRED"
+    - type: certificate
+      properties:
+        secretName: "REQUIRED"
+        dnsNames:
+        - "REQUIRED"
+    - type: scaler
+      properties:
+        minReplicas: 1
+        maxReplicas: 10
+        cpuUtilization: 70
+```
+
+### values.yaml
+
+The overlay mirrors the component/trait structure of `app.yaml`. Merge is by component
+name and trait type (not by index):
+
+```yaml
+# values.yaml
+components:
+- name: web
+  properties:
+    image: "myregistry/app:v1.2.3"
+    replicas: 3
+  traits:
+  - type: expose
+    properties:
+      rules:
+      - host: "app.example.com"
+        paths:
+        - path: /
+          port: 8080
+      tls:
+      - secretName: "my-app-tls"
+        hosts:
+        - "app.example.com"
+  - type: certificate
+    properties:
+      secretName: "my-app-tls"
+      dnsNames:
+      - "app.example.com"
+```
+
+### Supplying values at build time
+
+```sh
+# values.yaml is the only input mechanism — no --set flags
+kurel build . --profile cluster.yaml --values values.yaml
+```
+
+There is no `--set` equivalent: to override a value you must write `values.yaml`.
+
+### What the OAM runtime receives (after overlay)
+
+```yaml
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "myregistry/app:v1.2.3"   # from values.yaml
+      port: 8080                         # from app.yaml (not overridden)
+      replicas: 3                        # from values.yaml
+      resources:                         # from app.yaml (not overridden)
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: "app.example.com"        # from values.yaml
+          ...
+    - type: certificate
+      properties:
+        secretName: "my-app-tls"         # from values.yaml
+        dnsNames: ["app.example.com"]
+    - type: scaler
+      properties:
+        minReplicas: 1                   # from app.yaml (not overridden)
+        maxReplicas: 10
+        cpuUtilization: 70
+```
+
+### Merge algorithm
+
+1. Components are matched by `name` (not by index position in the list).
+2. Within a component, `properties` is deep-merged: user keys override package keys;
+   unmentioned package keys are preserved.
+3. Traits are matched by `type`. If multiple traits of the same type exist, they are
+   matched by index — this is a known limitation.
+4. Within a trait, `properties` is deep-merged the same way.
+5. After merge, any property value equal to the sentinel string `"REQUIRED"` causes the
+   build to fail with a clear error listing the component, trait, and property path.
+
+### What cannot be parameterized
+
+- A user cannot **add** a new component or trait via `values.yaml` — only override
+  properties of existing ones.
+- A user cannot **remove** a component or trait — all components from `app.yaml` are
+  always present.
+- Structural variations (include scaler only in production) require a separate package
+  variant, or conditional composition (Phase 2, issue #39).
+
+```yaml
+# NOT SUPPORTED — cannot add a component that is not in app.yaml
+components:
+- name: new-sidecar   # not in app.yaml — ignored or error
+  type: worker
+```
+
+### Implications
+
+- `app.yaml` is always a **valid standalone OAM Application**. It can be used with OAM
+  tooling, validated, imported into editors, and read as documentation for what the
+  package does with its defaults.
+- There is no explicit parameter schema — consumers must read `app.yaml` to understand
+  what values are overridable.
+- "Required" enforcement relies on the sentinel convention (`"REQUIRED"`). This is
+  ad-hoc: a user who sets `image: ""` passes validation but produces a broken manifest.
+- Trait index ambiguity when multiple traits of the same type exist (rare but possible
+  with e.g. two `configmap` traits) requires a deterministic resolution rule.
+
+### Pros
+
+- `app.yaml` is always valid, standalone OAM — readable by any OAM tooling, editors, validators
+- Type-safe: YAML values in `values.yaml` retain their types natively (integers stay integers)
+- No resolver complexity: overlay is a structural deep-merge, no type coercion
+- `app.yaml` serves as living documentation — readers see the defaults without running a build
+- Familiar mental model for Helm users
+
+### Cons
+
+- No explicit parameter schema — no machine-readable list of what a package accepts
+- "Required" enforcement is ad-hoc (sentinel strings, not schema validation)
+- No `--set key=value` flag — every override requires a `values.yaml` file
+- Values file mirrors app.yaml's internal structure — users must know component/trait names
+- Cannot remove or conditionally exclude components/traits
+- Trait-by-index matching is fragile for packages with multiple traits of the same type
+
+---
+
+## Summary Comparison
+
+| Aspect | Option A: Placeholders | Option B: Overlay |
+|---|---|---|
+| `app.yaml` is valid standalone OAM | **No** — template | **Yes** |
+| Explicit parameter schema in `kurel.yaml` | **Yes** | No |
+| Required parameters enforced | **Yes** — schema validation | Ad-hoc (sentinel strings) |
+| Type safety | Requires type-aware resolver | **Native YAML** |
+| `--set key=value` flags | **Yes** | No |
+| Values file complexity | Flat map | Mirrors app.yaml structure |
+| Structural parameterization | No | No |
+| Resolver implementation cost | Higher (type coercion) | **Lower** (deep-merge) |
+| Prototype compatibility | **Partial** (same resolver pattern) | No |

--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -1,0 +1,421 @@
+# Options: Policy Interface Design
+
+*Status: Decision required | Blocks: `design-policy-interface.md`, issue #38*
+
+This document fully designs both options for the `oam.Policy` interface.
+Read both options completely before deciding.
+
+**Scope:** The `Policy` and `Enforceable` interface definitions in `pkg/oam`, how
+`*api.EnvironmentPolicy` in crane satisfies `Policy` after migration, and how handler
+code uses the interface. This does not cover `TransformContext`, handler registration,
+or the pipeline execution loop.
+
+---
+
+## Background
+
+### Current state in crane
+
+```go
+// crane/internal/policy/policy.go
+type Enforceable interface {
+    ApplyPolicy(policy *api.EnvironmentPolicy) error
+}
+```
+
+Component config types (e.g. `WebserviceConfig`, `WorkerConfig`) implement this interface.
+The transformer calls `ApplyPolicy` after parsing each component, passing the environment
+policy from the request.
+
+```go
+// crane/pkg/api/types.go (abbreviated)
+type EnvironmentPolicy struct {
+    Enforced     EnforcedLimits         // MaxReplicas, MaxCPU, MaxMemory, MaxStorageSize, AllowedRegistries
+    Defaults     DefaultValues          // Replicas, CPURequest, MemoryRequest, CPULimit, MemoryLimit
+    Security     SecurityPolicy         // AllowHostNetwork, AllowPrivileged, AllowHostPID, AllowHostIPC, AllowHostPathVolumes
+    Placement    *PlacementRules        // optional
+    Capabilities *CapabilityConstraints // Allowed, Forbidden, Required
+}
+```
+
+### Goal after migration
+
+```go
+// launcher/pkg/oam/policy.go
+type Enforceable interface {
+    ApplyPolicy(policy Policy) error
+}
+```
+
+Where crane's `*api.EnvironmentPolicy` satisfies `Policy` — so that migrated handlers
+compile without the import path change breaking anything beyond the type signature.
+
+### Compatibility scope
+
+The compatibility requirement is **behavioral**, not **zero code change**: migrated OAM
+fixtures must produce identical manifest output. Handler code will be updated as part of
+the migration (Phase 4 in the roadmap). The question is what shape the interface takes.
+
+---
+
+## Option B — Typed Accessor Interface
+
+### Interface definition
+
+`Policy` exposes typed getter methods corresponding to every piece of data that handlers
+currently access via `*api.EnvironmentPolicy`.
+
+```go
+// launcher/pkg/oam/policy.go
+
+// Policy provides environment-level constraints and defaults for OAM handlers.
+// Handlers call its methods to apply limits and defaults; they must not type-assert.
+type Policy interface {
+    // Enforced limits — nil / empty string means no limit
+    MaxReplicas() *int32
+    MaxCPU() string
+    MaxMemory() string
+    MaxStorageSize() string
+    AllowedRegistries() []string
+
+    // Defaults — nil / empty string means "no default; leave OAM value as-is"
+    DefaultReplicas() *int32
+    DefaultCPURequest() string
+    DefaultMemoryRequest() string
+    DefaultCPULimit() string
+    DefaultMemoryLimit() string
+
+    // Security flags — false is the zero value (default-deny)
+    AllowHostNetwork() bool
+    AllowPrivileged() bool
+    AllowHostPID() bool
+    AllowHostIPC() bool
+    AllowHostPathVolumes() bool
+
+    // Capability constraints — nil means unconstrained
+    AllowedCapabilities() []string
+    ForbiddenCapabilities() []string
+    RequiredCapabilities() []string
+}
+
+// Enforceable is implemented by component configs that accept policy enforcement.
+type Enforceable interface {
+    ApplyPolicy(policy Policy) error
+}
+```
+
+### NoopPolicy
+
+```go
+// NoopPolicy is used when no policy is configured.
+// All methods return nil / empty / false (permit everything, apply no defaults).
+type NoopPolicy struct{}
+
+func (*NoopPolicy) MaxReplicas() *int32          { return nil }
+func (*NoopPolicy) MaxCPU() string               { return "" }
+func (*NoopPolicy) MaxMemory() string            { return "" }
+func (*NoopPolicy) MaxStorageSize() string       { return "" }
+func (*NoopPolicy) AllowedRegistries() []string  { return nil }
+func (*NoopPolicy) DefaultReplicas() *int32      { return nil }
+func (*NoopPolicy) DefaultCPURequest() string    { return "" }
+func (*NoopPolicy) DefaultMemoryRequest() string { return "" }
+func (*NoopPolicy) DefaultCPULimit() string      { return "" }
+func (*NoopPolicy) DefaultMemoryLimit() string   { return "" }
+func (*NoopPolicy) AllowHostNetwork() bool       { return false }
+func (*NoopPolicy) AllowPrivileged() bool        { return false }
+func (*NoopPolicy) AllowHostPID() bool           { return false }
+func (*NoopPolicy) AllowHostIPC() bool           { return false }
+func (*NoopPolicy) AllowHostPathVolumes() bool   { return false }
+func (*NoopPolicy) AllowedCapabilities() []string   { return nil }
+func (*NoopPolicy) ForbiddenCapabilities() []string { return nil }
+func (*NoopPolicy) RequiredCapabilities() []string  { return nil }
+```
+
+### How crane satisfies Policy
+
+crane adds accessor methods to `*api.EnvironmentPolicy`. No adapter or wrapper struct is
+needed — the existing type grows a method set:
+
+```go
+// crane/pkg/api/policy_impl.go (new file)
+package api
+
+import "github.com/go-kure/launcher/pkg/oam"
+
+// Verify at compile time that *EnvironmentPolicy satisfies oam.Policy.
+var _ oam.Policy = (*EnvironmentPolicy)(nil)
+
+func (p *EnvironmentPolicy) MaxReplicas() *int32          { return p.Enforced.MaxReplicas }
+func (p *EnvironmentPolicy) MaxCPU() string               { return p.Enforced.MaxCPU }
+func (p *EnvironmentPolicy) MaxMemory() string            { return p.Enforced.MaxMemory }
+func (p *EnvironmentPolicy) MaxStorageSize() string       { return p.Enforced.MaxStorageSize }
+func (p *EnvironmentPolicy) AllowedRegistries() []string  { return p.Enforced.AllowedRegistries }
+func (p *EnvironmentPolicy) DefaultReplicas() *int32      { return p.Defaults.Replicas }
+func (p *EnvironmentPolicy) DefaultCPURequest() string    { return p.Defaults.CPURequest }
+func (p *EnvironmentPolicy) DefaultMemoryRequest() string { return p.Defaults.MemoryRequest }
+func (p *EnvironmentPolicy) DefaultCPULimit() string      { return p.Defaults.CPULimit }
+func (p *EnvironmentPolicy) DefaultMemoryLimit() string   { return p.Defaults.MemoryLimit }
+func (p *EnvironmentPolicy) AllowHostNetwork() bool       { return p.Security.AllowHostNetwork }
+func (p *EnvironmentPolicy) AllowPrivileged() bool        { return p.Security.AllowPrivileged }
+func (p *EnvironmentPolicy) AllowHostPID() bool           { return p.Security.AllowHostPID }
+func (p *EnvironmentPolicy) AllowHostIPC() bool           { return p.Security.AllowHostIPC }
+func (p *EnvironmentPolicy) AllowHostPathVolumes() bool   { return p.Security.AllowHostPathVolumes }
+
+func (p *EnvironmentPolicy) AllowedCapabilities() []string {
+    if p.Capabilities == nil { return nil }
+    return p.Capabilities.Allowed
+}
+func (p *EnvironmentPolicy) ForbiddenCapabilities() []string {
+    if p.Capabilities == nil { return nil }
+    return p.Capabilities.Forbidden
+}
+func (p *EnvironmentPolicy) RequiredCapabilities() []string {
+    if p.Capabilities == nil { return nil }
+    return p.Capabilities.Required
+}
+```
+
+### How handler code changes
+
+The change is mechanical: the parameter type changes from `*api.EnvironmentPolicy` to
+`oam.Policy`, and field accesses become method calls:
+
+```go
+// Before (crane):
+func (c *WebserviceConfig) ApplyPolicy(p *api.EnvironmentPolicy) error {
+    if p == nil { return nil }
+    c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, p.Defaults.Replicas)
+    if err := policy.EnforceMaxReplicas(c.Replicas, p.Enforced.MaxReplicas); err != nil {
+        return err
+    }
+    if err := policy.EnforceAllowedRegistries(c.Image, p.Enforced.AllowedRegistries); err != nil {
+        return err
+    }
+    return nil
+}
+
+// After (launcher-migrated):
+func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
+    // nil check not needed — caller always passes at least NoopPolicy
+    c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, p.DefaultReplicas())
+    if err := policy.EnforceMaxReplicas(c.Replicas, p.MaxReplicas()); err != nil {
+        return err
+    }
+    if err := policy.EnforceAllowedRegistries(c.Image, p.AllowedRegistries()); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+No type assertions. No imports of crane's `api` package in handler code.
+
+### Interface growth
+
+If `EnvironmentPolicy` gains a new field (e.g. `MaxPodCount`), `Policy` must be explicitly
+extended with a new method, and `NoopPolicy` must implement it. This is an intentional
+gate — it ensures new policy fields are consciously exposed to the public interface.
+
+The `var _ oam.Policy = (*EnvironmentPolicy)(nil)` compile check in crane's file catches
+any omission immediately.
+
+### Summary
+
+- 19 methods (as defined above)
+- crane gains ~20 accessor methods on `EnvironmentPolicy` (pure boilerplate, no logic)
+- Handler code: method calls, no type assertions, no adapter imports
+- Compiler verifies the contract at crane build time
+- Interface must grow manually as `EnvironmentPolicy` grows
+
+---
+
+## Option C — Opaque Marker Interface
+
+### Interface definition
+
+`Policy` is a marker interface: it identifies an object as a policy but exposes no data.
+All data access happens through crane-controlled types or local sub-interfaces.
+
+```go
+// launcher/pkg/oam/policy.go
+
+// Policy marks an object as an OAM policy carrier.
+// It carries no data methods; handlers access policy data through type assertions
+// or sub-interfaces defined locally in their own package.
+type Policy interface {
+    // unexported marker — prevents accidental satisfaction outside this module
+    oamPolicy()
+}
+
+// Enforceable is implemented by component configs that accept policy enforcement.
+type Enforceable interface {
+    ApplyPolicy(policy Policy) error
+}
+```
+
+### NoopPolicy
+
+```go
+// NoopPolicy is used when no policy is configured.
+// It satisfies Policy; all type assertions against it return false,
+// so handlers that assert to access limits/defaults effectively skip enforcement.
+type NoopPolicy struct{}
+
+func (*NoopPolicy) oamPolicy() {} // satisfies Policy; no data methods
+```
+
+### How crane satisfies Policy
+
+crane wraps `*api.EnvironmentPolicy` in an adapter struct. The adapter satisfies
+`oam.Policy` and also exposes the data methods that crane's own handlers will assert to.
+
+```go
+// crane/internal/policy/oam_adapter.go (new file)
+package policy
+
+import (
+    "github.com/go-kure/launcher/pkg/oam"
+    "gitlab.com/autops/wharf/crane/pkg/api"
+)
+
+// OAMPolicyAdapter wraps *api.EnvironmentPolicy and satisfies oam.Policy.
+type OAMPolicyAdapter struct {
+    env *api.EnvironmentPolicy
+}
+
+// NewOAMPolicy returns an oam.Policy for the given environment policy.
+// Returns oam.NoopPolicy when env is nil.
+func NewOAMPolicy(env *api.EnvironmentPolicy) oam.Policy {
+    if env == nil {
+        return &oam.NoopPolicy{}
+    }
+    return &OAMPolicyAdapter{env: env}
+}
+
+func (a *OAMPolicyAdapter) oamPolicy() {} // satisfies oam.Policy
+
+// Data accessors — used by crane handlers that type-assert to this type or to sub-interfaces
+func (a *OAMPolicyAdapter) MaxReplicas() *int32          { return a.env.Enforced.MaxReplicas }
+func (a *OAMPolicyAdapter) MaxCPU() string               { return a.env.Enforced.MaxCPU }
+func (a *OAMPolicyAdapter) MaxMemory() string            { return a.env.Enforced.MaxMemory }
+func (a *OAMPolicyAdapter) MaxStorageSize() string       { return a.env.Enforced.MaxStorageSize }
+func (a *OAMPolicyAdapter) AllowedRegistries() []string  { return a.env.Enforced.AllowedRegistries }
+func (a *OAMPolicyAdapter) DefaultReplicas() *int32      { return a.env.Defaults.Replicas }
+// ... (same accessor set as Option B, but on the adapter, not on EnvironmentPolicy)
+```
+
+### How handler code changes — two sub-options
+
+crane's handlers receive `oam.Policy` and must extract data. There are two ways to do this:
+
+**Sub-option C1: Assert to the concrete adapter**
+
+```go
+// crane handler — asserts directly to crane's own adapter type
+func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
+    ep, ok := p.(*cranePolicy.OAMPolicyAdapter)
+    if !ok {
+        return nil // NoopPolicy or unknown policy type — skip enforcement
+    }
+    c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, ep.DefaultReplicas())
+    if err := policy.EnforceMaxReplicas(c.Replicas, ep.MaxReplicas()); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+Consequence: the handler file gains an import of crane's own `cranePolicy` package to
+name the adapter type. The handler is still tightly coupled to crane's concrete types —
+just through an extra indirection layer.
+
+**Sub-option C2: Assert to local sub-interfaces**
+
+Each handler defines a minimal sub-interface for the policy data it needs:
+
+```go
+// crane handler — asserts to a local sub-interface
+func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
+    type replicaLimiter interface {
+        MaxReplicas() *int32
+        DefaultReplicas() *int32
+    }
+    type registryLimiter interface {
+        AllowedRegistries() []string
+    }
+
+    if rl, ok := p.(replicaLimiter); ok {
+        c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, rl.DefaultReplicas())
+        if err := policy.EnforceMaxReplicas(c.Replicas, rl.MaxReplicas()); err != nil {
+            return err
+        }
+    }
+    if rl, ok := p.(registryLimiter); ok {
+        if err := policy.EnforceAllowedRegistries(c.Image, rl.AllowedRegistries()); err != nil {
+            return err
+        }
+    }
+    return nil
+}
+```
+
+No import of the adapter type. The handler works with any `oam.Policy` that happens to
+implement `replicaLimiter` — including future launcher-native policies.
+
+### NoopPolicy problem
+
+With Option C, `NoopPolicy` has no data methods. Both C1 and C2 return early (no
+enforcement, no defaults) when the policy is `NoopPolicy`:
+- C1: `p.(*OAMPolicyAdapter)` assertion fails → `return nil`
+- C2: `p.(replicaLimiter)` assertion fails → skip the block
+
+This means NoopPolicy silently disables all enforcement and default application. This is
+the intended behavior (no policy = no constraints), but it is implicit. Bugs where a nil
+policy slips through as `(*NoopPolicy)(nil)` (nil pointer wrapped in interface) would also
+silently skip all enforcement without error.
+
+To make this explicit, the transformer must always pass `&oam.NoopPolicy{}` (non-nil
+NoopPolicy) rather than a nil `oam.Policy` interface value, and handler code must not
+check `p == nil`.
+
+### Interface growth
+
+If `EnvironmentPolicy` adds a new field, the adapter grows a new accessor method. The
+`Policy` interface is never updated. Sub-option C2 handler files also grow a new line in
+their local sub-interface if they need the new data.
+
+There is no compile-time check that the adapter covers all data a handler might need —
+only runtime behavior verifies coverage.
+
+### Summary
+
+- 1 interface method (marker only)
+- crane gains one `OAMPolicyAdapter` struct with ~20 accessor methods
+- Handler code: type assertions (C1: to adapter type; C2: to local sub-interfaces)
+- No compiler verification — coverage gaps are silent
+- Policy interface never grows; adapters grow instead
+- A future launcher-native Policy (completely different semantics) can satisfy the marker without any constraint on its shape
+
+---
+
+## Summary Comparison
+
+| Aspect | Option B: Typed Accessors | Option C: Opaque Marker |
+|---|---|---|
+| Interface methods | ~19 | 1 (marker) |
+| Compiler verifies crane implements Policy | **Yes** — `var _ oam.Policy = ...` | No |
+| Type assertions in handler code | **None** | Required (C1 or C2) |
+| NoopPolicy works implicitly | **Yes** — zero returns permit everything | Silent skip (assertions fail) |
+| Boilerplate | ~20 methods on `EnvironmentPolicy` | Adapter struct + ~20 methods |
+| Handler imports | `oam` package only | `oam` + adapter type (C1) or just `oam` (C2) |
+| Interface grows with EnvironmentPolicy | **Yes** — explicit gate | No — adapter grows silently |
+| Future non-crane Policy implementations | Must implement all ~19 methods | Only satisfy the marker |
+| Coverage gap detection | **Compile time** | Runtime (silent) |
+
+### When Option C's flexibility matters
+
+Option C's main advantage — that future Policy implementations only need the marker, not
+19 methods — is relevant if launcher will define its own native Policy type (separate from
+crane's EnvironmentPolicy) that has fundamentally different enforcement semantics. If the
+only Policy implementation that will ever exist is crane's EnvironmentPolicy wrapped in an
+adapter, Option C adds indirection without benefit.

--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -1,6 +1,6 @@
 # Options: Policy Interface Design
 
-*Status: Decision required | Blocks: `design-policy-interface.md`, issue #38*
+*Status: **Decided — Option A** | Issue #38*
 
 This document fully designs both options for the `oam.Policy` interface.
 Read both options completely before deciding.

--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -1,9 +1,16 @@
-# Options: Policy Interface Design
+# Design: Policy Interface
 
-*Status: **Decided — Option A** | Issue #38*
+*Status: **Final — Option A selected** | Issue #38*
 
-This document fully designs both options for the `oam.Policy` interface.
-Read both options completely before deciding.
+| Version | Date | Summary |
+|---|---|---|
+| 1.1 | 2026-05-14 | Record decision (Option A); add framing section; rename options A/B; remove Option B |
+| 1.0 | 2026-04-19 | Initial draft — compared typed accessor (Option A) and opaque marker (Option B) |
+
+**Decision:** `oam.Policy` is a typed accessor interface with ~19 methods. Reason:
+compile-time verification, no type assertions in handler code, and explicit `NoopPolicy`
+behaviour (zero returns permit everything) are more important than the flexibility of a
+marker interface for future policy types.
 
 **Scope:** The `Policy` and `Enforceable` interface definitions in `pkg/oam`, how
 `*api.EnvironmentPolicy` in crane satisfies `Policy` after migration, and how handler
@@ -268,199 +275,16 @@ any omission immediately.
 
 ---
 
-## Option B — Opaque Marker Interface
+## Why Not an Opaque Marker Interface
 
-### Interface definition
+The rejected alternative defined `Policy` as a single marker method (`oamPolicy()`),
+with all data access via type assertions in handler code. It was rejected because:
 
-`Policy` is a marker interface: it identifies an object as a policy but exposes no data.
-All data access happens through crane-controlled types or local sub-interfaces.
+- Handler code requires type assertions (to the adapter type or to local sub-interfaces) — no compiler verification of coverage
+- `NoopPolicy` has no data methods; enforcement is silently skipped by failed assertions rather than by explicit zero-value returns — the "no policy = no constraints" behaviour is implicit, not self-documenting
+- A nil pointer wrapped in the interface (`(*NoopPolicy)(nil)`) silently skips all enforcement without error
+- The `Policy` interface never grows, so the adapter accumulates data silently as `EnvironmentPolicy` evolves — no compile-time gate
 
-```go
-// launcher/pkg/oam/policy.go
-
-// Policy marks an object as an OAM policy carrier.
-// It carries no data methods; handlers access policy data through type assertions
-// or sub-interfaces defined locally in their own package.
-type Policy interface {
-    // unexported marker — prevents accidental satisfaction outside this module
-    oamPolicy()
-}
-
-// Enforceable is implemented by component configs that accept policy enforcement.
-type Enforceable interface {
-    ApplyPolicy(policy Policy) error
-}
-```
-
-### NoopPolicy
-
-```go
-// NoopPolicy is used when no policy is configured.
-// It satisfies Policy; all type assertions against it return false,
-// so handlers that assert to access limits/defaults effectively skip enforcement.
-type NoopPolicy struct{}
-
-func (*NoopPolicy) oamPolicy() {} // satisfies Policy; no data methods
-```
-
-### How crane satisfies Policy
-
-crane wraps `*api.EnvironmentPolicy` in an adapter struct. The adapter satisfies
-`oam.Policy` and also exposes the data methods that crane's own handlers will assert to.
-
-```go
-// crane/internal/policy/oam_adapter.go (new file)
-package policy
-
-import (
-    "github.com/go-kure/launcher/pkg/oam"
-    "gitlab.com/autops/wharf/crane/pkg/api"
-)
-
-// OAMPolicyAdapter wraps *api.EnvironmentPolicy and satisfies oam.Policy.
-type OAMPolicyAdapter struct {
-    env *api.EnvironmentPolicy
-}
-
-// NewOAMPolicy returns an oam.Policy for the given environment policy.
-// Returns oam.NoopPolicy when env is nil.
-func NewOAMPolicy(env *api.EnvironmentPolicy) oam.Policy {
-    if env == nil {
-        return &oam.NoopPolicy{}
-    }
-    return &OAMPolicyAdapter{env: env}
-}
-
-func (a *OAMPolicyAdapter) oamPolicy() {} // satisfies oam.Policy
-
-// Data accessors — used by crane handlers that type-assert to this type or to sub-interfaces
-func (a *OAMPolicyAdapter) MaxReplicas() *int32          { return a.env.Enforced.MaxReplicas }
-func (a *OAMPolicyAdapter) MaxCPU() string               { return a.env.Enforced.MaxCPU }
-func (a *OAMPolicyAdapter) MaxMemory() string            { return a.env.Enforced.MaxMemory }
-func (a *OAMPolicyAdapter) MaxStorageSize() string       { return a.env.Enforced.MaxStorageSize }
-func (a *OAMPolicyAdapter) AllowedRegistries() []string  { return a.env.Enforced.AllowedRegistries }
-func (a *OAMPolicyAdapter) DefaultReplicas() *int32      { return a.env.Defaults.Replicas }
-// ... (same accessor set as Option A, but on the adapter, not on EnvironmentPolicy)
-```
-
-### How handler code changes — two sub-options
-
-crane's handlers receive `oam.Policy` and must extract data. There are two ways to do this:
-
-**Sub-option B1: Assert to the concrete adapter**
-
-```go
-// crane handler — asserts directly to crane's own adapter type
-func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
-    ep, ok := p.(*cranePolicy.OAMPolicyAdapter)
-    if !ok {
-        return nil // NoopPolicy or unknown policy type — skip enforcement
-    }
-    c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, ep.DefaultReplicas())
-    if err := policy.EnforceMaxReplicas(c.Replicas, ep.MaxReplicas()); err != nil {
-        return err
-    }
-    return nil
-}
-```
-
-Consequence: the handler file gains an import of crane's own `cranePolicy` package to
-name the adapter type. The handler is still tightly coupled to crane's concrete types —
-just through an extra indirection layer.
-
-**Sub-option B2: Assert to local sub-interfaces**
-
-Each handler defines a minimal sub-interface for the policy data it needs:
-
-```go
-// crane handler — asserts to a local sub-interface
-func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
-    type replicaLimiter interface {
-        MaxReplicas() *int32
-        DefaultReplicas() *int32
-    }
-    type registryLimiter interface {
-        AllowedRegistries() []string
-    }
-
-    if rl, ok := p.(replicaLimiter); ok {
-        c.Replicas = policy.ApplyDefaultReplicas(c.Replicas, c.explicitReplicas, rl.DefaultReplicas())
-        if err := policy.EnforceMaxReplicas(c.Replicas, rl.MaxReplicas()); err != nil {
-            return err
-        }
-    }
-    if rl, ok := p.(registryLimiter); ok {
-        if err := policy.EnforceAllowedRegistries(c.Image, rl.AllowedRegistries()); err != nil {
-            return err
-        }
-    }
-    return nil
-}
-```
-
-No import of the adapter type. The handler works with any `oam.Policy` that happens to
-implement `replicaLimiter` — including future launcher-native policies.
-
-### NoopPolicy problem
-
-With Option B, `NoopPolicy` has no data methods. Both B1 and B2 return early (no
-enforcement, no defaults) when the policy is `NoopPolicy`:
-- B1: `p.(*OAMPolicyAdapter)` assertion fails → `return nil`
-- B2: `p.(replicaLimiter)` assertion fails → skip the block
-
-This means NoopPolicy silently disables all enforcement and default application. This is
-the intended behavior (no policy = no constraints), but it is implicit. Bugs where a nil
-policy slips through as `(*NoopPolicy)(nil)` (nil pointer wrapped in interface) would also
-silently skip all enforcement without error.
-
-To make this explicit, the transformer must always pass `&oam.NoopPolicy{}` (non-nil
-NoopPolicy) rather than a nil `oam.Policy` interface value, and handler code must not
-check `p == nil`.
-
-### Interface growth
-
-If `EnvironmentPolicy` adds a new field, the adapter grows a new accessor method. The
-`Policy` interface is never updated. Sub-option B2 handler files also grow a new line in
-their local sub-interface if they need the new data.
-
-There is no compile-time check that the adapter covers all data a handler might need —
-only runtime behavior verifies coverage.
-
-### Summary
-
-- 1 interface method (marker only)
-- crane gains one `OAMPolicyAdapter` struct with ~20 accessor methods
-- Handler code: type assertions (B1: to adapter type; B2: to local sub-interfaces)
-- No compiler verification — coverage gaps are silent
-- Policy interface never grows; adapters grow instead
-- A future launcher-native Policy (completely different semantics) can satisfy the marker without any constraint on its shape
-
----
-
-## Summary Comparison
-
-| Aspect | Option A: Typed Accessors | Option B: Opaque Marker |
-|---|---|---|
-| Interface methods | ~19 | 1 (marker) |
-| Compiler verifies crane implements Policy | **Yes** — `var _ oam.Policy = ...` | No |
-| Type assertions in handler code | **None** | Required (B1 or B2) |
-| NoopPolicy works implicitly | **Yes** — zero returns permit everything | Silent skip (assertions fail) |
-| Boilerplate | ~20 methods on `EnvironmentPolicy` | Adapter struct + ~20 methods |
-| Handler imports | `oam` package only | `oam` + adapter type (B1) or just `oam` (B2) |
-| Interface grows with EnvironmentPolicy | **Yes** — explicit gate | No — adapter grows silently |
-| Future non-crane Policy implementations | Must implement all ~19 methods | Only satisfy the marker |
-| Coverage gap detection | **Compile time** | Runtime (silent) |
-
-### When Option B's flexibility matters
-
-Option B's main advantage — that future Policy implementations only need the marker, not
-19 methods — is relevant if launcher will define its own native Policy type (separate from
-crane's EnvironmentPolicy) that has fundamentally different enforcement semantics. Because
-policy is launcher-native from day one (see Framing above), a future launcher policy type
-is a realistic scenario. However, if that future type has the same enforcement surface as
-crane's `EnvironmentPolicy` (replicas, memory, allowed registries, security flags), it
-would implement the same 19 methods anyway.
-
-Option A's explicit interface growth (every new policy field requires a new interface
-method) is an intentional gate, not a burden — it ensures new policy data is consciously
-exposed to the public API surface rather than silently accumulating in an adapter.
+The explicit interface growth of the typed accessor approach (every new policy field
+requires a new method and a `NoopPolicy` stub) is an intentional gate, not a burden —
+it ensures new policy data is consciously exposed to the public API surface.

--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -12,6 +12,45 @@ or the pipeline execution loop.
 
 ---
 
+## Framing
+
+### Policy vs ClusterProfile
+
+These are separate concerns with different owners:
+
+- **ClusterProfile** — describes how the platform implements each trait (which ingress
+  controller, which certificate issuer). Written once per cluster by a platform operator.
+  Covered in `design-cluster-profile.md`.
+- **Policy** — describes enforcement constraints and defaults applied to application
+  components (max replicas, allowed registries, memory limits). Written per environment by
+  a platform or security operator. Covered here.
+
+The two inputs are orthogonal. A cluster profile says "ingress means Gateway API here";
+a policy says "no component may request more than 2 replicas in staging". ClusterProfile
+values flow into trait rendering; Policy values flow into component configuration
+enforcement.
+
+### Policy is launcher-native from day one
+
+`kurel build` will accept a `--policy` flag pointing to a policy document. This means the
+`oam.Policy` interface is a first-class launcher abstraction from Phase 1, not solely a
+crane compatibility seam.
+
+When no policy is supplied, launcher passes `NoopPolicy` — a concrete type that satisfies
+`oam.Policy` and permits everything (all limits absent, all defaults absent, all security
+flags false). Handlers always receive a non-nil `Policy` value; nil checks in handler code
+are not needed or intended.
+
+### crane compatibility
+
+crane's `*api.EnvironmentPolicy` is the existing concrete policy type. After migration,
+crane wires it into launcher by satisfying the `oam.Policy` interface. The question is how.
+
+The interface must be rich enough to serve both crane's `EnvironmentPolicy` and future
+launcher-native policy document types that may have different enforcement semantics.
+
+---
+
 ## Background
 
 ### Current state in crane
@@ -58,7 +97,7 @@ the migration (Phase 4 in the roadmap). The question is what shape the interface
 
 ---
 
-## Option B — Typed Accessor Interface
+## Option A — Typed Accessor Interface
 
 ### Interface definition
 
@@ -229,7 +268,7 @@ any omission immediately.
 
 ---
 
-## Option C — Opaque Marker Interface
+## Option B — Opaque Marker Interface
 
 ### Interface definition
 
@@ -301,14 +340,14 @@ func (a *OAMPolicyAdapter) MaxMemory() string            { return a.env.Enforced
 func (a *OAMPolicyAdapter) MaxStorageSize() string       { return a.env.Enforced.MaxStorageSize }
 func (a *OAMPolicyAdapter) AllowedRegistries() []string  { return a.env.Enforced.AllowedRegistries }
 func (a *OAMPolicyAdapter) DefaultReplicas() *int32      { return a.env.Defaults.Replicas }
-// ... (same accessor set as Option B, but on the adapter, not on EnvironmentPolicy)
+// ... (same accessor set as Option A, but on the adapter, not on EnvironmentPolicy)
 ```
 
 ### How handler code changes — two sub-options
 
 crane's handlers receive `oam.Policy` and must extract data. There are two ways to do this:
 
-**Sub-option C1: Assert to the concrete adapter**
+**Sub-option B1: Assert to the concrete adapter**
 
 ```go
 // crane handler — asserts directly to crane's own adapter type
@@ -329,7 +368,7 @@ Consequence: the handler file gains an import of crane's own `cranePolicy` packa
 name the adapter type. The handler is still tightly coupled to crane's concrete types —
 just through an extra indirection layer.
 
-**Sub-option C2: Assert to local sub-interfaces**
+**Sub-option B2: Assert to local sub-interfaces**
 
 Each handler defines a minimal sub-interface for the policy data it needs:
 
@@ -364,10 +403,10 @@ implement `replicaLimiter` — including future launcher-native policies.
 
 ### NoopPolicy problem
 
-With Option C, `NoopPolicy` has no data methods. Both C1 and C2 return early (no
+With Option B, `NoopPolicy` has no data methods. Both B1 and B2 return early (no
 enforcement, no defaults) when the policy is `NoopPolicy`:
-- C1: `p.(*OAMPolicyAdapter)` assertion fails → `return nil`
-- C2: `p.(replicaLimiter)` assertion fails → skip the block
+- B1: `p.(*OAMPolicyAdapter)` assertion fails → `return nil`
+- B2: `p.(replicaLimiter)` assertion fails → skip the block
 
 This means NoopPolicy silently disables all enforcement and default application. This is
 the intended behavior (no policy = no constraints), but it is implicit. Bugs where a nil
@@ -381,7 +420,7 @@ check `p == nil`.
 ### Interface growth
 
 If `EnvironmentPolicy` adds a new field, the adapter grows a new accessor method. The
-`Policy` interface is never updated. Sub-option C2 handler files also grow a new line in
+`Policy` interface is never updated. Sub-option B2 handler files also grow a new line in
 their local sub-interface if they need the new data.
 
 There is no compile-time check that the adapter covers all data a handler might need —
@@ -391,7 +430,7 @@ only runtime behavior verifies coverage.
 
 - 1 interface method (marker only)
 - crane gains one `OAMPolicyAdapter` struct with ~20 accessor methods
-- Handler code: type assertions (C1: to adapter type; C2: to local sub-interfaces)
+- Handler code: type assertions (B1: to adapter type; B2: to local sub-interfaces)
 - No compiler verification — coverage gaps are silent
 - Policy interface never grows; adapters grow instead
 - A future launcher-native Policy (completely different semantics) can satisfy the marker without any constraint on its shape
@@ -400,22 +439,28 @@ only runtime behavior verifies coverage.
 
 ## Summary Comparison
 
-| Aspect | Option B: Typed Accessors | Option C: Opaque Marker |
+| Aspect | Option A: Typed Accessors | Option B: Opaque Marker |
 |---|---|---|
 | Interface methods | ~19 | 1 (marker) |
 | Compiler verifies crane implements Policy | **Yes** — `var _ oam.Policy = ...` | No |
-| Type assertions in handler code | **None** | Required (C1 or C2) |
+| Type assertions in handler code | **None** | Required (B1 or B2) |
 | NoopPolicy works implicitly | **Yes** — zero returns permit everything | Silent skip (assertions fail) |
 | Boilerplate | ~20 methods on `EnvironmentPolicy` | Adapter struct + ~20 methods |
-| Handler imports | `oam` package only | `oam` + adapter type (C1) or just `oam` (C2) |
+| Handler imports | `oam` package only | `oam` + adapter type (B1) or just `oam` (B2) |
 | Interface grows with EnvironmentPolicy | **Yes** — explicit gate | No — adapter grows silently |
 | Future non-crane Policy implementations | Must implement all ~19 methods | Only satisfy the marker |
 | Coverage gap detection | **Compile time** | Runtime (silent) |
 
-### When Option C's flexibility matters
+### When Option B's flexibility matters
 
-Option C's main advantage — that future Policy implementations only need the marker, not
+Option B's main advantage — that future Policy implementations only need the marker, not
 19 methods — is relevant if launcher will define its own native Policy type (separate from
-crane's EnvironmentPolicy) that has fundamentally different enforcement semantics. If the
-only Policy implementation that will ever exist is crane's EnvironmentPolicy wrapped in an
-adapter, Option C adds indirection without benefit.
+crane's EnvironmentPolicy) that has fundamentally different enforcement semantics. Because
+policy is launcher-native from day one (see Framing above), a future launcher policy type
+is a realistic scenario. However, if that future type has the same enforcement surface as
+crane's `EnvironmentPolicy` (replicas, memory, allowed registries, security flags), it
+would implement the same 19 methods anyway.
+
+Option A's explicit interface growth (every new policy field requires a new interface
+method) is an intentional gate, not a burden — it ensures new policy data is consciously
+exposed to the public API surface rather than silently accumulating in an adapter.

--- a/examples/01-webservice-minimal.yaml
+++ b/examples/01-webservice-minimal.yaml
@@ -1,0 +1,19 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: myregistry/my-app:v1.2.3
+      port: 8080
+      replicas: 1
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "500m"
+          memory: "256Mi"

--- a/examples/02-webservice-with-expose.yaml
+++ b/examples/02-webservice-with-expose.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: myregistry/my-app:v1.2.3
+      port: 8080
+      replicas: 2
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: my-app.example.com
+          paths:
+          - path: /
+            port: 8080

--- a/examples/03-webservice-with-tls.yaml
+++ b/examples/03-webservice-with-tls.yaml
@@ -1,0 +1,29 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: myregistry/my-app:v1.2.3
+      port: 8080
+      replicas: 2
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: my-app.example.com
+          paths:
+          - path: /
+            port: 8080
+        tls:
+        - secretName: my-app-tls
+          hosts:
+          - my-app.example.com
+    - type: certificate
+      properties:
+        secretName: my-app-tls
+        dnsNames:
+        - my-app.example.com

--- a/examples/04-webservice-full.yaml
+++ b/examples/04-webservice-full.yaml
@@ -1,0 +1,51 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: myregistry/my-app:v1.2.3
+      port: 8080
+      replicas: 3
+      env:
+      - name: LOG_LEVEL
+        value: info
+      - name: DB_HOST
+        value: postgres.svc.cluster.local
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "256Mi"
+        limits:
+          cpu: "1000m"
+          memory: "512Mi"
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: my-app.example.com
+          paths:
+          - path: /
+            port: 8080
+        tls:
+        - secretName: my-app-tls
+          hosts:
+          - my-app.example.com
+    - type: certificate
+      properties:
+        secretName: my-app-tls
+        dnsNames:
+        - my-app.example.com
+    - type: external-secret
+      properties:
+        secretName: my-app-db-credentials
+        remoteRef:
+          key: prod/my-app/db
+    - type: scaler
+      properties:
+        minReplicas: 2
+        maxReplicas: 10
+        cpuUtilization: 70

--- a/examples/05-worker-minimal.yaml
+++ b/examples/05-worker-minimal.yaml
@@ -1,0 +1,15 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-worker
+spec:
+  components:
+  - name: worker
+    type: worker
+    properties:
+      image: myregistry/my-worker:v1.2.3
+      replicas: 1
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"

--- a/examples/06-worker-with-traits.yaml
+++ b/examples/06-worker-with-traits.yaml
@@ -1,0 +1,27 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-worker
+spec:
+  components:
+  - name: worker
+    type: worker
+    properties:
+      image: myregistry/my-worker:v1.2.3
+      replicas: 2
+      env:
+      - name: QUEUE_URL
+        value: amqp://rabbitmq.svc.cluster.local
+    traits:
+    - type: external-secret
+      properties:
+        secretName: my-worker-credentials
+        remoteRef:
+          key: prod/my-worker/credentials
+    - type: configmap
+      properties:
+        name: my-worker-config
+        data:
+          BATCH_SIZE: "50"
+          TIMEOUT_SECONDS: "30"
+        mountPath: /etc/worker

--- a/examples/07-cronjob-minimal.yaml
+++ b/examples/07-cronjob-minimal.yaml
@@ -1,0 +1,11 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-cronjob
+spec:
+  components:
+  - name: cleanup
+    type: cronjob
+    properties:
+      image: myregistry/my-cronjob:v1.2.3
+      schedule: "0 2 * * *"

--- a/examples/08-cronjob-full.yaml
+++ b/examples/08-cronjob-full.yaml
@@ -1,0 +1,30 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-cronjob
+spec:
+  components:
+  - name: cleanup
+    type: cronjob
+    properties:
+      image: myregistry/my-cronjob:v1.2.3
+      schedule: "0 2 * * *"
+      concurrencyPolicy: Forbid
+      successfulJobsHistoryLimit: 3
+      failedJobsHistoryLimit: 1
+      env:
+      - name: LOG_LEVEL
+        value: info
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+        limits:
+          cpu: "500m"
+          memory: "128Mi"
+    traits:
+    - type: external-secret
+      properties:
+        secretName: my-cronjob-credentials
+        remoteRef:
+          key: prod/my-cronjob/credentials

--- a/examples/09-postgresql-minimal.yaml
+++ b/examples/09-postgresql-minimal.yaml
@@ -1,0 +1,12 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-database
+spec:
+  components:
+  - name: db
+    type: postgresql
+    properties:
+      instances: 1
+      storage:
+        size: "10Gi"

--- a/examples/10-postgresql-ha.yaml
+++ b/examples/10-postgresql-ha.yaml
@@ -1,0 +1,24 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-database
+spec:
+  components:
+  - name: db
+    type: postgresql
+    properties:
+      instances: 3
+      storage:
+        size: "50Gi"
+        storageClass: fast-ssd
+      postgresql:
+        parameters:
+          max_connections: "200"
+          shared_buffers: "256MB"
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "512Mi"
+        limits:
+          cpu: "2000m"
+          memory: "2Gi"

--- a/examples/11-helmrelease.yaml
+++ b/examples/11-helmrelease.yaml
@@ -1,0 +1,22 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-third-party
+spec:
+  components:
+  - name: redis
+    type: helmrelease
+    properties:
+      chart:
+        name: redis
+        repository: https://charts.bitnami.com/bitnami
+        version: "18.6.1"
+      values:
+        auth:
+          enabled: false
+        master:
+          persistence:
+            enabled: true
+            size: "8Gi"
+        replica:
+          replicaCount: 1

--- a/examples/12-daemonset.yaml
+++ b/examples/12-daemonset.yaml
@@ -1,0 +1,25 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: node-agent
+spec:
+  components:
+  - name: agent
+    type: daemonset
+    properties:
+      image: myregistry/node-agent:v1.0.0
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+        limits:
+          cpu: "200m"
+          memory: "128Mi"
+      volumes:
+      - name: host-proc
+        hostPath:
+          path: /proc
+      volumeMounts:
+      - name: host-proc
+        mountPath: /host/proc
+        readOnly: true

--- a/examples/13-statefulset.yaml
+++ b/examples/13-statefulset.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-stateful-app
+spec:
+  components:
+  - name: app
+    type: statefulset
+    properties:
+      image: myregistry/my-stateful-app:v1.0.0
+      replicas: 3
+      port: 8080
+      storage:
+        size: "20Gi"
+        storageClass: standard
+        mountPath: /data
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "256Mi"

--- a/examples/14-full-stack.yaml
+++ b/examples/14-full-stack.yaml
@@ -1,0 +1,159 @@
+# Full-stack example — exercises every Phase 1 component type and every Phase 1 trait type.
+# Use with cluster-profiles/gateway-certmanager-aws.yaml to exercise scoped capabilities.
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: full-stack
+spec:
+  components:
+
+  # --- webservice: expose (public) + certificate + scaler + external-secret + configmap ---
+  - name: web
+    type: webservice
+    properties:
+      image: myregistry/web:v1.0.0
+      port: 8080
+      replicas: 3
+      env:
+      - name: LOG_LEVEL
+        value: info
+      resources:
+        requests:
+          cpu: "200m"
+          memory: "256Mi"
+        limits:
+          cpu: "1"
+          memory: "512Mi"
+    traits:
+    - type: expose
+      properties:
+        rules:
+        - host: app.example.com
+          paths:
+          - path: /
+            port: 8080
+        tls:
+        - secretName: web-tls
+          hosts:
+          - app.example.com
+    - type: certificate
+      properties:
+        secretName: web-tls
+        dnsNames:
+        - app.example.com
+    - type: external-secret
+      properties:
+        secretName: web-app-secrets
+        remoteRef:
+          key: prod/web/secrets
+    - type: configmap
+      properties:
+        name: web-config
+        data:
+          FEATURE_FLAGS: "new-ui=true"
+        mountPath: /etc/config
+    - type: scaler
+      properties:
+        minReplicas: 2
+        maxReplicas: 10
+        cpuUtilization: 70
+
+  # --- webservice: expose (internal, scoped) ---
+  - name: api
+    type: webservice
+    properties:
+      image: myregistry/api:v1.0.0
+      port: 9090
+      replicas: 2
+    traits:
+    - type: expose
+      properties:
+        scope: internal
+        rules:
+        - host: api.internal.example.com
+          paths:
+          - path: /
+            port: 9090
+
+  # --- worker: external-secret + configmap ---
+  - name: worker
+    type: worker
+    properties:
+      image: myregistry/worker:v1.0.0
+      replicas: 2
+      env:
+      - name: QUEUE_URL
+        value: amqp://rabbitmq.svc.cluster.local
+    traits:
+    - type: external-secret
+      properties:
+        secretName: worker-credentials
+        remoteRef:
+          key: prod/worker/credentials
+    - type: configmap
+      properties:
+        name: worker-config
+        data:
+          BATCH_SIZE: "50"
+        mountPath: /etc/worker
+
+  # --- cronjob ---
+  - name: cleanup
+    type: cronjob
+    properties:
+      image: myregistry/cleanup:v1.0.0
+      schedule: "0 3 * * *"
+      concurrencyPolicy: Forbid
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "64Mi"
+
+  # --- postgresql ---
+  - name: db
+    type: postgresql
+    properties:
+      instances: 3
+      storage:
+        size: "50Gi"
+        storageClass: fast-ssd
+      resources:
+        requests:
+          cpu: "500m"
+          memory: "1Gi"
+
+  # --- helmrelease ---
+  - name: redis
+    type: helmrelease
+    properties:
+      chart:
+        name: redis
+        repository: https://charts.bitnami.com/bitnami
+        version: "18.6.1"
+      values:
+        auth:
+          enabled: false
+        master:
+          persistence:
+            size: "8Gi"
+
+  # --- daemonset ---
+  - name: log-collector
+    type: daemonset
+    properties:
+      image: myregistry/log-collector:v1.0.0
+      resources:
+        requests:
+          cpu: "50m"
+          memory: "64Mi"
+
+  # --- statefulset ---
+  - name: session-store
+    type: statefulset
+    properties:
+      image: myregistry/session-store:v1.0.0
+      replicas: 3
+      port: 6379
+      storage:
+        size: "10Gi"
+        mountPath: /data

--- a/examples/14-full-stack.yaml
+++ b/examples/14-full-stack.yaml
@@ -1,4 +1,7 @@
 # Full-stack example — exercises every Phase 1 component type and every Phase 1 trait type.
+# Component types: webservice, worker, cronjob, postgresql, helmrelease, daemonset, statefulset
+# Trait types: expose (public + scoped internal), ingress, httproute, certificate,
+#              external-secret, configmap, scaler
 # Use with cluster-profiles/gateway-certmanager-aws.yaml to exercise scoped capabilities.
 apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
@@ -157,3 +160,41 @@ spec:
       storage:
         size: "10Gi"
         mountPath: /data
+
+  # --- webservice: ingress (direct — no capability dispatch) ---
+  - name: admin
+    type: webservice
+    properties:
+      image: myregistry/admin:v1.0.0
+      port: 8080
+      replicas: 1
+    traits:
+    - type: ingress
+      properties:
+        ingressClassName: nginx
+        rules:
+        - host: admin.example.com
+          paths:
+          - path: /
+            port: 8080
+
+  # --- webservice: httproute (direct — no capability dispatch) ---
+  - name: metrics
+    type: webservice
+    properties:
+      image: myregistry/metrics:v1.0.0
+      port: 9090
+      replicas: 1
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+        - name: prod-gateway
+          namespace: gateway-system
+        rules:
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /metrics
+          backendRefs:
+          - port: 9090

--- a/examples/cluster-profiles/gateway-certmanager-aws.yaml
+++ b/examples/cluster-profiles/gateway-certmanager-aws.yaml
@@ -17,7 +17,7 @@ spec:
     certificate:
       rendering:
         issuerRef:
-          name: letsencrypt-prod
+          name: internal-ca
           kind: ClusterIssuer
     external-secret:
       rendering:

--- a/examples/cluster-profiles/gateway-certmanager-aws.yaml
+++ b/examples/cluster-profiles/gateway-certmanager-aws.yaml
@@ -1,0 +1,27 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: prod-gateway
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: gateway
+        gatewayName: prod-gateway
+        gatewayNamespace: gateway-system
+    expose.internal:
+      rendering:
+        controllerType: gateway
+        gatewayName: internal-gateway
+        gatewayNamespace: gateway-system
+    certificate:
+      rendering:
+        issuerRef:
+          name: letsencrypt-prod
+          kind: ClusterIssuer
+    external-secret:
+      rendering:
+        secretStoreRef:
+          name: aws-secretsmanager
+          kind: ClusterSecretStore
+        refreshInterval: "1h"

--- a/examples/cluster-profiles/minimal.yaml
+++ b/examples/cluster-profiles/minimal.yaml
@@ -1,0 +1,10 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: staging-minimal
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: traefik

--- a/examples/cluster-profiles/nginx-certmanager-vault.yaml
+++ b/examples/cluster-profiles/nginx-certmanager-vault.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: prod-nginx
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+    certificate:
+      rendering:
+        issuerRef:
+          name: letsencrypt-prod
+          kind: ClusterIssuer
+    external-secret:
+      rendering:
+        secretStoreRef:
+          name: vault-backend
+          kind: ClusterSecretStore


### PR DESCRIPTION
## Summary

Phase 0 design documents for the OAM runtime project. All three design issues are resolved in this PR.

**Closes #36, #37, #38.**

---

### Documents

- **`docs/oam/design-gvk.md`** — API group and document ownership: all launcher-native docs use `launcher.gokure.dev/v1alpha1`. Rationale for not using `core.oam.dev/v1beta1` or `wharf.zone`. Parser strictness rule (unknown fields rejected).

- **`docs/oam/design-cluster-profile.md`** — Complete design for `cluster.yaml` (issue #37): ClusterProfile schema, capability key resolution (`<type>.<scope>` → `<type>` fallback), merge semantics, `CapabilityAware` handler contract, example profiles, crane migration guide.

- **`docs/oam/options-param-syntax.md`** — Parameter syntax design (issue #36): **decided Option A** — `${var}` placeholders in `app.yaml` with typed schema in `kurel.yaml`. Rejected alternative summarised under "Why Not".

- **`docs/oam/options-policy-interface.md`** — Policy interface design (issue #38): **decided Option A** — typed accessor interface (~19 methods), compiler-verified, no type assertions in handlers. Rejected alternative summarised under "Why Not".

- **`docs/oam/options-package-composition.md`** — Package composition: **deferred to Phase 2 (issue #39)**. No optional sections in Phase 1. Background and open questions captured for #39.

- **`docs/oam/design-kurel-package.md`** — Kurel package spec (issue #36): package layout, `kurel.yaml` schema, supported component and trait types, two-parameter-set model, complete §6 Parameter Syntax (Option A).

- **`examples/`** — 14 Application examples + 3 ClusterProfile examples covering all Phase 1 component and trait types. `14-full-stack.yaml` exercises every component and trait type in a single Application.

---

### Decisions

| Concern | Decision |
|---|---|
| API group | `launcher.gokure.dev/v1alpha1` for all native docs |
| Parser strictness | Strict — unknown fields are a build error |
| ClusterProfile | `rendering` values only; no `parameters` field |
| Parameter syntax | Option A — `${var}` placeholders + typed schema in `kurel.yaml` |
| Policy interface | Option A — typed accessor interface (~19 methods) |
| Package composition | Deferred to Phase 2 (issue #39) |

**Decision rule:** launcher is a semantically richer Helm alternative — explicit package API contract and compiler-verified correctness take precedence over YAML validity at rest.

Closes #36.
Closes #37.
Closes #38.