### PR TITLE
feat: pkg/errors and pkg/oam — types, parser, validator

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,91 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ValidationError is returned when a semantic constraint is violated.
+// For enum-type errors (unknown type values), Value and ValidValues are populated.
+// For custom-message errors (missing fields, invalid format), Message is populated.
+type ValidationError struct {
+	Field       string   // the field that failed
+	Component   string   // application name or context (e.g. "application")
+	Value       string   // the rejected value (enum errors)
+	ValidValues []string // valid options (enum errors)
+	Message     string   // custom message (non-enum errors)
+}
+
+func (e *ValidationError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	if len(e.ValidValues) > 0 {
+		return fmt.Sprintf("invalid value %q for %q in %q; must be one of: %s",
+			e.Value, e.Field, e.Component, strings.Join(e.ValidValues, ", "))
+	}
+	return fmt.Sprintf("invalid value %q for %q in %q", e.Value, e.Field, e.Component)
+}
+
+// NewValidationError creates a structured enum-type ValidationError.
+// Use this when a field value is not in the set of known valid values.
+func NewValidationError(field, value, component string, validValues []string) *ValidationError {
+	return &ValidationError{
+		Field:       field,
+		Value:       value,
+		Component:   component,
+		ValidValues: validValues,
+	}
+}
+
+// ParseError is returned when a document fails YAML parsing.
+type ParseError struct {
+	Kind    string
+	File    string
+	Line    int
+	Column  int
+	Wrapped error
+}
+
+func (e *ParseError) Error() string {
+	if e.Line > 0 {
+		return fmt.Sprintf("parse error in %s at line %d: %v", e.Kind, e.Line, e.Wrapped)
+	}
+	return fmt.Sprintf("parse error in %s: %v", e.Kind, e.Wrapped)
+}
+
+func (e *ParseError) Unwrap() error { return e.Wrapped }
+
+// NewParseError creates a ParseError for the given document kind.
+func NewParseError(kind, file string, line, col int, cause error) *ParseError {
+	return &ParseError{Kind: kind, File: file, Line: line, Column: col, Wrapped: cause}
+}
+
+// New returns a new error with the given message.
+func New(msg string) error { return errors.New(msg) }
+
+// Errorf returns a new formatted error.
+func Errorf(format string, args ...any) error { return fmt.Errorf(format, args...) }
+
+// Wrap wraps err with a context message. Returns nil if err is nil.
+func Wrap(err error, msg string) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", msg, err)
+}
+
+// Wrapf wraps err with a formatted context message. Returns nil if err is nil.
+func Wrapf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s: %w", fmt.Sprintf(format, args...), err)
+}
+
+// Is reports whether any error in err's tree matches target.
+func Is(err, target error) bool { return errors.Is(err, target) }
+
+// As finds the first error in err's tree that matches target and sets target to that value.
+func As(err error, target any) bool { return errors.As(err, target) }

--- a/pkg/oam/doc.go
+++ b/pkg/oam/doc.go
@@ -1,0 +1,3 @@
+// Package oam provides the OAM data model, YAML parser, and semantic
+// validator for launcher Application documents (apiVersion: launcher.gokure.dev/v1alpha1).
+package oam

--- a/pkg/oam/parser.go
+++ b/pkg/oam/parser.go
@@ -8,8 +8,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/go-kure/launcher/pkg/errors"
 	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
 )
 
 // Parse parses an Application YAML document in strict mode.

--- a/pkg/oam/parser.go
+++ b/pkg/oam/parser.go
@@ -1,0 +1,99 @@
+package oam
+
+import (
+	"bytes"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"gopkg.in/yaml.v3"
+)
+
+// Parse parses an Application YAML document in strict mode.
+// Unknown fields are rejected; the document is semantically validated before returning.
+func Parse(data []byte) (*Application, error) {
+	var app Application
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&app); err != nil {
+		return nil, yamlParseError(err)
+	}
+
+	if err := validate(&app); err != nil {
+		return nil, err
+	}
+
+	return &app, nil
+}
+
+// ParseMulti parses a multi-document YAML stream. Each document is validated
+// independently. Returns an error if no documents are found or any document fails.
+func ParseMulti(data []byte) ([]*Application, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var apps []*Application
+	for {
+		var app Application
+		if err := dec.Decode(&app); err != nil {
+			if stderrors.Is(err, io.EOF) {
+				break
+			}
+			return nil, yamlParseError(err)
+		}
+		if err := validate(&app); err != nil {
+			return nil, err
+		}
+		apps = append(apps, &app)
+	}
+
+	if len(apps) == 0 {
+		return nil, errors.NewParseError("Application", "", 0, 0,
+			fmt.Errorf("no documents found"))
+	}
+	return apps, nil
+}
+
+// MustParse parses an Application YAML document and panics on error.
+// Use only in tests or initialization code where errors are truly unexpected.
+func MustParse(data []byte) *Application {
+	app, err := Parse(data)
+	if err != nil {
+		panic(err)
+	}
+	return app
+}
+
+// yamlParseError converts a yaml decode error into a ParseError,
+// extracting line information from yaml.TypeError when available.
+func yamlParseError(err error) *errors.ParseError {
+	var typeErr *yaml.TypeError
+	if stderrors.As(err, &typeErr) && len(typeErr.Errors) > 0 {
+		line := extractYAMLLine(typeErr.Errors[0])
+		return errors.NewParseError("Application", "", line, 0, err)
+	}
+	return errors.NewParseError("Application", "", 0, 0, err)
+}
+
+// extractYAMLLine parses the line number from a yaml.TypeError error string.
+// yaml.TypeError strings have the form "line N: <message>".
+func extractYAMLLine(s string) int {
+	rest, ok := strings.CutPrefix(s, "line ")
+	if !ok {
+		return 0
+	}
+	numStr, _, ok := strings.Cut(rest, ":")
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(numStr))
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/pkg/oam/parser_test.go
+++ b/pkg/oam/parser_test.go
@@ -1,0 +1,796 @@
+package oam
+
+import (
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+func TestParse_ValidApplication(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if app.APIVersion != "launcher.gokure.dev/v1alpha1" {
+		t.Errorf("apiVersion = %q, want %q", app.APIVersion, "launcher.gokure.dev/v1alpha1")
+	}
+	if app.Kind != "Application" {
+		t.Errorf("kind = %q, want %q", app.Kind, "Application")
+	}
+	if app.Metadata.Name != "hello" {
+		t.Errorf("metadata.name = %q, want %q", app.Metadata.Name, "hello")
+	}
+	if len(app.Spec.Components) != 1 {
+		t.Fatalf("len(components) = %d, want 1", len(app.Spec.Components))
+	}
+	if app.Spec.Components[0].Name != "web" {
+		t.Errorf("component.name = %q, want %q", app.Spec.Components[0].Name, "web")
+	}
+	if app.Spec.Components[0].Type != "webservice" {
+		t.Errorf("component.type = %q, want %q", app.Spec.Components[0].Type, "webservice")
+	}
+}
+
+func TestParse_MultipleComponents(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+spec:
+  components:
+  - name: frontend
+    type: webservice
+    properties:
+      image: frontend:v1
+  - name: backend
+    type: worker
+    properties:
+      image: backend:v1
+  - name: db
+    type: postgresql
+    properties:
+      version: "15"
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(app.Spec.Components) != 3 {
+		t.Fatalf("len(components) = %d, want 3", len(app.Spec.Components))
+	}
+
+	expected := []struct{ name, typ string }{
+		{"frontend", "webservice"},
+		{"backend", "worker"},
+		{"db", "postgresql"},
+	}
+	for i, exp := range expected {
+		if app.Spec.Components[i].Name != exp.name {
+			t.Errorf("components[%d].name = %q, want %q", i, app.Spec.Components[i].Name, exp.name)
+		}
+		if app.Spec.Components[i].Type != exp.typ {
+			t.Errorf("components[%d].type = %q, want %q", i, app.Spec.Components[i].Type, exp.typ)
+		}
+	}
+}
+
+func TestParse_WithTraits(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: webapp
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: api:v1
+    traits:
+    - type: ingress
+      properties:
+        domain: api.example.com
+    - type: configmap
+      properties:
+        name: api-config
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(app.Spec.Components[0].Traits) != 2 {
+		t.Fatalf("len(traits) = %d, want 2", len(app.Spec.Components[0].Traits))
+	}
+	if app.Spec.Components[0].Traits[0].Type != "ingress" {
+		t.Errorf("traits[0].type = %q, want %q", app.Spec.Components[0].Traits[0].Type, "ingress")
+	}
+	if app.Spec.Components[0].Traits[1].Type != "configmap" {
+		t.Errorf("traits[1].type = %q, want %q", app.Spec.Components[0].Traits[1].Type, "configmap")
+	}
+}
+
+func TestParse_WithPolicies(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: web:v1
+  policies:
+  - name: resource-limits
+    type: env-policy
+    properties:
+      enforced:
+        maxReplicas: 5
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(app.Spec.Policies) != 1 {
+		t.Fatalf("len(policies) = %d, want 1", len(app.Spec.Policies))
+	}
+	if app.Spec.Policies[0].Name != "resource-limits" {
+		t.Errorf("policies[0].name = %q, want %q", app.Spec.Policies[0].Name, "resource-limits")
+	}
+	if app.Spec.Policies[0].Type != "env-policy" {
+		t.Errorf("policies[0].type = %q, want %q", app.Spec.Policies[0].Type, "env-policy")
+	}
+}
+
+func TestParse_RejectsUnknownFields(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  unknownField: value
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	var parseErr *errors.ParseError
+	if !stderrors.As(err, &parseErr) {
+		t.Errorf("expected *errors.ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestParse_RejectsInvalidYAML(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+    - this is invalid yaml
+      - nested wrong
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	var parseErr *errors.ParseError
+	if !stderrors.As(err, &parseErr) {
+		t.Errorf("expected *errors.ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestParse_YAMLTypeErrorIncludesLineInfo(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  unknownField: value
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	var parseErr *errors.ParseError
+	if !stderrors.As(err, &parseErr) {
+		t.Fatalf("expected *errors.ParseError, got %T: %v", err, err)
+	}
+	if parseErr.Line == 0 {
+		t.Errorf("expected ParseError.Line > 0, got 0 (line info not extracted from yaml.TypeError)")
+	}
+}
+
+func TestExtractYAMLLine(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"line 5: cannot unmarshal", 5},
+		{"line 12: field foo not found", 12},
+		{"line 1: something", 1},
+		{"no line prefix here", 0},
+		{"line abc: bad", 0},
+		{"line : empty", 0},
+		{"", 0},
+	}
+	for _, tc := range tests {
+		got := extractYAMLLine(tc.input)
+		if got != tc.want {
+			t.Errorf("extractYAMLLine(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestParse_RejectsCoreOAMAPIVersion(t *testing.T) {
+	// core.oam.dev/v1beta1 is crane's API group — not accepted by launcher.
+	input := `
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for core.oam.dev/v1beta1, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "core.oam.dev/v1beta1") {
+		t.Errorf("error = %q, want to contain 'core.oam.dev/v1beta1'", err.Error())
+	}
+}
+
+func TestParse_RejectsUnsupportedAPIVersion(t *testing.T) {
+	input := `
+apiVersion: core.oam.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unsupported apiVersion, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParse_RejectsWrongKind(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Component
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for wrong kind, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParse_RejectsMissingName(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+	if !strings.Contains(err.Error(), "metadata.name is required") {
+		t.Errorf("error = %q, want to contain 'metadata.name is required'", err.Error())
+	}
+}
+
+func TestParse_RejectsEmptyComponents(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components: []
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for empty components, got nil")
+	}
+	if !strings.Contains(err.Error(), "at least one component") {
+		t.Errorf("error = %q, want to contain 'at least one component'", err.Error())
+	}
+}
+
+func TestParse_RejectsUnknownComponentType(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: unknown-type
+    properties:
+      image: nginx:1.25
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown component type, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Value != "unknown-type" {
+		t.Errorf("Value = %q, want %q", valErr.Value, "unknown-type")
+	}
+	if len(valErr.ValidValues) == 0 {
+		t.Error("expected ValidValues to be populated for unknown component type")
+	}
+}
+
+func TestParse_RejectsUnknownTraitType(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: unknown-trait
+      properties:
+        foo: bar
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown trait type, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Value != "unknown-trait" {
+		t.Errorf("Value = %q, want %q", valErr.Value, "unknown-trait")
+	}
+	if len(valErr.ValidValues) == 0 {
+		t.Error("expected ValidValues to be populated for unknown trait type")
+	}
+}
+
+func TestParse_RejectsDeferredPhase2TraitType(t *testing.T) {
+	// pvc is a Phase 2 trait (issue #49) — not yet supported in Phase 1.
+	// It must fail at validate time, not silently pass to dispatch.
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: pvc
+      properties:
+        size: 10Gi
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for deferred Phase 2 trait pvc, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+	if valErr.Value != "pvc" {
+		t.Errorf("Value = %q, want %q", valErr.Value, "pvc")
+	}
+}
+
+func TestParse_RejectsDuplicateComponentNames(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+  - name: web
+    type: worker
+    properties:
+      image: worker:1.0.0
+`
+	_, err := Parse([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for duplicate component name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate component name") {
+		t.Errorf("error = %q, want to contain 'duplicate component name'", err.Error())
+	}
+}
+
+func TestParse_RejectsInvalidDNS1123Name(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name: "uppercase",
+			input: `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: Hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`,
+		},
+		{
+			name: "underscore",
+			input: `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello_world
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`,
+		},
+		{
+			name: "starts with hyphen",
+			input: `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: -hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.input))
+			if err == nil {
+				t.Fatal("expected error for invalid DNS-1123 name, got nil")
+			}
+			if !strings.Contains(err.Error(), "DNS-1123") {
+				t.Errorf("error = %q, want to contain 'DNS-1123'", err.Error())
+			}
+		})
+	}
+}
+
+func TestParse_ComponentProperties(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+      port: 8080
+      replicas: 3
+      env:
+      - name: FOO
+        value: bar
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	props := app.Spec.Components[0].Properties
+	if props["image"] != "nginx:1.25" {
+		t.Errorf("properties.image = %q, want %q", props["image"], "nginx:1.25")
+	}
+	if props["port"] != 8080 {
+		t.Errorf("properties.port = %v, want %v", props["port"], 8080)
+	}
+	if props["replicas"] != 3 {
+		t.Errorf("properties.replicas = %v, want %v", props["replicas"], 3)
+	}
+}
+
+func TestParseMulti_SingleDocument(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	apps, err := ParseMulti([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("len(apps) = %d, want 1", len(apps))
+	}
+	if apps[0].Metadata.Name != "hello" {
+		t.Errorf("apps[0].metadata.name = %q, want %q", apps[0].Metadata.Name, "hello")
+	}
+}
+
+func TestParseMulti_MultipleDocuments(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: app-one
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: app-one:v1
+---
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: app-two
+spec:
+  components:
+  - name: worker
+    type: worker
+    properties:
+      image: app-two:v1
+---
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: app-three
+spec:
+  components:
+  - name: db
+    type: postgresql
+    properties:
+      version: "16"
+`
+	apps, err := ParseMulti([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(apps) != 3 {
+		t.Fatalf("len(apps) = %d, want 3", len(apps))
+	}
+	expected := []string{"app-one", "app-two", "app-three"}
+	for i, name := range expected {
+		if apps[i].Metadata.Name != name {
+			t.Errorf("apps[%d].metadata.name = %q, want %q", i, apps[i].Metadata.Name, name)
+		}
+	}
+}
+
+func TestParseMulti_EmptyDocument(t *testing.T) {
+	_, err := ParseMulti([]byte(""))
+	if err == nil {
+		t.Fatal("expected error for empty input, got nil")
+	}
+	if !strings.Contains(err.Error(), "no documents found") {
+		t.Errorf("error = %q, want to contain 'no documents found'", err.Error())
+	}
+}
+
+func TestParseMulti_InvalidSecondDocument(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: good-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+---
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: bad-app
+  unknownField: oops
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := ParseMulti([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid second document, got nil")
+	}
+}
+
+func TestParseMulti_ValidationErrorInSecondDocument(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: good-app
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+---
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: bad-version
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	_, err := ParseMulti([]byte(input))
+	if err == nil {
+		t.Fatal("expected validation error for second document, got nil")
+	}
+	if !strings.Contains(err.Error(), "core.oam.dev/v1beta1") {
+		t.Errorf("error = %q, want to contain 'core.oam.dev/v1beta1'", err.Error())
+	}
+}
+
+func TestMustParse_Panics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("MustParse should panic on invalid input")
+		}
+	}()
+
+	MustParse([]byte("invalid yaml: {{{"))
+}
+
+func TestMustParse_Success(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+`
+	app := MustParse([]byte(input))
+	if app.Metadata.Name != "hello" {
+		t.Errorf("metadata.name = %q, want %q", app.Metadata.Name, "hello")
+	}
+}
+
+func TestParse_ComponentAnnotations(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+  - name: cert-manager
+    type: helmrelease
+    properties:
+      chart: cert-manager
+    annotations:
+      wharf.zone/tier: infra
+`
+	app, err := Parse([]byte(input))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	comp := app.Spec.Components[0]
+	if comp.Annotations == nil {
+		t.Fatal("expected non-nil Annotations")
+	}
+	if got := comp.Annotations["wharf.zone/tier"]; got != "infra" {
+		t.Errorf("annotations[wharf.zone/tier] = %q, want %q", got, "infra")
+	}
+}

--- a/pkg/oam/types.go
+++ b/pkg/oam/types.go
@@ -1,0 +1,45 @@
+package oam
+
+// Application represents an OAM Application resource.
+type Application struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   Metadata        `yaml:"metadata"`
+	Spec       ApplicationSpec `yaml:"spec"`
+}
+
+// Metadata contains standard Kubernetes-style metadata fields.
+type Metadata struct {
+	Name        string            `yaml:"name"`
+	Namespace   string            `yaml:"namespace,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// ApplicationSpec defines the components and policies of an OAM application.
+type ApplicationSpec struct {
+	Components []Component `yaml:"components"`
+	Policies   []Policy    `yaml:"policies,omitempty"`
+}
+
+// Component represents a single component within an OAM application.
+type Component struct {
+	Name        string            `yaml:"name"`
+	Type        string            `yaml:"type"`
+	Properties  map[string]any    `yaml:"properties"`
+	Traits      []Trait           `yaml:"traits,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}
+
+// Trait represents an operational behavior attached to a component.
+type Trait struct {
+	Type       string         `yaml:"type"`
+	Properties map[string]any `yaml:"properties"`
+}
+
+// Policy defines application-level policies passed through to the runtime unchanged.
+type Policy struct {
+	Name       string         `yaml:"name"`
+	Type       string         `yaml:"type"`
+	Properties map[string]any `yaml:"properties,omitempty"`
+}

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -5,8 +5,9 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/go-kure/launcher/pkg/errors"
 	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/go-kure/launcher/pkg/errors"
 )
 
 // SupportedAPIVersion is the only accepted apiVersion for Application documents.

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -1,0 +1,199 @@
+package oam
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+// SupportedAPIVersion is the only accepted apiVersion for Application documents.
+const SupportedAPIVersion = "launcher.gokure.dev/v1alpha1"
+
+// validComponentTypes is the Phase 1 set. Updated when Phase 2 handlers land.
+var validComponentTypes = map[string]bool{
+	"webservice":  true,
+	"worker":      true,
+	"postgresql":  true,
+	"cronjob":     true,
+	"helmrelease": true,
+	"daemonset":   true,
+	"statefulset": true,
+}
+
+// validTraitTypes is the Phase 1 set from design-kurel-package.md §4.3.
+// Deferred until Phase 2 (#49, #50): pvc, networkpolicy, cilium-networkpolicy, volsync.
+// Updated when Phase 2 handlers land.
+var validTraitTypes = map[string]bool{
+	"expose":          true,
+	"ingress":         true,
+	"httproute":       true,
+	"certificate":     true,
+	"external-secret": true,
+	"configmap":       true,
+	"scaler":          true,
+}
+
+// traitComponentRestrictions maps trait types to the component types they support.
+// Traits not listed here are allowed on any component type.
+var traitComponentRestrictions = map[string]map[string]bool{
+	"scaler": {"webservice": true, "worker": true},
+}
+
+// validate performs semantic validation on a parsed Application.
+func validate(app *Application) error {
+	if app.APIVersion != SupportedAPIVersion {
+		return oamValidationError("apiVersion", fmt.Sprintf("unsupported apiVersion %q, expected %q",
+			app.APIVersion, SupportedAPIVersion))
+	}
+
+	if app.Kind != "Application" {
+		return oamValidationError("kind", fmt.Sprintf("expected kind Application, got %q", app.Kind))
+	}
+
+	if app.Metadata.Name == "" {
+		return oamValidationError("metadata.name", "metadata.name is required")
+	}
+
+	if errs := validation.IsDNS1123Subdomain(app.Metadata.Name); len(errs) > 0 {
+		return oamValidationError("metadata.name", fmt.Sprintf("metadata.name %q is not a valid DNS-1123 subdomain",
+			app.Metadata.Name))
+	}
+
+	if app.Metadata.Namespace != "" {
+		if errs := validation.IsDNS1123Subdomain(app.Metadata.Namespace); len(errs) > 0 {
+			return oamValidationError("metadata.namespace", fmt.Sprintf("metadata.namespace %q is not a valid DNS-1123 subdomain",
+				app.Metadata.Namespace))
+		}
+	}
+
+	if len(app.Spec.Components) == 0 {
+		return oamValidationError("spec.components", "spec.components must contain at least one component")
+	}
+
+	seenNames := make(map[string]bool)
+	for i, c := range app.Spec.Components {
+		if err := validateComponent(&c, i, seenNames); err != nil {
+			return err
+		}
+	}
+
+	seenPolicyNames := make(map[string]bool)
+	for i, p := range app.Spec.Policies {
+		if err := validatePolicy(&p, i, seenPolicyNames); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateComponent(c *Component, index int, seenNames map[string]bool) error {
+	if c.Name == "" {
+		return oamValidationError("name", fmt.Sprintf("spec.components[%d].name is required", index))
+	}
+
+	if errs := validation.IsDNS1123Subdomain(c.Name); len(errs) > 0 {
+		return oamValidationError("name", fmt.Sprintf("component name %q is not a valid DNS-1123 subdomain", c.Name))
+	}
+
+	if seenNames[c.Name] {
+		return oamValidationError("name", fmt.Sprintf("duplicate component name %q", c.Name))
+	}
+	seenNames[c.Name] = true
+
+	if c.Type == "" {
+		return oamValidationError("type", fmt.Sprintf("component %q missing type", c.Name))
+	}
+
+	if !validComponentTypes[c.Type] {
+		return errors.NewValidationError("type", c.Type, c.Name, supportedComponentTypes())
+	}
+
+	for j, t := range c.Traits {
+		if err := validateTrait(&t, c.Name, c.Type, j); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateTrait(t *Trait, componentName, componentType string, index int) error {
+	if t.Type == "" {
+		return oamValidationError("type", fmt.Sprintf("component %q trait[%d] missing type",
+			componentName, index))
+	}
+
+	if !validTraitTypes[t.Type] {
+		return errors.NewValidationError("type", t.Type, componentName, supportedTraitTypes())
+	}
+
+	if allowed, restricted := traitComponentRestrictions[t.Type]; restricted {
+		if !allowed[componentType] {
+			supportedTypes := make([]string, 0, len(allowed))
+			for ct := range allowed {
+				supportedTypes = append(supportedTypes, ct)
+			}
+			slices.Sort(supportedTypes)
+			return oamValidationError("type", fmt.Sprintf(
+				"trait %q is not supported on component type %q (component %q); supported types: %s",
+				t.Type, componentType, componentName, strings.Join(supportedTypes, ", ")))
+		}
+	}
+
+	return nil
+}
+
+// validatePolicy checks that a policy has a non-empty name and type.
+// Policy types are open-ended in Phase 1 — no allowlist, no semantic interpretation
+// of policy properties. See design-kurel-package.md §4.4.
+func validatePolicy(p *Policy, index int, seenNames map[string]bool) error {
+	if p.Name == "" {
+		return oamValidationError("name", fmt.Sprintf("spec.policies[%d].name is required", index))
+	}
+
+	if errs := validation.IsDNS1123Subdomain(p.Name); len(errs) > 0 {
+		return oamValidationError("name", fmt.Sprintf("policy name %q is not a valid DNS-1123 subdomain", p.Name))
+	}
+
+	if seenNames[p.Name] {
+		return oamValidationError("name", fmt.Sprintf("duplicate policy name %q", p.Name))
+	}
+	seenNames[p.Name] = true
+
+	if p.Type == "" {
+		return oamValidationError("type", fmt.Sprintf("policy %q missing type", p.Name))
+	}
+
+	return nil
+}
+
+// oamValidationError creates a ValidationError with a custom message.
+func oamValidationError(field, message string) *errors.ValidationError {
+	return &errors.ValidationError{
+		Field:     field,
+		Component: "application",
+		Message:   message,
+	}
+}
+
+func supportedComponentTypes() []string {
+	types := make([]string, 0, len(validComponentTypes))
+	for t := range validComponentTypes {
+		types = append(types, t)
+	}
+	slices.Sort(types)
+	return types
+}
+
+func supportedTraitTypes() []string {
+	types := make([]string, 0, len(validTraitTypes))
+	for t := range validTraitTypes {
+		types = append(types, t)
+	}
+	slices.Sort(types)
+	return types
+}

--- a/pkg/oam/validate_test.go
+++ b/pkg/oam/validate_test.go
@@ -1,0 +1,262 @@
+package oam
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_ScalerTraitOnCronjob(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name: "batch-job",
+					Type: "cronjob",
+					Traits: []Trait{
+						{Type: "scaler", Properties: map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for scaler trait on cronjob, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported on component type") {
+		t.Errorf("error = %q, want to contain 'not supported on component type'", err.Error())
+	}
+}
+
+func TestValidate_ScalerTraitOnWebservice(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name: "web",
+					Type: "webservice",
+					Traits: []Trait{
+						{Type: "scaler", Properties: map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err != nil {
+		t.Errorf("unexpected error for scaler trait on webservice: %v", err)
+	}
+}
+
+func TestValidate_ScalerTraitOnWorker(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name: "bg",
+					Type: "worker",
+					Traits: []Trait{
+						{Type: "scaler", Properties: map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err != nil {
+		t.Errorf("unexpected error for scaler trait on worker: %v", err)
+	}
+}
+
+func TestValidate_ScalerTraitOnPostgresql(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name: "db",
+					Type: "postgresql",
+					Traits: []Trait{
+						{Type: "scaler", Properties: map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for scaler trait on postgresql, got nil")
+	}
+	if !strings.Contains(err.Error(), "not supported on component type") {
+		t.Errorf("error = %q, want to contain 'not supported on component type'", err.Error())
+	}
+}
+
+func TestValidate_PolicyOpenEndedType(t *testing.T) {
+	// Policy types are open-ended in Phase 1 — any non-empty type is accepted.
+	// Arbitrary types like env-policy, my-custom-policy, etc. must not be rejected.
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+			Policies: []Policy{
+				{Name: "resource-limits", Type: "env-policy"},
+				{Name: "my-custom", Type: "my-custom-policy-type"},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err != nil {
+		t.Errorf("unexpected error for open-ended policy types: %v", err)
+	}
+}
+
+func TestValidate_PolicyDuplicateName(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+			Policies: []Policy{
+				{Name: "my-policy", Type: "env-policy"},
+				{Name: "my-policy", Type: "another-type"},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for duplicate policy name, got nil")
+	}
+	if !strings.Contains(err.Error(), "duplicate policy name") {
+		t.Errorf("error = %q, want to contain 'duplicate policy name'", err.Error())
+	}
+}
+
+func TestValidate_PolicyInvalidDNS1123Name(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+			Policies: []Policy{
+				{Name: "My Policy!", Type: "env-policy"},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for invalid DNS-1123 policy name, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a valid DNS-1123") {
+		t.Errorf("error = %q, want to contain 'not a valid DNS-1123'", err.Error())
+	}
+}
+
+func TestValidate_PolicyMissingType(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+			Policies: []Policy{
+				{Name: "my-policy", Type: ""},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for missing policy type, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing type") {
+		t.Errorf("error = %q, want to contain 'missing type'", err.Error())
+	}
+}
+
+func TestValidate_NamespaceValidDNS1123(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app", Namespace: "my-namespace"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err != nil {
+		t.Errorf("unexpected error for valid namespace: %v", err)
+	}
+}
+
+func TestValidate_NamespaceInvalidDNS1123(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app", Namespace: "My Namespace!"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err == nil {
+		t.Fatal("expected validation error for invalid namespace, got nil")
+	}
+	if !strings.Contains(err.Error(), "not a valid DNS-1123") {
+		t.Errorf("error = %q, want to contain 'not a valid DNS-1123'", err.Error())
+	}
+}
+
+func TestValidate_NamespaceEmpty(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
+			},
+		},
+	}
+
+	err := validate(app)
+	if err != nil {
+		t.Errorf("unexpected error for empty namespace: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Creates `pkg/errors` — launcher's error utility package (`ValidationError`, `ParseError`, `New`, `Wrap`, `Errorf`, etc.)
- Creates `pkg/oam` — OAM data model, strict YAML parser, and semantic validator for `launcher.gokure.dev/v1alpha1` Application documents
- 36 tests covering happy paths, error cases, strict mode, and launcher-specific behavior

Closes #43.

## Key decisions vs crane

| Concern | Crane | Launcher |
|---|---|---|
| `apiVersion` | `core.oam.dev/v1beta1` | `launcher.gokure.dev/v1alpha1` |
| Trait types | 16 (incl. crane-only) | 7 Phase 1 set (design-kurel-package.md §4.3) |
| Policy type validation | Closed allowlist of 5 types | Open-ended — name + type non-empty only |
| Policy property semantics | Dependency/placement ref checks | None — passed through unchanged (§4.4) |
| Error types | `kure/pkg/errors` | `launcher/pkg/errors` (new package) |

Deferred Phase 2 traits (`pvc`, `networkpolicy`, `cilium-networkpolicy`, `volsync`) fail at validate time — enforces "valid for current runtime" semantics.

`pkg/patch` still imports `kure/pkg/errors` — migration is a separate follow-up.

## Test plan

- [ ] All CI checks pass (lint, test, build)
- [ ] `pkg/oam` tests cover: valid apps, strict mode rejection, unknown field rejection, API version check, deferred trait rejection, open-ended policy acceptance, scaler component restrictions, DNS-1123 validation