### PR TITLE
refactor: rename oam.Policy struct to ApplicationPolicy

### DIFF
--- a/pkg/oam/types.go
+++ b/pkg/oam/types.go
@@ -18,8 +18,8 @@ type Metadata struct {
 
 // ApplicationSpec defines the components and policies of an OAM application.
 type ApplicationSpec struct {
-	Components []Component `yaml:"components"`
-	Policies   []Policy    `yaml:"policies,omitempty"`
+	Components []Component         `yaml:"components"`
+	Policies   []ApplicationPolicy `yaml:"policies,omitempty"`
 }
 
 // Component represents a single component within an OAM application.
@@ -37,8 +37,8 @@ type Trait struct {
 	Properties map[string]any `yaml:"properties"`
 }
 
-// Policy defines application-level policies passed through to the runtime unchanged.
-type Policy struct {
+// ApplicationPolicy defines an application-level policy entry passed through to the runtime unchanged.
+type ApplicationPolicy struct {
 	Name       string         `yaml:"name"`
 	Type       string         `yaml:"type"`
 	Properties map[string]any `yaml:"properties,omitempty"`

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -83,7 +83,7 @@ func validate(app *Application) error {
 
 	seenPolicyNames := make(map[string]bool)
 	for i, p := range app.Spec.Policies {
-		if err := validatePolicy(&p, i, seenPolicyNames); err != nil {
+		if err := validateApplicationPolicy(&p, i, seenPolicyNames); err != nil {
 			return err
 		}
 	}
@@ -148,10 +148,10 @@ func validateTrait(t *Trait, componentName, componentType string, index int) err
 	return nil
 }
 
-// validatePolicy checks that a policy has a non-empty name and type.
+// validateApplicationPolicy checks that an application policy entry has a non-empty name and type.
 // Policy types are open-ended in Phase 1 — no allowlist, no semantic interpretation
 // of policy properties. See design-kurel-package.md §4.4.
-func validatePolicy(p *Policy, index int, seenNames map[string]bool) error {
+func validateApplicationPolicy(p *ApplicationPolicy, index int, seenNames map[string]bool) error {
 	if p.Name == "" {
 		return oamValidationError("name", fmt.Sprintf("spec.policies[%d].name is required", index))
 	}

--- a/pkg/oam/validate_test.go
+++ b/pkg/oam/validate_test.go
@@ -118,7 +118,7 @@ func TestValidate_PolicyOpenEndedType(t *testing.T) {
 			Components: []Component{
 				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
 			},
-			Policies: []Policy{
+			Policies: []ApplicationPolicy{
 				{Name: "resource-limits", Type: "env-policy"},
 				{Name: "my-custom", Type: "my-custom-policy-type"},
 			},
@@ -140,7 +140,7 @@ func TestValidate_PolicyDuplicateName(t *testing.T) {
 			Components: []Component{
 				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
 			},
-			Policies: []Policy{
+			Policies: []ApplicationPolicy{
 				{Name: "my-policy", Type: "env-policy"},
 				{Name: "my-policy", Type: "another-type"},
 			},
@@ -165,7 +165,7 @@ func TestValidate_PolicyInvalidDNS1123Name(t *testing.T) {
 			Components: []Component{
 				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
 			},
-			Policies: []Policy{
+			Policies: []ApplicationPolicy{
 				{Name: "My Policy!", Type: "env-policy"},
 			},
 		},
@@ -189,7 +189,7 @@ func TestValidate_PolicyMissingType(t *testing.T) {
 			Components: []Component{
 				{Name: "web", Type: "webservice", Properties: map[string]any{"image": "nginx:1.25"}},
 			},
-			Policies: []Policy{
+			Policies: []ApplicationPolicy{
 				{Name: "my-policy", Type: ""},
 			},
 		},


### PR DESCRIPTION
## Summary

- Renames `type Policy struct` → `type ApplicationPolicy struct` in `pkg/oam/types.go`
- Updates `ApplicationSpec.Policies []Policy` → `[]ApplicationPolicy`
- Renames internal `validatePolicy` → `validateApplicationPolicy` in `validate.go`
- Updates all `[]Policy{...}` literals in `validate_test.go`

## Why

Reserves the `oam.Policy` identifier for the enforcement interface being introduced in #46 ([options-policy-interface.md](docs/oam/options-policy-interface.md), Final — Option A). The OAM document policy element (name, type, properties) is now `ApplicationPolicy` to avoid the naming collision.

## Test plan

- [ ] All existing tests pass (`GOWORK=off make test`)
- [ ] Lint clean (`GOWORK=off make lint`)
- [ ] No new test needed — pure rename, behaviour unchanged