### PR TITLE
feat: pkg/oam — handler interfaces, ClusterProfile, Policy (#44, #45, #46)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -218,18 +218,32 @@ The `Policy` interface is launcher's primary extension point for downstream cons
 
 ```go
 type Policy interface {
-    ValidateImage(ref string) error
-    ValidateReplicas(n int32) error
-    ValidateResources(req corev1.ResourceRequirements) error
-    ValidateStorage(size resource.Quantity) error
-    ValidatePodSpec(spec *corev1.PodSpec) error
-    ValidateCapability(traitType string) error
+    // Enforced limits — nil or empty string means no limit.
+    MaxReplicas() *int32
+    MaxCPU() string
+    MaxMemory() string
+    MaxStorageSize() string
+    AllowedRegistries() []string
+    // Defaults — nil or empty string means leave the OAM value as-is.
     DefaultReplicas() *int32
-    DefaultResources() *corev1.ResourceRequirements
+    DefaultCPURequest() string
+    DefaultMemoryRequest() string
+    DefaultCPULimit() string
+    DefaultMemoryLimit() string
+    // Security flags — false is the zero value (default-deny).
+    AllowHostNetwork() bool
+    AllowPrivileged() bool
+    AllowHostPID() bool
+    AllowHostIPC() bool
+    AllowHostPathVolumes() bool
+    // Capability constraints — nil means unconstrained.
+    AllowedCapabilities() []string
+    ForbiddenCapabilities() []string
+    RequiredCapabilities() []string
 }
 ```
 
-`NoopPolicy` is the default — all methods pass through. Downstream consumers implement `Policy` to add enforcement. Every built-in handler calls `Policy` automatically via `TransformContext`; no handler wrapping is needed by consumers.
+`NoopPolicy` is the default when no policy document is supplied: no enforced limits, no defaults applied, security-sensitive booleans default-deny (false). Downstream consumers (e.g. crane's `*api.EnvironmentPolicy`) implement `Policy` to add enforcement. See `docs/oam/options-policy-interface.md` for the full design rationale.
 
 ---
 

--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -7,10 +7,10 @@
 | 1.1 | 2026-05-14 | Record decision (Option A); add framing section; rename options A/B; remove Option B |
 | 1.0 | 2026-04-19 | Initial draft — compared typed accessor (Option A) and opaque marker (Option B) |
 
-**Decision:** `oam.Policy` is a typed accessor interface with ~19 methods. Reason:
+**Decision:** `oam.Policy` is a typed accessor interface with 18 methods. Reason:
 compile-time verification, no type assertions in handler code, and explicit `NoopPolicy`
-behaviour (zero returns permit everything) are more important than the flexibility of a
-marker interface for future policy types.
+behaviour (no limits, no defaults, security-sensitive bools default-deny) are more important
+than the flexibility of a marker interface for future policy types.
 
 **Scope:** The `Policy` and `Enforceable` interface definitions in `pkg/oam`, how
 `*api.EnvironmentPolicy` in crane satisfies `Policy` after migration, and how handler
@@ -44,9 +44,14 @@ enforcement.
 crane compatibility seam.
 
 When no policy is supplied, launcher passes `NoopPolicy` — a concrete type that satisfies
-`oam.Policy` and permits everything (all limits absent, all defaults absent, all security
-flags false). Handlers always receive a non-nil `Policy` value; nil checks in handler code
-are not needed or intended.
+`oam.Policy` with the following semantics:
+- **No enforced limits** — all limit methods return nil or empty string
+- **No defaults applied** — all default methods return nil or empty string
+- **Security-sensitive features denied by default** — all security flag methods return false
+
+This is intentional default-deny behaviour for security flags, not a "permit everything"
+stance. Handlers always receive a non-nil `Policy` value; nil checks in handler code are
+not needed or intended.
 
 ### crane compatibility
 
@@ -154,7 +159,8 @@ type Enforceable interface {
 
 ```go
 // NoopPolicy is used when no policy is configured.
-// All methods return nil / empty / false (permit everything, apply no defaults).
+// No enforced limits, no defaults applied, security-sensitive features denied by default.
+// Security flags return false — intentional default-deny, not "permit everything".
 type NoopPolicy struct{}
 
 func (*NoopPolicy) MaxReplicas() *int32          { return nil }

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/Buvy
 github.com/controlplaneio-fluxcd/flux-operator v0.40.0 h1:LoUtsOagXI7nVpg6uhKzA/gWgcmvssy/7B2UKRPF5X0=
 github.com/controlplaneio-fluxcd/flux-operator v0.40.0/go.mod h1:ySL10hW+IdcUH3Ej5v3RFenzebJrMgmaM1XGrjc8sRk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
+github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -66,6 +68,8 @@ github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjT
 github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342 h1:/pfjvNZGHTIisL12xKJRVzSLt8AYUW6pWuxrImxjrxY=
 github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342/go.mod h1:Ne6H/bciRDZLiH8IB17B1BiIi7BtOoGN2TCRNsrCBsI=
+github.com/fluxcd/flux2/v2 v2.8.6 h1:ZVw0xXOmjm9BxU4f3rS3TXNzFU0OfgZofCiZhI9H5sE=
+github.com/fluxcd/flux2/v2 v2.8.6/go.mod h1:FqnpQiuQgT/1Uxhu2NhBUXZeDaSoBdN/AGVni+Z5qWI=
 github.com/fluxcd/helm-controller/api v1.5.4 h1:wbAwD+cSGBZEhT3qq1naBKkitdNbqRtWQUFNA3XTXOc=
 github.com/fluxcd/helm-controller/api v1.5.4/go.mod h1:lTgeUmtVYExMKp7mRDncsr4JwHTz3LFtLjRJZeR98lI=
 github.com/fluxcd/image-automation-controller/api v1.1.2 h1:Maa4qycz+iBCN/yJv9xNvuuj2IYihDAsSVwpHLhxkuk=
@@ -80,6 +84,10 @@ github.com/fluxcd/pkg/apis/kustomize v1.15.1 h1:t9QZh+3ZS8EKmlxrnnbcKZcGTrg8FDvM
 github.com/fluxcd/pkg/apis/kustomize v1.15.1/go.mod h1:IZOy4CCtR/hxMGb7erK1RfbGnczVv4/dRBoVD37AywI=
 github.com/fluxcd/pkg/apis/meta v1.25.1 h1:WG1GIC/SOz0GjxT0uVuO6AMicQ3yFsk6bDozCnq+fto=
 github.com/fluxcd/pkg/apis/meta v1.25.1/go.mod h1:c7o6mJGLCMvNrfdinGZehkrdZuFT9vZdZNrn66DtVD0=
+github.com/fluxcd/pkg/kustomize v1.27.2 h1:rtoccQyY4SnqXY/wtAXWGEXrINT923z4RBsIdISESik=
+github.com/fluxcd/pkg/kustomize v1.27.2/go.mod h1:A2RQTe9woDPiwJDWFlkoP4oF9eX9DeXr89FEkKnSObk=
+github.com/fluxcd/pkg/tar v0.17.0 h1:uNxbFXy8ly8C7fJ8D7w3rjTNJFrb4Hp1aY/30XkfvxY=
+github.com/fluxcd/pkg/tar v0.17.0/go.mod h1:b1xyIRYDD0ket4SV5u0UXYv+ZdN/O/HmIO5jZQdHQls=
 github.com/fluxcd/source-controller/api v1.8.3 h1:WNEETjmp/YTZx5IMg9ewz2Wn8YzOVETeJJ0LIPivm40=
 github.com/fluxcd/source-controller/api v1.8.3/go.mod h1:sio4t49RDx+S1etHRFAEEw8qfVuw0KKlOg8bRVlEYPM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -168,6 +176,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
 github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -204,6 +214,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFdJifH4BDsTlE89Zl93FEloxaWZfGcifgq8=
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -268,6 +280,8 @@ github.com/vishvananda/netns v0.0.5 h1:DfiHV+j8bA32MFM7bfEunvT8IAqQ/NzSJHtcmW5zd
 github.com/vishvananda/netns v0.0.5/go.mod h1:SpkAiCQRtJ6TvvxPnOSyH3BMl6unz3xZlaprSwhNNJM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
+github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
+github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 go.mongodb.org/mongo-driver v1.17.6 h1:87JUG1wZfWsr6rIz3ZmpH90rL5tea7O3IHuSwHUpsss=
 go.mongodb.org/mongo-driver v1.17.6/go.mod h1:Hy04i7O2kC4RS06ZrhPRqj/u4DTYkFDAAccj+rVKqgQ=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/pkg/oam/handler.go
+++ b/pkg/oam/handler.go
@@ -1,0 +1,35 @@
+package oam
+
+import "github.com/go-kure/kure/pkg/stack"
+
+// ComponentHandler handles transformation of a specific OAM component type
+// into a kure ApplicationConfig.
+type ComponentHandler interface {
+	CanHandle(componentType string) bool
+	ToApplicationConfig(component *Component, namespace string) (stack.ApplicationConfig, error)
+}
+
+// TraitHandler handles application of a specific OAM trait type to a kure
+// Application and Bundle.
+type TraitHandler interface {
+	CanHandle(traitType string) bool
+	Apply(trait *Trait, app *stack.Application, bundle *stack.Bundle) error
+}
+
+// CapabilityAware is an optional interface for TraitHandlers that require a
+// matching ClusterProfile capability to produce correct output. If
+// CapabilityRequired returns true and no capability resolves for the trait,
+// the runtime returns ErrMissingCapability.
+type CapabilityAware interface {
+	CapabilityRequired() bool
+}
+
+// SourceDeduplicatable is an optional interface for ApplicationConfig types
+// that generate source CRDs (e.g. HelmRepository). The runtime uses it to
+// suppress duplicate source generation when multiple components share the
+// same source URL.
+type SourceDeduplicatable interface {
+	GetSourceKey() string
+	GetSourceRefName() string
+	SuppressSourceGeneration(refName string)
+}

--- a/pkg/oam/policy.go
+++ b/pkg/oam/policy.go
@@ -1,0 +1,74 @@
+package oam
+
+// Policy provides environment-level constraints and defaults for OAM component
+// and trait handlers. Handlers call its methods; they must not type-assert.
+//
+// The 18 typed accessor methods correspond to every piece of data that handlers
+// currently access via crane's *api.EnvironmentPolicy. See the finalized design
+// in docs/oam/options-policy-interface.md (Option A).
+//
+// When no policy is supplied the runtime passes NoopPolicy, so handlers always
+// receive a non-nil Policy value and nil checks are not needed.
+type Policy interface {
+	// Enforced limits — nil or empty string means no limit is set.
+	MaxReplicas() *int32
+	MaxCPU() string
+	MaxMemory() string
+	MaxStorageSize() string
+	AllowedRegistries() []string
+
+	// Defaults — nil or empty string means leave the OAM value as-is.
+	DefaultReplicas() *int32
+	DefaultCPURequest() string
+	DefaultMemoryRequest() string
+	DefaultCPULimit() string
+	DefaultMemoryLimit() string
+
+	// Security flags — false is the zero value (default-deny).
+	AllowHostNetwork() bool
+	AllowPrivileged() bool
+	AllowHostPID() bool
+	AllowHostIPC() bool
+	AllowHostPathVolumes() bool
+
+	// Capability constraints — nil means unconstrained.
+	AllowedCapabilities() []string
+	ForbiddenCapabilities() []string
+	RequiredCapabilities() []string
+}
+
+// Enforceable is implemented by component and trait ApplicationConfig types that
+// accept per-environment policy enforcement. The runtime calls ApplyPolicy after
+// each handler produces a config; configs that do not implement Enforceable are
+// left unchanged.
+type Enforceable interface {
+	ApplyPolicy(policy Policy) error
+}
+
+// NoopPolicy satisfies Policy with zero values:
+// no enforced limits, no defaults applied, security-sensitive features denied by default.
+// Security flags are plain bool; false means denied — this is intentional default-deny
+// behaviour when no policy document is provided, not a "permit everything" stance.
+type NoopPolicy struct{}
+
+// compile-time interface check
+var _ Policy = (*NoopPolicy)(nil)
+
+func (*NoopPolicy) MaxReplicas() *int32             { return nil }
+func (*NoopPolicy) MaxCPU() string                  { return "" }
+func (*NoopPolicy) MaxMemory() string               { return "" }
+func (*NoopPolicy) MaxStorageSize() string          { return "" }
+func (*NoopPolicy) AllowedRegistries() []string     { return nil }
+func (*NoopPolicy) DefaultReplicas() *int32         { return nil }
+func (*NoopPolicy) DefaultCPURequest() string       { return "" }
+func (*NoopPolicy) DefaultMemoryRequest() string    { return "" }
+func (*NoopPolicy) DefaultCPULimit() string         { return "" }
+func (*NoopPolicy) DefaultMemoryLimit() string      { return "" }
+func (*NoopPolicy) AllowHostNetwork() bool          { return false }
+func (*NoopPolicy) AllowPrivileged() bool           { return false }
+func (*NoopPolicy) AllowHostPID() bool              { return false }
+func (*NoopPolicy) AllowHostIPC() bool              { return false }
+func (*NoopPolicy) AllowHostPathVolumes() bool      { return false }
+func (*NoopPolicy) AllowedCapabilities() []string   { return nil }
+func (*NoopPolicy) ForbiddenCapabilities() []string { return nil }
+func (*NoopPolicy) RequiredCapabilities() []string  { return nil }

--- a/pkg/oam/policy_test.go
+++ b/pkg/oam/policy_test.go
@@ -1,0 +1,65 @@
+package oam
+
+import "testing"
+
+// Compile-time check: NoopPolicy must satisfy Policy.
+var _ Policy = (*NoopPolicy)(nil)
+
+func TestNoopPolicy_ZeroValues(t *testing.T) {
+	p := &NoopPolicy{}
+
+	if got := p.MaxReplicas(); got != nil {
+		t.Errorf("MaxReplicas() = %v, want nil", got)
+	}
+	if got := p.MaxCPU(); got != "" {
+		t.Errorf("MaxCPU() = %q, want empty", got)
+	}
+	if got := p.MaxMemory(); got != "" {
+		t.Errorf("MaxMemory() = %q, want empty", got)
+	}
+	if got := p.MaxStorageSize(); got != "" {
+		t.Errorf("MaxStorageSize() = %q, want empty", got)
+	}
+	if got := p.AllowedRegistries(); got != nil {
+		t.Errorf("AllowedRegistries() = %v, want nil", got)
+	}
+	if got := p.DefaultReplicas(); got != nil {
+		t.Errorf("DefaultReplicas() = %v, want nil", got)
+	}
+	if got := p.DefaultCPURequest(); got != "" {
+		t.Errorf("DefaultCPURequest() = %q, want empty", got)
+	}
+	if got := p.DefaultMemoryRequest(); got != "" {
+		t.Errorf("DefaultMemoryRequest() = %q, want empty", got)
+	}
+	if got := p.DefaultCPULimit(); got != "" {
+		t.Errorf("DefaultCPULimit() = %q, want empty", got)
+	}
+	if got := p.DefaultMemoryLimit(); got != "" {
+		t.Errorf("DefaultMemoryLimit() = %q, want empty", got)
+	}
+	if got := p.AllowHostNetwork(); got {
+		t.Error("AllowHostNetwork() = true, want false (default-deny)")
+	}
+	if got := p.AllowPrivileged(); got {
+		t.Error("AllowPrivileged() = true, want false (default-deny)")
+	}
+	if got := p.AllowHostPID(); got {
+		t.Error("AllowHostPID() = true, want false (default-deny)")
+	}
+	if got := p.AllowHostIPC(); got {
+		t.Error("AllowHostIPC() = true, want false (default-deny)")
+	}
+	if got := p.AllowHostPathVolumes(); got {
+		t.Error("AllowHostPathVolumes() = true, want false (default-deny)")
+	}
+	if got := p.AllowedCapabilities(); got != nil {
+		t.Errorf("AllowedCapabilities() = %v, want nil", got)
+	}
+	if got := p.ForbiddenCapabilities(); got != nil {
+		t.Errorf("ForbiddenCapabilities() = %v, want nil", got)
+	}
+	if got := p.RequiredCapabilities(); got != nil {
+		t.Errorf("RequiredCapabilities() = %v, want nil", got)
+	}
+}

--- a/pkg/oam/profile.go
+++ b/pkg/oam/profile.go
@@ -1,0 +1,33 @@
+package oam
+
+// ClusterProfile encodes per-cluster capability bindings for the launcher runtime.
+// It is a YAML document with apiVersion launcher.gokure.dev/v1alpha1, kind ClusterProfile.
+//
+// Fields present in crane's ClusterProfile that are intentionally absent here:
+// spec.gitops (FluxCD delivery concern), spec.catalog, spec.componentCatalog,
+// spec.componentVariants (Wharf-specific). See docs/oam/design-cluster-profile.md §2.
+type ClusterProfile struct {
+	APIVersion string                 `yaml:"apiVersion" json:"apiVersion"`
+	Kind       string                 `yaml:"kind"       json:"kind"`
+	Metadata   ClusterProfileMetadata `yaml:"metadata"   json:"metadata"`
+	Spec       ClusterProfileSpec     `yaml:"spec"       json:"spec"`
+}
+
+// ClusterProfileMetadata holds the identifying metadata for a ClusterProfile.
+// Only name is defined; namespace, labels, and annotations are not part of the schema.
+type ClusterProfileMetadata struct {
+	Name string `yaml:"name" json:"name"`
+}
+
+// ClusterProfileSpec holds the capability bindings for a cluster.
+type ClusterProfileSpec struct {
+	Capabilities map[string]CapabilityBinding `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
+}
+
+// CapabilityBinding holds the rendering values the platform injects into trait
+// properties at build time. Renamed from crane's CapabilityDefinition; the
+// parameters field is removed — capability schema is not cluster-operator input.
+// See docs/oam/design-cluster-profile.md §2 and docs/oam/design-capability-schema.md §3.6.
+type CapabilityBinding struct {
+	Rendering map[string]any `yaml:"rendering,omitempty" json:"rendering,omitempty"`
+}


### PR DESCRIPTION
## Summary

Three focused additions to `pkg/oam`, all prerequisites for the runtime skeleton (#47):

- **`handler.go`** — `ComponentHandler`, `TraitHandler`, `CapabilityAware`, `SourceDeduplicatable` interfaces (closes #44)
- **`profile.go`** — `ClusterProfile` (full GVK document), `ClusterProfileMetadata`, `ClusterProfileSpec`, `CapabilityBinding` with YAML+JSON tags (closes #45)
- **`policy.go`** — `Policy` interface (18 typed accessor methods), `Enforceable`, `NoopPolicy` (closes #46)
- **`policy_test.go`** — 19 tests for NoopPolicy zero-value behaviour
- **`docs/oam/options-policy-interface.md`** — corrects NoopPolicy semantics (no limits, no defaults, security-sensitive flags default-deny)

## Key design notes

- `PolicyHandler`, `PolicyResult`, `Tier`, `ReconciliationSettings` intentionally absent — those are pipeline/runtime types deferred to #47/#53
- `ClusterProfile` uses `ClusterProfileMetadata{Name}` not the shared `Metadata` type — profile schema only defines `metadata.name`
- `CapabilityBinding.Rendering` only — `parameters` field removed per `design-cluster-profile.md` v1.1
- `NoopPolicy` is default-deny for security bools, not permit-everything — doc and code comment now agree

## Test plan

- [ ] `GOWORK=off make test` — all pass
- [ ] `GOWORK=off make lint` — clean
- [ ] `GOWORK=off make build` — clean