### PR TITLE
feat(oam): runtime skeleton — Transformer registry and pipeline types

### DIFF
--- a/pkg/oam/pipeline.go
+++ b/pkg/oam/pipeline.go
@@ -1,0 +1,70 @@
+package oam
+
+import (
+	"fmt"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// PolicyHandler dispatches a single OAM policy document during pipeline execution.
+type PolicyHandler interface {
+	CanHandle(policyType string) bool
+	Apply(policy *ApplicationPolicy, components []string, result *PolicyResult) error
+}
+
+// PolicyResult accumulates the effects of all OAM policy handlers.
+type PolicyResult struct {
+	TierOverrides          map[string]Tier
+	Dependencies           map[string][]string
+	AppDependsOn           []string
+	HealthCheckOverrides   []stack.HealthCheck
+	ReconciliationSettings *ReconciliationSettings
+}
+
+// NewPolicyResult creates an empty PolicyResult with initialised maps.
+func NewPolicyResult() *PolicyResult {
+	return &PolicyResult{
+		TierOverrides: make(map[string]Tier),
+		Dependencies:  make(map[string][]string),
+	}
+}
+
+// HasDependencies reports whether any dependency relationships were recorded.
+func (r *PolicyResult) HasDependencies() bool {
+	return len(r.Dependencies) > 0
+}
+
+// Tier classifies a component's deployment ordering.
+type Tier string
+
+const (
+	TierInfra    Tier = "infra"
+	TierServices Tier = "services"
+	TierApps     Tier = "apps"
+)
+
+// TierOrder defines the deployment order from earliest to latest.
+var TierOrder = []Tier{TierInfra, TierServices, TierApps}
+
+// ReconciliationSettings holds Flux reconciliation overrides from a reconciliation policy.
+type ReconciliationSettings struct {
+	Interval      string
+	RetryInterval string
+	Timeout       string
+	Prune         *bool
+	Wait          *bool
+	Force         *bool
+	Suspend       *bool
+}
+
+// ViolationError is returned when an Enforceable config rejects the current Policy.
+type ViolationError struct {
+	Component string
+	Cause     error
+}
+
+func (e *ViolationError) Error() string {
+	return fmt.Sprintf("component %q: %s", e.Component, e.Cause)
+}
+
+func (e *ViolationError) Unwrap() error { return e.Cause }

--- a/pkg/oam/pipeline_test.go
+++ b/pkg/oam/pipeline_test.go
@@ -1,0 +1,52 @@
+package oam
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewPolicyResult_Defaults(t *testing.T) {
+	r := NewPolicyResult()
+	if r.TierOverrides == nil {
+		t.Error("TierOverrides should be initialised, got nil")
+	}
+	if r.Dependencies == nil {
+		t.Error("Dependencies should be initialised, got nil")
+	}
+	if r.AppDependsOn != nil {
+		t.Errorf("AppDependsOn should be nil, got %v", r.AppDependsOn)
+	}
+	if r.HealthCheckOverrides != nil {
+		t.Errorf("HealthCheckOverrides should be nil, got %v", r.HealthCheckOverrides)
+	}
+	if r.ReconciliationSettings != nil {
+		t.Errorf("ReconciliationSettings should be nil, got %v", r.ReconciliationSettings)
+	}
+}
+
+func TestPolicyResult_HasDependencies(t *testing.T) {
+	r := NewPolicyResult()
+	if r.HasDependencies() {
+		t.Error("HasDependencies() = true on empty result, want false")
+	}
+	r.Dependencies["web"] = []string{"db"}
+	if !r.HasDependencies() {
+		t.Error("HasDependencies() = false after adding entry, want true")
+	}
+}
+
+func TestViolationError_Format(t *testing.T) {
+	cause := errors.New("max replicas exceeded")
+	e := &ViolationError{Component: "web", Cause: cause}
+
+	want := `component "web": max replicas exceeded`
+	if got := e.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+	if e.Unwrap() == nil {
+		t.Error("Unwrap() = nil, want non-nil cause")
+	}
+	if !errors.Is(e, cause) {
+		t.Error("errors.Is(e, cause) = false, want true")
+	}
+}

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -1,0 +1,105 @@
+package oam
+
+// ValidateAndApplyDefaults is implemented by built-in TraitHandlers that accept
+// rendering keys from ClusterProfile. Called at ClusterProfile evaluation time,
+// before any Application is processed. See design-capability-schema.md §2.2.
+type ValidateAndApplyDefaults interface {
+	ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error)
+}
+
+// TransformContext carries per-transform state passed to the pipeline.
+type TransformContext struct {
+	ClusterID    string
+	TenantID     string
+	Environment  string
+	AppVersion   string
+	TeamID       string
+	Namespace    string // overrides OAM metadata.namespace when set
+	Policy       Policy
+	Capabilities map[string]CapabilityBinding
+}
+
+// Transformer is the core OAM runtime. Handlers are registered at startup;
+// Transform/TransformWithPolicy (added in #53) execute the pipeline.
+// Internal storage uses maps keyed by typeName for O(1) dispatch.
+type Transformer struct {
+	componentHandlers map[string]ComponentHandler
+	traitHandlers     map[string]TraitHandler
+	policyHandlers    map[string]PolicyHandler
+}
+
+// NewTransformer creates a Transformer pre-loaded with component and trait handlers.
+// Inputs are maps keyed by typeName — the same key used by Register* and find* methods.
+// Each entry is routed through RegisterComponent/RegisterTrait so the startup assertion
+// (design-capability-schema.md §2.5) applies to pre-loaded handlers too.
+// Panics if any trait handler implements CapabilityAware but not ValidateAndApplyDefaults.
+// Nil maps are treated as empty.
+func NewTransformer(componentHandlers map[string]ComponentHandler, traitHandlers map[string]TraitHandler) *Transformer {
+	t := &Transformer{
+		componentHandlers: make(map[string]ComponentHandler),
+		traitHandlers:     make(map[string]TraitHandler),
+		policyHandlers:    make(map[string]PolicyHandler),
+	}
+	for typeName, h := range componentHandlers {
+		t.RegisterComponent(typeName, h)
+	}
+	for typeName, h := range traitHandlers {
+		t.RegisterTrait(typeName, h)
+	}
+	return t
+}
+
+// RegisterComponent registers a component handler under the given type name.
+// Panics if typeName is already registered or if h.CanHandle(typeName) returns false.
+func (t *Transformer) RegisterComponent(typeName string, h ComponentHandler) {
+	if _, exists := t.componentHandlers[typeName]; exists {
+		panic("oam: component handler already registered for type " + typeName)
+	}
+	if !h.CanHandle(typeName) {
+		panic("oam: component handler does not claim type " + typeName)
+	}
+	t.componentHandlers[typeName] = h
+}
+
+// RegisterTrait registers a trait handler under the given type name.
+// Panics if typeName is already registered, if h.CanHandle(typeName) returns false,
+// or if h implements CapabilityAware but not ValidateAndApplyDefaults.
+// See design-capability-schema.md §2.5.
+func (t *Transformer) RegisterTrait(typeName string, h TraitHandler) {
+	if _, exists := t.traitHandlers[typeName]; exists {
+		panic("oam: trait handler already registered for type " + typeName)
+	}
+	if !h.CanHandle(typeName) {
+		panic("oam: trait handler does not claim type " + typeName)
+	}
+	if _, ok := h.(CapabilityAware); ok {
+		if _, ok := h.(ValidateAndApplyDefaults); !ok {
+			panic("oam: trait handler for type " + typeName + " implements CapabilityAware but not ValidateAndApplyDefaults")
+		}
+	}
+	t.traitHandlers[typeName] = h
+}
+
+// RegisterPolicy registers a policy handler under the given type name.
+// Panics if typeName is already registered or if h.CanHandle(typeName) returns false.
+func (t *Transformer) RegisterPolicy(typeName string, h PolicyHandler) {
+	if _, exists := t.policyHandlers[typeName]; exists {
+		panic("oam: policy handler already registered for type " + typeName)
+	}
+	if !h.CanHandle(typeName) {
+		panic("oam: policy handler does not claim type " + typeName)
+	}
+	t.policyHandlers[typeName] = h
+}
+
+func (t *Transformer) findComponentHandler(componentType string) ComponentHandler {
+	return t.componentHandlers[componentType]
+}
+
+func (t *Transformer) findTraitHandler(traitType string) TraitHandler {
+	return t.traitHandlers[traitType]
+}
+
+func (t *Transformer) findPolicyHandler(policyType string) PolicyHandler {
+	return t.policyHandlers[policyType]
+}

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -1,0 +1,208 @@
+package oam
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// --- stub handlers for tests ---
+
+type stubComponentHandler struct{ typ string }
+
+func (h *stubComponentHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *stubComponentHandler) ToApplicationConfig(_ *Component, _ string) (stack.ApplicationConfig, error) {
+	return nil, nil
+}
+
+type stubTraitHandler struct{ typ string }
+
+func (h *stubTraitHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *stubTraitHandler) Apply(_ *Trait, _ *stack.Application, _ *stack.Bundle) error {
+	return nil
+}
+
+type capAwareHandler struct {
+	stubTraitHandler
+}
+
+func (h *capAwareHandler) CapabilityRequired() bool { return true }
+
+type capAwareWithVAD struct {
+	stubTraitHandler
+}
+
+func (h *capAwareWithVAD) CapabilityRequired() bool { return true }
+func (h *capAwareWithVAD) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	return rendering, nil
+}
+
+type stubPolicyHandler struct{ typ string }
+
+func (h *stubPolicyHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *stubPolicyHandler) Apply(_ *ApplicationPolicy, _ []string, _ *PolicyResult) error {
+	return nil
+}
+
+// mustPanic asserts that f panics.
+func mustPanic(t *testing.T, f func()) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, got none")
+		}
+	}()
+	f()
+}
+
+// --- NewTransformer ---
+
+func TestNewTransformer_Empty(t *testing.T) {
+	// Both nil and empty maps are valid.
+	tr1 := NewTransformer(nil, nil)
+	if tr1.findComponentHandler("any") != nil {
+		t.Error("expected nil for unregistered component handler")
+	}
+	if tr1.findTraitHandler("any") != nil {
+		t.Error("expected nil for unregistered trait handler")
+	}
+
+	tr2 := NewTransformer(map[string]ComponentHandler{}, map[string]TraitHandler{})
+	if tr2.findComponentHandler("any") != nil {
+		t.Error("expected nil for unregistered component handler (empty map)")
+	}
+}
+
+func TestNewTransformer_WithHandlers(t *testing.T) {
+	ch := &stubComponentHandler{typ: "webservice"}
+	th := &stubTraitHandler{typ: "expose"}
+
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": ch},
+		map[string]TraitHandler{"expose": th},
+	)
+
+	if got := tr.findComponentHandler("webservice"); got != ch {
+		t.Errorf("findComponentHandler(webservice) = %v, want %v", got, ch)
+	}
+	if got := tr.findTraitHandler("expose"); got != th {
+		t.Errorf("findTraitHandler(expose) = %v, want %v", got, th)
+	}
+}
+
+func TestNewTransformer_PanicsIfPreloadedCapabilityAwareWithoutVAD(t *testing.T) {
+	mustPanic(t, func() {
+		NewTransformer(nil, map[string]TraitHandler{
+			"ingress": &capAwareHandler{stubTraitHandler{typ: "ingress"}},
+		})
+	})
+}
+
+// --- RegisterComponent ---
+
+func TestTransformer_RegisterComponent_OK(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	ch := &stubComponentHandler{typ: "worker"}
+	tr.RegisterComponent("worker", ch)
+	if got := tr.findComponentHandler("worker"); got != ch {
+		t.Errorf("findComponentHandler(worker) = %v, want %v", got, ch)
+	}
+}
+
+func TestTransformer_RegisterComponent_PanicsOnDuplicate(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	tr.RegisterComponent("worker", &stubComponentHandler{typ: "worker"})
+	mustPanic(t, func() {
+		tr.RegisterComponent("worker", &stubComponentHandler{typ: "worker"})
+	})
+}
+
+func TestTransformer_RegisterComponent_PanicsOnCanHandleMismatch(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	mustPanic(t, func() {
+		tr.RegisterComponent("worker", &stubComponentHandler{typ: "webservice"})
+	})
+}
+
+// --- RegisterTrait ---
+
+func TestTransformer_RegisterTrait_OK(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	th := &stubTraitHandler{typ: "expose"}
+	tr.RegisterTrait("expose", th)
+	if got := tr.findTraitHandler("expose"); got != th {
+		t.Errorf("findTraitHandler(expose) = %v, want %v", got, th)
+	}
+}
+
+func TestTransformer_RegisterTrait_PanicsIfCapabilityAwareWithoutVAD(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	mustPanic(t, func() {
+		tr.RegisterTrait("ingress", &capAwareHandler{stubTraitHandler{typ: "ingress"}})
+	})
+}
+
+func TestTransformer_RegisterTrait_CapabilityAwareWithVAD_OK(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	th := &capAwareWithVAD{stubTraitHandler{typ: "ingress"}}
+	tr.RegisterTrait("ingress", th)
+	if got := tr.findTraitHandler("ingress"); got != th {
+		t.Errorf("findTraitHandler(ingress) = %v, want %v", got, th)
+	}
+}
+
+func TestTransformer_RegisterTrait_PanicsOnDuplicate(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	tr.RegisterTrait("expose", &stubTraitHandler{typ: "expose"})
+	mustPanic(t, func() {
+		tr.RegisterTrait("expose", &stubTraitHandler{typ: "expose"})
+	})
+}
+
+func TestTransformer_RegisterTrait_PanicsOnCanHandleMismatch(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	mustPanic(t, func() {
+		tr.RegisterTrait("expose", &stubTraitHandler{typ: "certificate"})
+	})
+}
+
+// --- RegisterPolicy ---
+
+func TestTransformer_RegisterPolicy(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	ph := &stubPolicyHandler{typ: "dependency"}
+	tr.RegisterPolicy("dependency", ph)
+	if got := tr.findPolicyHandler("dependency"); got != ph {
+		t.Errorf("findPolicyHandler(dependency) = %v, want %v", got, ph)
+	}
+}
+
+func TestTransformer_RegisterPolicy_PanicsOnDuplicate(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	tr.RegisterPolicy("dependency", &stubPolicyHandler{typ: "dependency"})
+	mustPanic(t, func() {
+		tr.RegisterPolicy("dependency", &stubPolicyHandler{typ: "dependency"})
+	})
+}
+
+func TestTransformer_RegisterPolicy_PanicsOnCanHandleMismatch(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	mustPanic(t, func() {
+		tr.RegisterPolicy("dependency", &stubPolicyHandler{typ: "placement"})
+	})
+}
+
+// --- find* with no match ---
+
+func TestTransformer_FindHandler_NoMatch(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	if got := tr.findComponentHandler("unknown"); got != nil {
+		t.Errorf("findComponentHandler(unknown) = %v, want nil", got)
+	}
+	if got := tr.findTraitHandler("unknown"); got != nil {
+		t.Errorf("findTraitHandler(unknown) = %v, want nil", got)
+	}
+	if got := tr.findPolicyHandler("unknown"); got != nil {
+		t.Errorf("findPolicyHandler(unknown) = %v, want nil", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Transformer` struct with map-keyed handler registries (`componentHandlers`, `traitHandlers`, `policyHandlers`) for O(1) dispatch by typeName
- Adds `TransformContext` carrying per-transform state (ClusterID, TenantID, Environment, AppVersion, TeamID, Namespace, Policy, Capabilities)
- Adds `ValidateAndApplyDefaults` interface and startup assertion: `RegisterTrait` panics if a `CapabilityAware` handler does not also implement `ValidateAndApplyDefaults`
- All three `Register*` methods panic on duplicate typeName or `h.CanHandle(typeName) == false`; `NewTransformer` routes pre-loaded handlers through `Register*` so the assertion fires for constructor-supplied handlers too
- Adds pipeline-support types in `pipeline.go`: `PolicyHandler`, `PolicyResult`, `NewPolicyResult`, `Tier`/`TierOrder`, `ReconciliationSettings`, `ViolationError`
- `Transform`/`TransformWithPolicy` pipeline methods deferred to #53

## Test plan

- `TestNewTransformer_Empty` — nil and empty maps both accepted
- `TestNewTransformer_WithHandlers` — map-based pre-load, handlers found by typeName
- `TestNewTransformer_PanicsIfPreloadedCapabilityAwareWithoutVAD` — startup assertion via constructor
- Duplicate-key and CanHandle-mismatch panic tests for all three `Register*` methods
- `TestViolationError_Format`, `TestNewPolicyResult_Defaults`, `TestPolicyResult_HasDependencies`
- All 30 pkg/oam tests pass; coverage 96.3%

Closes #47