### PR TITLE
feat(oam): transform pipeline — Transform, TransformWithPolicy, and pipeline stages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.36.0
+	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -140,7 +141,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.0 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
-	sigs.k8s.io/controller-runtime v0.24.0 // indirect
 	sigs.k8s.io/gateway-api v1.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/pkg/oam/classify.go
+++ b/pkg/oam/classify.go
@@ -1,0 +1,49 @@
+package oam
+
+import "fmt"
+
+// TierAnnotation is the OAM component annotation key for overriding the default tier.
+const TierAnnotation = "wharf.zone/tier"
+
+// defaultTierMap maps OAM component types to their deployment tier.
+var defaultTierMap = map[string]Tier{
+	"postgresql":  TierServices,
+	"webservice":  TierApps,
+	"worker":      TierApps,
+	"cronjob":     TierApps,
+	"helmrelease": TierApps,
+	"daemonset":   TierInfra,
+	"statefulset": TierApps,
+}
+
+// validTiers is the set of valid tier values for annotation validation.
+var validTiers = map[Tier]bool{
+	TierInfra:    true,
+	TierServices: true,
+	TierApps:     true,
+}
+
+// ClassifyComponent returns the deployment tier for the given component.
+// It checks the TierAnnotation first, then the defaultTierMap, and falls back to TierApps.
+func ClassifyComponent(c *Component) (Tier, error) {
+	if v, ok := c.Annotations[TierAnnotation]; ok {
+		tier := Tier(v)
+		if !validTiers[tier] {
+			return "", fmt.Errorf("invalid tier annotation %q on component %q: must be one of infra, services, apps", v, c.Name)
+		}
+		return tier, nil
+	}
+	if tier, ok := defaultTierMap[c.Type]; ok {
+		return tier, nil
+	}
+	return TierApps, nil
+}
+
+// groupByTier groups component entries by their deployment tier.
+func groupByTier(entries []componentEntry) map[Tier][]componentEntry {
+	groups := make(map[Tier][]componentEntry)
+	for _, e := range entries {
+		groups[e.tier] = append(groups[e.tier], e)
+	}
+	return groups
+}

--- a/pkg/oam/classify_test.go
+++ b/pkg/oam/classify_test.go
@@ -1,0 +1,68 @@
+package oam
+
+import "testing"
+
+func TestClassifyComponent_Annotation(t *testing.T) {
+	c := &Component{
+		Name:        "cache",
+		Type:        "unknown",
+		Annotations: map[string]string{TierAnnotation: "infra"},
+	}
+	tier, err := ClassifyComponent(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != TierInfra {
+		t.Errorf("got %q, want %q", tier, TierInfra)
+	}
+}
+
+func TestClassifyComponent_InvalidAnnotation(t *testing.T) {
+	c := &Component{
+		Name:        "cache",
+		Type:        "unknown",
+		Annotations: map[string]string{TierAnnotation: "invalid"},
+	}
+	_, err := ClassifyComponent(c)
+	if err == nil {
+		t.Error("expected error for invalid tier annotation, got nil")
+	}
+}
+
+func TestClassifyComponent_DefaultMap(t *testing.T) {
+	cases := []struct {
+		typ  string
+		want Tier
+	}{
+		{"webservice", TierApps},
+		{"worker", TierApps},
+		{"cronjob", TierApps},
+		{"helmrelease", TierApps},
+		{"statefulset", TierApps},
+		{"postgresql", TierServices},
+		{"daemonset", TierInfra},
+	}
+	for _, tc := range cases {
+		t.Run(tc.typ, func(t *testing.T) {
+			c := &Component{Name: tc.typ, Type: tc.typ}
+			tier, err := ClassifyComponent(c)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tier != tc.want {
+				t.Errorf("got %q, want %q", tier, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyComponent_FallbackToApps(t *testing.T) {
+	c := &Component{Name: "custom", Type: "unknown-type"}
+	tier, err := ClassifyComponent(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != TierApps {
+		t.Errorf("got %q, want %q", tier, TierApps)
+	}
+}

--- a/pkg/oam/errors.go
+++ b/pkg/oam/errors.go
@@ -1,0 +1,25 @@
+package oam
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrMissingCapability is returned when a CapabilityAware trait handler is applied
+// without a matching entry in TransformContext.Capabilities.
+var ErrMissingCapability = errors.New("oam: capability key not found in ClusterProfile")
+
+// TransformError represents a failure in the OAM-to-kure transformation pipeline.
+type TransformError struct {
+	Message string
+	Cause   error
+}
+
+func (e *TransformError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s", e.Message, e.Cause)
+	}
+	return e.Message
+}
+
+func (e *TransformError) Unwrap() error { return e.Cause }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -151,6 +151,11 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 		return nil, nil, err
 	}
 
+	// Phase 1.5: validate capability constraints declared by the Policy.
+	if err := enforceCapabilityConstraints(collectTraitTypes(app), ctx.Policy); err != nil {
+		return nil, nil, &ViolationError{Component: app.Metadata.Name, Cause: err}
+	}
+
 	// Phase 2: apply OAM policies (placement overrides, dependency graph).
 	policyResult, err := t.applyPolicies(app, entries)
 	if err != nil {
@@ -647,6 +652,71 @@ func walkLeafBundle(bundle *stack.Bundle, fn func(*stack.Bundle)) {
 	for _, child := range bundle.Children {
 		walkLeafBundle(child, fn)
 	}
+}
+
+// collectTraitTypes returns the unique trait types used across all components.
+func collectTraitTypes(app *Application) []string {
+	seen := make(map[string]bool)
+	var types []string
+	for _, comp := range app.Spec.Components {
+		for _, trait := range comp.Traits {
+			if !seen[trait.Type] {
+				seen[trait.Type] = true
+				types = append(types, trait.Type)
+			}
+		}
+	}
+	return types
+}
+
+// enforceCapabilityConstraints checks that the application's trait types satisfy the
+// capability constraints from the active Policy. Returns nil when all constraint slices
+// are empty (which is always true for NoopPolicy).
+func enforceCapabilityConstraints(traitTypes []string, policy Policy) error {
+	forbidden := policy.ForbiddenCapabilities()
+	allowed := policy.AllowedCapabilities()
+	required := policy.RequiredCapabilities()
+
+	if len(forbidden) == 0 && len(allowed) == 0 && len(required) == 0 {
+		return nil
+	}
+
+	used := make(map[string]bool, len(traitTypes))
+	for _, t := range traitTypes {
+		used[t] = true
+	}
+
+	if len(forbidden) > 0 {
+		forbiddenSet := make(map[string]bool, len(forbidden))
+		for _, f := range forbidden {
+			forbiddenSet[f] = true
+		}
+		for _, t := range traitTypes {
+			if forbiddenSet[t] {
+				return fmt.Errorf("capability %q is forbidden by environment policy", t)
+			}
+		}
+	}
+
+	if len(allowed) > 0 {
+		allowedSet := make(map[string]bool, len(allowed))
+		for _, a := range allowed {
+			allowedSet[a] = true
+		}
+		for _, t := range traitTypes {
+			if !allowedSet[t] {
+				return fmt.Errorf("capability %q is not in the allowed list", t)
+			}
+		}
+	}
+
+	for _, r := range required {
+		if !used[r] {
+			return fmt.Errorf("required capability %q is missing", r)
+		}
+	}
+
+	return nil
 }
 
 // deepCopyMap returns a deep copy of a map[string]any via JSON round-trip.

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -1,5 +1,14 @@
 package oam
 
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
 // ValidateAndApplyDefaults is implemented by built-in TraitHandlers that accept
 // rendering keys from ClusterProfile. Called at ClusterProfile evaluation time,
 // before any Application is processed. See design-capability-schema.md §2.2.
@@ -102,4 +111,553 @@ func (t *Transformer) findTraitHandler(traitType string) TraitHandler {
 
 func (t *Transformer) findPolicyHandler(policyType string) PolicyHandler {
 	return t.policyHandlers[policyType]
+}
+
+// --- Pipeline entry points ---
+
+// componentEntry holds a component with its corresponding stack application and tier.
+type componentEntry struct {
+	index     int
+	component Component
+	app       *stack.Application
+	tier      Tier
+}
+
+// Transform converts an OAM Application to a kure Cluster.
+func (t *Transformer) Transform(app *Application, ctx TransformContext) (*stack.Cluster, error) {
+	cluster, _, err := t.TransformWithPolicy(app, ctx)
+	return cluster, err
+}
+
+// TransformWithPolicy converts an OAM Application to a kure Cluster and
+// returns the accumulated PolicyResult. ctx.Policy is normalized to NoopPolicy
+// if nil so that all pipeline stages always receive a non-nil Policy value.
+func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext) (*stack.Cluster, *PolicyResult, error) {
+	if ctx.Policy == nil {
+		ctx.Policy = &NoopPolicy{}
+	}
+
+	namespace := ctx.Namespace
+	if namespace == "" {
+		namespace = app.Metadata.Namespace
+	}
+	if namespace == "" {
+		namespace = "default"
+	}
+
+	// Phase 1: create applications, apply Enforceable policy, classify tiers.
+	entries, err := t.createApplications(app, namespace, ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Phase 2: apply OAM policies (placement overrides, dependency graph).
+	policyResult, err := t.applyPolicies(app, entries)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Apply placement tier overrides before grouping.
+	for i, entry := range entries {
+		if tier, ok := policyResult.TierOverrides[entry.component.Name]; ok {
+			entries[i].tier = tier
+		}
+	}
+
+	// Phase 3: group by tier and build cluster.
+	tierGroups := groupByTier(entries)
+
+	var cluster *stack.Cluster
+	if policyResult.HasDependencies() {
+		cluster, err = t.buildDependencyAwareCluster(app, entries, policyResult.Dependencies, ctx)
+	} else if len(tierGroups) <= 1 {
+		cluster, err = t.buildFlatCluster(app, entries, ctx)
+	} else {
+		cluster, err = t.buildHierarchicalCluster(app, entries, tierGroups, ctx)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Phase 4: post-build bundle decorations.
+	componentMap := make(map[string]componentEntry, len(entries))
+	for _, e := range entries {
+		componentMap[e.component.Name] = e
+	}
+	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides)
+	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
+
+	return cluster, policyResult, nil
+}
+
+// createApplications converts OAM components to stack applications, applies
+// Enforceable policy, and classifies each component into a deployment tier.
+func (t *Transformer) createApplications(app *Application, namespace string, ctx TransformContext) ([]componentEntry, error) {
+	entries := make([]componentEntry, 0, len(app.Spec.Components))
+	for i, component := range app.Spec.Components {
+		handler := t.findComponentHandler(component.Type)
+		if handler == nil {
+			return nil, &TransformError{Message: fmt.Sprintf("no handler for component type %q", component.Type)}
+		}
+
+		config, err := handler.ToApplicationConfig(&component, namespace)
+		if err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("component %q", component.Name), Cause: err}
+		}
+
+		if enforceable, ok := config.(Enforceable); ok {
+			if err := enforceable.ApplyPolicy(ctx.Policy); err != nil {
+				return nil, &ViolationError{Component: component.Name, Cause: err}
+			}
+		}
+
+		tier, err := ClassifyComponent(&component)
+		if err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("component %q", component.Name), Cause: err}
+		}
+
+		stackApp := stack.NewApplication(component.Name, namespace, config)
+		entries = append(entries, componentEntry{
+			index:     i,
+			component: component,
+			app:       stackApp,
+			tier:      tier,
+		})
+	}
+
+	deduplicateSourceRefs(entries)
+	return entries, nil
+}
+
+// applyPolicies runs all registered policy handlers for the application's OAM policies.
+func (t *Transformer) applyPolicies(app *Application, entries []componentEntry) (*PolicyResult, error) {
+	result := NewPolicyResult()
+	if len(app.Spec.Policies) == 0 {
+		return result, nil
+	}
+
+	componentNames := make([]string, len(entries))
+	for i, e := range entries {
+		componentNames[i] = e.component.Name
+	}
+
+	for _, p := range app.Spec.Policies {
+		handler := t.findPolicyHandler(p.Type)
+		if handler == nil {
+			return nil, &TransformError{Message: fmt.Sprintf("no handler for policy type %q", p.Type)}
+		}
+		if err := handler.Apply(&p, componentNames, result); err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("policy %q", p.Name), Cause: err}
+		}
+	}
+
+	return result, nil
+}
+
+// buildFlatCluster creates a single-bundle cluster when all components belong to one tier.
+func (t *Transformer) buildFlatCluster(app *Application, entries []componentEntry, ctx TransformContext) (*stack.Cluster, error) {
+	apps := make([]*stack.Application, 0, len(entries))
+	for _, e := range entries {
+		apps = append(apps, e.app)
+	}
+
+	bundle, err := stack.NewBundle(app.Metadata.Name, apps, nil)
+	if err != nil {
+		return nil, &TransformError{Message: "failed to create bundle", Cause: err}
+	}
+
+	if err := t.applyTraits(app, entries, bundle, ctx); err != nil {
+		return nil, err
+	}
+
+	node := &stack.Node{Name: "", Bundle: bundle}
+	return stack.NewCluster(ctx.ClusterID, node), nil
+}
+
+// buildHierarchicalCluster creates an umbrella bundle with one tier-child per populated tier.
+func (t *Transformer) buildHierarchicalCluster(app *Application, entries []componentEntry, tierGroups map[Tier][]componentEntry, ctx TransformContext) (*stack.Cluster, error) {
+	tierBundles := make([]*stack.Bundle, 0, len(tierGroups))
+	for _, tier := range TierOrder {
+		group, ok := tierGroups[tier]
+		if !ok {
+			continue
+		}
+
+		apps := make([]*stack.Application, 0, len(group))
+		for _, e := range group {
+			apps = append(apps, e.app)
+		}
+
+		bundleName := fmt.Sprintf("%s-%s", app.Metadata.Name, tier)
+		bundle, err := stack.NewBundle(bundleName, apps, nil)
+		if err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("failed to create %s bundle", tier), Cause: err}
+		}
+
+		if err := t.applyTraits(app, group, bundle, ctx); err != nil {
+			return nil, err
+		}
+
+		tierBundles = append(tierBundles, bundle)
+	}
+
+	waitTrue := true
+	umbrella := &stack.Bundle{
+		Name:     app.Metadata.Name,
+		Children: tierBundles,
+		Wait:     &waitTrue,
+	}
+	umbrella.InitializeUmbrella()
+	if err := umbrella.Validate(); err != nil {
+		return nil, &TransformError{Message: "failed to validate umbrella bundle", Cause: err}
+	}
+
+	rootNode := &stack.Node{Name: umbrella.Name, Bundle: umbrella}
+	rootNode.InitializePathMap()
+	return stack.NewCluster(ctx.ClusterID, rootNode), nil
+}
+
+// buildDependencyAwareCluster creates per-component bundles when explicit dependency
+// policies are present. Each component gets its own Node and Bundle, enabling arbitrary
+// DependsOn relationships.
+func (t *Transformer) buildDependencyAwareCluster(app *Application, entries []componentEntry, deps map[string][]string, ctx TransformContext) (*stack.Cluster, error) {
+	rootNode := &stack.Node{
+		Name:     "",
+		Children: make([]*stack.Node, 0, len(entries)),
+	}
+
+	bundleMap := make(map[string]*stack.Bundle, len(entries))
+	tierBundles := make(map[Tier][]*stack.Bundle)
+
+	for _, entry := range entries {
+		bundleName := fmt.Sprintf("%s-%s", app.Metadata.Name, entry.component.Name)
+		bundle, err := stack.NewBundle(bundleName, []*stack.Application{entry.app}, nil)
+		if err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("failed to create bundle for component %q", entry.component.Name), Cause: err}
+		}
+
+		if err := t.applyTraits(app, []componentEntry{entry}, bundle, ctx); err != nil {
+			return nil, err
+		}
+
+		bundleMap[entry.component.Name] = bundle
+		tierBundles[entry.tier] = append(tierBundles[entry.tier], bundle)
+
+		childNode := &stack.Node{Name: entry.component.Name, Bundle: bundle}
+		childNode.SetParent(rootNode)
+		rootNode.Children = append(rootNode.Children, childNode)
+	}
+
+	// Wire explicit dependencies from policies.
+	for component, depNames := range deps {
+		bundle := bundleMap[component]
+		for _, depName := range depNames {
+			if depBundle := bundleMap[depName]; depBundle != nil {
+				bundle.DependsOn = append(bundle.DependsOn, depBundle)
+			}
+		}
+	}
+
+	// Wire automatic cross-tier dependencies: each bundle depends on all bundles in the
+	// immediately preceding populated tier.
+	var prevTierBundles []*stack.Bundle
+	for _, tier := range TierOrder {
+		current := tierBundles[tier]
+		if len(prevTierBundles) > 0 {
+			for _, b := range current {
+				for _, ptb := range prevTierBundles {
+					if !slices.Contains(b.DependsOn, ptb) {
+						b.DependsOn = append(b.DependsOn, ptb)
+					}
+				}
+			}
+		}
+		if len(current) > 0 {
+			prevTierBundles = current
+		}
+	}
+
+	if err := detectBundleCycles(entries, bundleMap); err != nil {
+		return nil, &TransformError{Message: "dependency cycle after applying cross-tier edges", Cause: err}
+	}
+
+	rootNode.InitializePathMap()
+	return stack.NewCluster(ctx.ClusterID, rootNode), nil
+}
+
+// applyTraits applies all traits for the given component entries to the bundle.
+// Capability rendering values are merged into trait properties before dispatch;
+// OAM inline values take precedence. Policy enforcement is applied to configs
+// added by each trait.
+func (t *Transformer) applyTraits(app *Application, entries []componentEntry, bundle *stack.Bundle, ctx TransformContext) error {
+	for _, entry := range entries {
+		for _, trait := range app.Spec.Components[entry.index].Traits {
+			handler := t.findTraitHandler(trait.Type)
+			if handler == nil {
+				return &TransformError{Message: fmt.Sprintf("no handler for trait type %q", trait.Type)}
+			}
+
+			if aware, ok := handler.(CapabilityAware); ok && aware.CapabilityRequired() {
+				key := buildCapabilityKey(trait)
+				_, foundScoped := ctx.Capabilities[key]
+				_, foundBare := ctx.Capabilities[trait.Type]
+				if !foundScoped && !foundBare {
+					return &TransformError{
+						Message: fmt.Sprintf("component %q trait %q: capability %q not found in ClusterProfile",
+							entry.component.Name, trait.Type, key),
+						Cause: ErrMissingCapability,
+					}
+				}
+			}
+
+			resolved := resolveCapability(trait, ctx.Capabilities)
+			prevLen := len(bundle.Applications)
+			if err := handler.Apply(&resolved, entry.app, bundle); err != nil {
+				return &TransformError{
+					Message: fmt.Sprintf("component %q trait %q", entry.component.Name, trait.Type),
+					Cause:   err,
+				}
+			}
+
+			for _, newApp := range bundle.Applications[prevLen:] {
+				if enforceable, ok := newApp.Config.(Enforceable); ok {
+					if err := enforceable.ApplyPolicy(ctx.Policy); err != nil {
+						return &ViolationError{Component: entry.component.Name, Cause: err}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// --- Helpers ---
+
+// deduplicateSourceRefs suppresses duplicate source CRD generation when multiple
+// components share the same source URL.
+func deduplicateSourceRefs(entries []componentEntry) {
+	seen := make(map[string]string) // sourceKey → sourceRefName
+	for _, entry := range entries {
+		dedup, ok := entry.app.Config.(SourceDeduplicatable)
+		if !ok {
+			continue
+		}
+		key := dedup.GetSourceKey()
+		if key == "" {
+			continue
+		}
+		if existingName, found := seen[key]; found {
+			dedup.SuppressSourceGeneration(existingName)
+		} else {
+			seen[key] = dedup.GetSourceRefName()
+		}
+	}
+}
+
+// resolveCapability merges capability rendering values into trait properties.
+// Rendering values act as platform-provided defaults; OAM inline values take precedence.
+// Key resolution: tries the scoped key ("<type>.<scope>"), then falls back to the bare
+// "<type>" key. Returns the original trait unchanged when no matching capability exists.
+func resolveCapability(trait Trait, capabilities map[string]CapabilityBinding) Trait {
+	if len(capabilities) == 0 {
+		return trait
+	}
+	key := buildCapabilityKey(trait)
+	cap, ok := capabilities[key]
+	if !ok {
+		cap, ok = capabilities[trait.Type]
+	}
+	if !ok || len(cap.Rendering) == 0 {
+		return trait
+	}
+
+	rendering, err := deepCopyMap(cap.Rendering)
+	if err != nil {
+		rendering = cap.Rendering
+	}
+
+	merged := make(map[string]any, len(rendering)+len(trait.Properties))
+	maps.Copy(merged, rendering)
+	maps.Copy(merged, trait.Properties)
+
+	result := trait
+	result.Properties = merged
+	return result
+}
+
+// buildCapabilityKey returns "<type>.<scope>" when the trait carries a non-empty
+// scope property, or "<type>" otherwise. Resolution falls back to the bare type key.
+func buildCapabilityKey(trait Trait) string {
+	if scope, ok := trait.Properties["scope"].(string); ok && scope != "" {
+		return trait.Type + "." + scope
+	}
+	return trait.Type
+}
+
+// detectBundleCycles builds a name-keyed dependency graph from bundle DependsOn
+// pointers and checks for cycles.
+func detectBundleCycles(entries []componentEntry, bundleMap map[string]*stack.Bundle) error {
+	bundleToName := make(map[*stack.Bundle]string, len(entries))
+	for _, e := range entries {
+		bundleToName[bundleMap[e.component.Name]] = e.component.Name
+	}
+
+	graph := make(map[string][]string)
+	for _, e := range entries {
+		bundle := bundleMap[e.component.Name]
+		for _, dep := range bundle.DependsOn {
+			if depName, ok := bundleToName[dep]; ok {
+				graph[e.component.Name] = append(graph[e.component.Name], depName)
+			}
+		}
+	}
+
+	return detectCycles(graph)
+}
+
+// detectCycles checks for circular dependencies in a string-keyed graph using DFS.
+func detectCycles(deps map[string][]string) error {
+	const (
+		unvisited = 0
+		visiting  = 1
+		visited   = 2
+	)
+
+	state := make(map[string]int)
+
+	var visit func(node string, path []string) error
+	visit = func(node string, path []string) error {
+		if state[node] == visited {
+			return nil
+		}
+		if state[node] == visiting {
+			return fmt.Errorf("circular dependency: %v -> %s", path, node)
+		}
+		state[node] = visiting
+		path = append(path, node)
+		for _, dep := range deps[node] {
+			if err := visit(dep, path); err != nil {
+				return err
+			}
+		}
+		state[node] = visited
+		return nil
+	}
+
+	for node := range deps {
+		if state[node] == unvisited {
+			if err := visit(node, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// componentHealthCheckGVK maps OAM component types to their primary workload GVK.
+// Types not listed (e.g. cronjob) are skipped — their resources are ephemeral.
+var componentHealthCheckGVK = map[string]struct{ APIVersion, Kind string }{
+	"webservice":  {"apps/v1", "Deployment"},
+	"worker":      {"apps/v1", "Deployment"},
+	"statefulset": {"apps/v1", "StatefulSet"},
+	"daemonset":   {"apps/v1", "DaemonSet"},
+	"helmrelease": {"helm.toolkit.fluxcd.io/v2", "HelmRelease"},
+	"postgresql":  {"postgresql.cnpg.io/v1", "Cluster"},
+}
+
+// applyAutoHealthChecks walks all leaf bundles and appends inferred health check
+// references based on each component's type, followed by any explicit overrides.
+func applyAutoHealthChecks(cluster *stack.Cluster, componentMap map[string]componentEntry, overrides []stack.HealthCheck) {
+	if cluster == nil {
+		return
+	}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		for _, app := range bundle.Applications {
+			entry, ok := componentMap[app.Name]
+			if !ok {
+				continue
+			}
+			gvk, ok := componentHealthCheckGVK[entry.component.Type]
+			if !ok {
+				continue
+			}
+			bundle.HealthChecks = append(bundle.HealthChecks, stack.HealthCheck{
+				APIVersion: gvk.APIVersion,
+				Kind:       gvk.Kind,
+				Name:       app.Name,
+				Namespace:  app.Namespace,
+			})
+		}
+		bundle.HealthChecks = append(bundle.HealthChecks, overrides...)
+	})
+}
+
+// applyReconciliationSettings applies Flux reconciliation overrides from a
+// reconciliation policy to all leaf bundles.
+func applyReconciliationSettings(cluster *stack.Cluster, _ map[string]componentEntry, settings *ReconciliationSettings) {
+	if cluster == nil || settings == nil {
+		return
+	}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		if settings.Interval != "" {
+			bundle.Interval = settings.Interval
+		}
+		if settings.RetryInterval != "" {
+			bundle.RetryInterval = settings.RetryInterval
+		}
+		if settings.Timeout != "" {
+			bundle.Timeout = settings.Timeout
+		}
+		if settings.Prune != nil {
+			bundle.Prune = settings.Prune
+		}
+		if settings.Wait != nil {
+			bundle.Wait = settings.Wait
+		}
+		if settings.Force != nil {
+			bundle.Force = settings.Force
+		}
+		if settings.Suspend != nil {
+			bundle.Suspend = settings.Suspend
+		}
+	})
+}
+
+// walkLeafBundles calls fn for every leaf bundle reachable from node.
+func walkLeafBundles(node *stack.Node, fn func(*stack.Bundle)) {
+	if node == nil {
+		return
+	}
+	if node.Bundle != nil {
+		walkLeafBundle(node.Bundle, fn)
+	}
+	for _, child := range node.Children {
+		walkLeafBundles(child, fn)
+	}
+}
+
+func walkLeafBundle(bundle *stack.Bundle, fn func(*stack.Bundle)) {
+	if bundle == nil {
+		return
+	}
+	if !bundle.IsUmbrella() {
+		fn(bundle)
+		return
+	}
+	for _, child := range bundle.Children {
+		walkLeafBundle(child, fn)
+	}
+}
+
+// deepCopyMap returns a deep copy of a map[string]any via JSON round-trip.
+func deepCopyMap(src map[string]any) (map[string]any, error) {
+	data, err := json.Marshal(src)
+	if err != nil {
+		return nil, err
+	}
+	var dst map[string]any
+	if err := json.Unmarshal(data, &dst); err != nil {
+		return nil, err
+	}
+	return dst, nil
 }

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -500,6 +500,79 @@ func TestTransform_NilPolicyNormalized(t *testing.T) {
 	}
 }
 
+// constrainedPolicy is a Policy stub with configurable capability constraints.
+type constrainedPolicy struct {
+	NoopPolicy
+	forbidden []string
+	allowed   []string
+	required  []string
+}
+
+func (p *constrainedPolicy) ForbiddenCapabilities() []string { return p.forbidden }
+func (p *constrainedPolicy) AllowedCapabilities() []string   { return p.allowed }
+func (p *constrainedPolicy) RequiredCapabilities() []string  { return p.required }
+
+func TestTransform_CapabilityConstraint_Forbidden(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		map[string]TraitHandler{"expose": &stubTraitHandler{typ: "expose"}},
+	)
+	comp := Component{
+		Name:   "web",
+		Type:   "webservice",
+		Traits: []Trait{{Type: "expose", Properties: map[string]any{}}},
+	}
+	app := makeApp("myapp", comp)
+	policy := &constrainedPolicy{forbidden: []string{"expose"}}
+	_, err := tr.Transform(app, TransformContext{Policy: policy})
+	if err == nil {
+		t.Fatal("expected ViolationError for forbidden capability")
+	}
+	var ve *ViolationError
+	if !errors.As(err, &ve) {
+		t.Errorf("expected ViolationError, got %T: %v", err, err)
+	}
+}
+
+func TestTransform_CapabilityConstraint_NotInAllowedList(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		map[string]TraitHandler{"expose": &stubTraitHandler{typ: "expose"}},
+	)
+	comp := Component{
+		Name:   "web",
+		Type:   "webservice",
+		Traits: []Trait{{Type: "expose", Properties: map[string]any{}}},
+	}
+	app := makeApp("myapp", comp)
+	policy := &constrainedPolicy{allowed: []string{"ingress"}} // "expose" not in list
+	_, err := tr.Transform(app, TransformContext{Policy: policy})
+	if err == nil {
+		t.Fatal("expected ViolationError for capability not in allowed list")
+	}
+	var ve *ViolationError
+	if !errors.As(err, &ve) {
+		t.Errorf("expected ViolationError, got %T: %v", err, err)
+	}
+}
+
+func TestTransform_CapabilityConstraint_RequiredMissing(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		nil,
+	)
+	app := makeApp("myapp", makeComponent("web", "webservice")) // no traits
+	policy := &constrainedPolicy{required: []string{"ingress"}}
+	_, err := tr.Transform(app, TransformContext{Policy: policy})
+	if err == nil {
+		t.Fatal("expected ViolationError for missing required capability")
+	}
+	var ve *ViolationError
+	if !errors.As(err, &ve) {
+		t.Errorf("expected ViolationError, got %T: %v", err, err)
+	}
+}
+
 // --- find* with no match ---
 
 func TestTransformer_FindHandler_NoMatch(t *testing.T) {

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -1,7 +1,10 @@
 package oam
 
 import (
+	"errors"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/kure/pkg/stack"
 )
@@ -42,6 +45,81 @@ type stubPolicyHandler struct{ typ string }
 func (h *stubPolicyHandler) CanHandle(t string) bool { return t == h.typ }
 func (h *stubPolicyHandler) Apply(_ *ApplicationPolicy, _ []string, _ *PolicyResult) error {
 	return nil
+}
+
+// --- pipeline stubs ---
+
+// stubAppConfig is a minimal ApplicationConfig that generates nothing.
+type stubAppConfig struct{}
+
+func (s *stubAppConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+
+// pipelineComponentHandler returns a real (non-nil) stubAppConfig.
+type pipelineComponentHandler struct{ typ string }
+
+func (h *pipelineComponentHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *pipelineComponentHandler) ToApplicationConfig(_ *Component, _ string) (stack.ApplicationConfig, error) {
+	return &stubAppConfig{}, nil
+}
+
+// enforcingConfig implements ApplicationConfig and Enforceable; fails when failPolicy is set.
+type enforcingConfig struct {
+	failPolicy bool
+}
+
+func (e *enforcingConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+func (e *enforcingConfig) ApplyPolicy(_ Policy) error {
+	if e.failPolicy {
+		return errors.New("policy violation")
+	}
+	return nil
+}
+
+// enforcingComponentHandler returns an enforcingConfig.
+type enforcingComponentHandler struct {
+	typ        string
+	failPolicy bool
+}
+
+func (h *enforcingComponentHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *enforcingComponentHandler) ToApplicationConfig(_ *Component, _ string) (stack.ApplicationConfig, error) {
+	return &enforcingConfig{failPolicy: h.failPolicy}, nil
+}
+
+// capAwarePipelineHandler is a CapabilityAware+ValidateAndApplyDefaults trait handler.
+type capAwarePipelineHandler struct{ typ string }
+
+func (h *capAwarePipelineHandler) CanHandle(t string) bool  { return t == h.typ }
+func (h *capAwarePipelineHandler) CapabilityRequired() bool { return true }
+func (h *capAwarePipelineHandler) Apply(_ *Trait, _ *stack.Application, _ *stack.Bundle) error {
+	return nil
+}
+func (h *capAwarePipelineHandler) ValidateAndApplyDefaults(r map[string]any) (map[string]any, error) {
+	return r, nil
+}
+
+// depWritingPolicyHandler writes a dependency into PolicyResult.
+type depWritingPolicyHandler struct {
+	from, to string
+}
+
+func (h *depWritingPolicyHandler) CanHandle(t string) bool { return t == "dependency" }
+func (h *depWritingPolicyHandler) Apply(_ *ApplicationPolicy, _ []string, result *PolicyResult) error {
+	result.Dependencies[h.from] = append(result.Dependencies[h.from], h.to)
+	return nil
+}
+
+// makeApp builds a minimal Application for pipeline tests.
+func makeApp(name string, components ...Component) *Application {
+	return &Application{
+		Metadata: Metadata{Name: name, Namespace: "test"},
+		Spec:     ApplicationSpec{Components: components},
+	}
+}
+
+// makeComponent builds a Component with the given name and type.
+func makeComponent(name, typ string) Component {
+	return Component{Name: name, Type: typ}
 }
 
 // mustPanic asserts that f panics.
@@ -190,6 +268,236 @@ func TestTransformer_RegisterPolicy_PanicsOnCanHandleMismatch(t *testing.T) {
 	mustPanic(t, func() {
 		tr.RegisterPolicy("dependency", &stubPolicyHandler{typ: "placement"})
 	})
+}
+
+// --- Pipeline: resolveCapability / buildCapabilityKey ---
+
+func TestResolveCapability_NoCapabilities(t *testing.T) {
+	trait := Trait{Type: "expose", Properties: map[string]any{"port": 80}}
+	got := resolveCapability(trait, nil)
+	if got.Properties["port"] != 80 {
+		t.Errorf("expected port 80, got %v", got.Properties["port"])
+	}
+	if len(got.Properties) != 1 {
+		t.Errorf("expected 1 property, got %d", len(got.Properties))
+	}
+}
+
+func TestResolveCapability_MergesRendering(t *testing.T) {
+	caps := map[string]CapabilityBinding{
+		"ingress": {Rendering: map[string]any{"host": "example.com", "tls": true}},
+	}
+	// OAM inline value takes precedence.
+	trait := Trait{Type: "ingress", Properties: map[string]any{"host": "override.com"}}
+	got := resolveCapability(trait, caps)
+	if got.Properties["host"] != "override.com" {
+		t.Errorf("expected OAM value to win: got %v", got.Properties["host"])
+	}
+	if got.Properties["tls"] != true {
+		t.Errorf("expected rendering value to be merged: got %v", got.Properties["tls"])
+	}
+}
+
+func TestBuildCapabilityKey_Scoped(t *testing.T) {
+	trait := Trait{Type: "ingress", Properties: map[string]any{"scope": "internal"}}
+	if got := buildCapabilityKey(trait); got != "ingress.internal" {
+		t.Errorf("buildCapabilityKey = %q, want %q", got, "ingress.internal")
+	}
+}
+
+func TestBuildCapabilityKey_Bare(t *testing.T) {
+	trait := Trait{Type: "ingress", Properties: map[string]any{}}
+	if got := buildCapabilityKey(trait); got != "ingress" {
+		t.Errorf("buildCapabilityKey = %q, want %q", got, "ingress")
+	}
+}
+
+// --- Pipeline: Transform / TransformWithPolicy ---
+
+func TestTransform_SingleComponent_Flat(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		nil,
+	)
+	app := makeApp("myapp", makeComponent("web", "webservice"))
+	cluster, err := tr.Transform(app, TransformContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cluster == nil {
+		t.Fatal("expected non-nil cluster")
+	}
+	if cluster.Node == nil || cluster.Node.Bundle == nil {
+		t.Fatal("expected flat cluster with root bundle")
+	}
+	if len(cluster.Node.Bundle.Applications) != 1 {
+		t.Errorf("expected 1 application in bundle, got %d", len(cluster.Node.Bundle.Applications))
+	}
+}
+
+func TestTransform_MultiTier_Hierarchical(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{
+			"webservice": &pipelineComponentHandler{typ: "webservice"},
+			"daemonset":  &pipelineComponentHandler{typ: "daemonset"},
+		},
+		nil,
+	)
+	app := makeApp("myapp",
+		makeComponent("web", "webservice"), // TierApps
+		makeComponent("log", "daemonset"),  // TierInfra
+	)
+	cluster, err := tr.Transform(app, TransformContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cluster.Node == nil || cluster.Node.Bundle == nil {
+		t.Fatal("expected umbrella bundle at root")
+	}
+	if !cluster.Node.Bundle.IsUmbrella() {
+		t.Error("expected umbrella bundle for multi-tier app")
+	}
+	if len(cluster.Node.Bundle.Children) != 2 {
+		t.Errorf("expected 2 tier children, got %d", len(cluster.Node.Bundle.Children))
+	}
+}
+
+func TestTransform_DependencyPolicy_PerComponentBundles(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{
+			"webservice": &pipelineComponentHandler{typ: "webservice"},
+			"postgresql": &pipelineComponentHandler{typ: "postgresql"},
+		},
+		nil,
+	)
+	tr.RegisterPolicy("dependency", &depWritingPolicyHandler{from: "web", to: "db"})
+
+	app := &Application{
+		Metadata: Metadata{Name: "myapp", Namespace: "test"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				makeComponent("web", "webservice"),
+				makeComponent("db", "postgresql"),
+			},
+			Policies: []ApplicationPolicy{
+				{Name: "order", Type: "dependency"},
+			},
+		},
+	}
+	cluster, result, err := tr.TransformWithPolicy(app, TransformContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.HasDependencies() {
+		t.Error("expected PolicyResult to have dependencies")
+	}
+	// Per-component cluster: root node has children (one per component).
+	if cluster.Node == nil {
+		t.Fatal("expected non-nil root node")
+	}
+	if len(cluster.Node.Children) != 2 {
+		t.Errorf("expected 2 component nodes, got %d", len(cluster.Node.Children))
+	}
+}
+
+func TestTransform_NoComponentHandler(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	app := makeApp("myapp", makeComponent("web", "webservice"))
+	_, err := tr.Transform(app, TransformContext{})
+	if err == nil {
+		t.Fatal("expected error for missing handler")
+	}
+	var te *TransformError
+	if !errors.As(err, &te) {
+		t.Errorf("expected TransformError, got %T: %v", err, err)
+	}
+}
+
+func TestTransform_NoTraitHandler(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		nil,
+	)
+	comp := Component{
+		Name:   "web",
+		Type:   "webservice",
+		Traits: []Trait{{Type: "expose", Properties: map[string]any{}}},
+	}
+	app := makeApp("myapp", comp)
+	_, err := tr.Transform(app, TransformContext{})
+	if err == nil {
+		t.Fatal("expected error for missing trait handler")
+	}
+	var te *TransformError
+	if !errors.As(err, &te) {
+		t.Errorf("expected TransformError, got %T: %v", err, err)
+	}
+}
+
+func TestTransform_CapabilityMissing(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		map[string]TraitHandler{"ingress": &capAwarePipelineHandler{typ: "ingress"}},
+	)
+	comp := Component{
+		Name:   "web",
+		Type:   "webservice",
+		Traits: []Trait{{Type: "ingress", Properties: map[string]any{}}},
+	}
+	app := makeApp("myapp", comp)
+	_, err := tr.Transform(app, TransformContext{}) // no capabilities
+	if err == nil {
+		t.Fatal("expected error for missing capability")
+	}
+	if !errors.Is(err, ErrMissingCapability) {
+		t.Errorf("expected ErrMissingCapability in chain, got: %v", err)
+	}
+}
+
+func TestTransform_PolicyViolation(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{
+			"webservice": &enforcingComponentHandler{typ: "webservice", failPolicy: true},
+		},
+		nil,
+	)
+	app := makeApp("myapp", makeComponent("web", "webservice"))
+	_, err := tr.Transform(app, TransformContext{})
+	if err == nil {
+		t.Fatal("expected ViolationError")
+	}
+	var ve *ViolationError
+	if !errors.As(err, &ve) {
+		t.Errorf("expected ViolationError, got %T: %v", err, err)
+	}
+}
+
+func TestTransformWithPolicy_ReturnsPolicyResult(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		nil,
+	)
+	app := makeApp("myapp", makeComponent("web", "webservice"))
+	_, result, err := tr.TransformWithPolicy(app, TransformContext{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil PolicyResult")
+	}
+}
+
+func TestTransform_NilPolicyNormalized(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"webservice": &pipelineComponentHandler{typ: "webservice"}},
+		nil,
+	)
+	app := makeApp("myapp", makeComponent("web", "webservice"))
+	// nil Policy must not panic — normalized to NoopPolicy.
+	_, err := tr.Transform(app, TransformContext{Policy: nil})
+	if err != nil {
+		t.Fatalf("unexpected error with nil policy: %v", err)
+	}
 }
 
 // --- find* with no match ---


### PR DESCRIPTION
## Summary

- Adds `Transform` and `TransformWithPolicy` to `Transformer`, implementing the full 4-phase pipeline: create applications → apply policies → build cluster (flat/hierarchical/dependency-aware) → post-build decorations
- `ctx.Policy` is normalized to `&NoopPolicy{}` if nil at the start of both entry points, enforcing the contract that handlers always receive a non-nil `Policy`
- `pkg/oam/errors.go` — `TransformError{Message, Cause}` and `ErrMissingCapability` sentinel
- `pkg/oam/classify.go` — `ClassifyComponent`, `defaultTierMap`, `TierAnnotation = "wharf.zone/tier"`, `groupByTier`
- Capability key resolution: scoped (`"<type>.<scope>"`) → bare (`"<type>"`); no `.default` intermediate (per design-cluster-profile.md)
- No namespace bundle, no label generation, no `wrapBundleConfigs` — all crane-specific concerns

## Test plan

- `TestClassifyComponent_*` — annotation override, invalid annotation, defaultTierMap lookup, fallback to TierApps
- `TestTransform_SingleComponent_Flat` — one component → flat cluster
- `TestTransform_MultiTier_Hierarchical` — webservice + daemonset → umbrella cluster with 2 tier children
- `TestTransform_DependencyPolicy_PerComponentBundles` — stub PolicyHandler writes Dependencies → per-component bundles
- `TestTransform_NoComponentHandler` / `TestTransform_NoTraitHandler` — TransformError returned
- `TestTransform_CapabilityMissing` — ErrMissingCapability in error chain
- `TestTransform_PolicyViolation` — ViolationError returned
- `TestTransform_NilPolicyNormalized` — nil Policy does not panic
- `TestResolveCapability_*` / `TestBuildCapabilityKey_*` — unit tests for helpers
- All 50 pkg/oam tests pass; coverage 84.7%

Closes #53