### PR TITLE
feat(kurel): add build command — OAM vertical slice (#55)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/avast/retry-go/v5 v5.0.0 // indirect
 	github.com/backube/volsync v0.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -87,6 +88,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
+	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -138,6 +140,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
+	k8s.io/cli-runtime v0.36.0 // indirect
 	k8s.io/client-go v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/Buvy
 github.com/controlplaneio-fluxcd/flux-operator v0.40.0 h1:LoUtsOagXI7nVpg6uhKzA/gWgcmvssy/7B2UKRPF5X0=
 github.com/controlplaneio-fluxcd/flux-operator v0.40.0/go.mod h1:ySL10hW+IdcUH3Ej5v3RFenzebJrMgmaM1XGrjc8sRk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/cyphar/filepath-securejoin v0.6.1 h1:5CeZ1jPXEiYt3+Z6zqprSAgSWiggmpVyciv8syjIpVE=
 github.com/cyphar/filepath-securejoin v0.6.1/go.mod h1:A8hd4EnAeyujCJRrICiOWqjS1AX0a9kM5XL+NwKoYSc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -326,6 +328,7 @@ golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.42.0 h1:UiKe+zDFmJobeJ5ggPwOshJIVt6/Ft0rcfrXZDLWAWY=

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -1,0 +1,176 @@
+package kurel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kio "github.com/go-kure/kure/pkg/io"
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+type buildOptions struct {
+	profilePath string
+	outputDir   string
+	namespace   string
+	clusterID   string
+}
+
+func newBuildCommand() *cobra.Command {
+	opts := &buildOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "build <app.yaml>",
+		Short: "Build Kubernetes manifests from an OAM Application",
+		Long: `Build generates static Kubernetes manifests from an OAM Application YAML file
+and a platform ClusterProfile. Output is written to stdout (default) or a directory.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runBuild(cmd, args[0], opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.profilePath, "profile", "", "path to ClusterProfile YAML (required)")
+	cmd.Flags().StringVarP(&opts.outputDir, "output", "o", "", "output directory (default: stdout)")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "namespace override")
+	cmd.Flags().StringVar(&opts.clusterID, "cluster-id", "local", "cluster identifier")
+
+	_ = cmd.MarkFlagRequired("profile")
+
+	return cmd
+}
+
+func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
+	appData, err := os.ReadFile(appPath)
+	if err != nil {
+		return errors.Wrapf(err, "reading application file %q", appPath)
+	}
+
+	app, err := oam.Parse(appData)
+	if err != nil {
+		return errors.Wrapf(err, "parsing application file %q", appPath)
+	}
+
+	profileData, err := os.ReadFile(opts.profilePath)
+	if err != nil {
+		return errors.Wrapf(err, "reading profile file %q", opts.profilePath)
+	}
+
+	var profile oam.ClusterProfile
+	if err := yaml.Unmarshal(profileData, &profile); err != nil {
+		return errors.Wrapf(err, "parsing profile file %q", opts.profilePath)
+	}
+
+	transformer := newBuiltinTransformer()
+
+	ctx := oam.TransformContext{
+		ClusterID:    opts.clusterID,
+		Namespace:    opts.namespace,
+		Capabilities: profile.Spec.Capabilities,
+	}
+
+	cluster, err := transformer.Transform(app, ctx)
+	if err != nil {
+		return errors.Wrap(err, "transforming application")
+	}
+
+	objects, err := collectFromNode(cluster.Node)
+	if err != nil {
+		return errors.Wrap(err, "generating manifests")
+	}
+
+	if len(objects) == 0 {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning: no resources generated")
+		return nil
+	}
+
+	yamlBytes, err := kio.EncodeObjectsToYAML(objects)
+	if err != nil {
+		return errors.Wrap(err, "encoding YAML output")
+	}
+
+	if opts.outputDir == "" {
+		_, err = cmd.OutOrStdout().Write(yamlBytes)
+		return errors.Wrap(err, "writing to stdout")
+	}
+
+	return writeOutputDir(opts.outputDir, app.Metadata.Name, yamlBytes)
+}
+
+// newBuiltinTransformer creates a Transformer pre-loaded with the supported
+// built-in handlers for this vertical slice (webservice, expose, ingress).
+func newBuiltinTransformer() *oam.Transformer {
+	return oam.NewTransformer(
+		map[string]oam.ComponentHandler{
+			"webservice": &components.WebserviceHandler{},
+		},
+		map[string]oam.TraitHandler{
+			"expose":  &traits.ExposeHandler{},
+			"ingress": &traits.IngressHandler{}, //nolint:staticcheck
+		},
+	)
+}
+
+// collectFromNode walks the node tree and collects all generated client.Objects
+// from leaf bundles.
+func collectFromNode(node *stack.Node) ([]*client.Object, error) {
+	if node == nil {
+		return nil, nil
+	}
+	var all []*client.Object
+	if node.Bundle != nil {
+		objs, err := collectFromBundle(node.Bundle)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, objs...)
+	}
+	for _, child := range node.Children {
+		objs, err := collectFromNode(child)
+		if err != nil {
+			return nil, err
+		}
+		all = append(all, objs...)
+	}
+	return all, nil
+}
+
+// collectFromBundle collects generated objects from a bundle.
+// Umbrella bundles are recursed; leaf bundles are generated directly.
+func collectFromBundle(bundle *stack.Bundle) ([]*client.Object, error) {
+	if bundle == nil {
+		return nil, nil
+	}
+	if bundle.IsUmbrella() {
+		var all []*client.Object
+		for _, child := range bundle.Children {
+			objs, err := collectFromBundle(child)
+			if err != nil {
+				return nil, err
+			}
+			all = append(all, objs...)
+		}
+		return all, nil
+	}
+	return bundle.Generate()
+}
+
+func writeOutputDir(dir, appName string, data []byte) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return errors.Wrapf(err, "creating output directory %q", dir)
+	}
+	outPath := filepath.Join(dir, appName+".yaml")
+	if err := os.WriteFile(outPath, data, 0644); err != nil {
+		return errors.Wrapf(err, "writing output file %q", outPath)
+	}
+	return nil
+}

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kio "github.com/go-kure/kure/pkg/io"
@@ -65,14 +64,14 @@ func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
 		return errors.Wrapf(err, "reading profile file %q", opts.profilePath)
 	}
 
-	var profile oam.ClusterProfile
-	if err := yaml.Unmarshal(profileData, &profile); err != nil {
+	profile, err := oam.ParseClusterProfile(profileData)
+	if err != nil {
 		return errors.Wrapf(err, "parsing profile file %q", opts.profilePath)
 	}
 
 	transformer := newBuiltinTransformer()
 
-	evaluatedProfile, err := transformer.EvaluateProfile(&profile)
+	evaluatedProfile, err := transformer.EvaluateProfile(profile)
 	if err != nil {
 		return errors.Wrapf(err, "evaluating profile %q", opts.profilePath)
 	}

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -72,10 +72,15 @@ func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
 
 	transformer := newBuiltinTransformer()
 
+	evaluatedProfile, err := transformer.EvaluateProfile(&profile)
+	if err != nil {
+		return errors.Wrapf(err, "evaluating profile %q", opts.profilePath)
+	}
+
 	ctx := oam.TransformContext{
 		ClusterID:    opts.clusterID,
 		Namespace:    opts.namespace,
-		Capabilities: profile.Spec.Capabilities,
+		Capabilities: evaluatedProfile.Spec.Capabilities,
 	}
 
 	cluster, err := transformer.Transform(app, ctx)

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -207,6 +207,36 @@ func TestBuildCommand_NamespaceOverride(t *testing.T) {
 	}
 }
 
+func TestBuildCommand_StaleProfileField_Rejected(t *testing.T) {
+	const staleCraneProfile = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: stale-cluster
+spec:
+  gitops:
+    url: https://git.example.com
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+`
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", staleCraneProfile)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for stale crane field spec.gitops in cluster.yaml")
+	}
+}
+
 func TestBuildCommand_IsRegistered(t *testing.T) {
 	cmd := NewKurelCommand()
 	var found bool

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -1,0 +1,229 @@
+package kurel
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testAppYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+      traits:
+        - type: expose
+          properties:
+            controllerType: ingress
+            rules:
+              - host: frontend.example.com
+                paths:
+                  - path: /
+`
+
+const testClusterYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+`
+
+func writeTempFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writeTempFile %s: %v", name, err)
+	}
+	return path
+}
+
+func TestBuildCommand_StdoutOutput(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build command failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if got == "" {
+		t.Fatal("expected non-empty YAML output")
+	}
+	if !strings.Contains(got, "apiVersion") {
+		t.Errorf("expected YAML output to contain 'apiVersion', got:\n%s", got)
+	}
+	if !strings.Contains(got, "Deployment") {
+		t.Errorf("expected output to contain 'Deployment' for webservice component, got:\n%s", got)
+	}
+}
+
+func TestBuildCommand_OutputDir(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	outDir := filepath.Join(dir, "manifests")
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath, "--output", outDir})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build command failed: %v\noutput: %s", err, out.String())
+	}
+
+	outFile := filepath.Join(outDir, "my-app.yaml")
+	if _, err := os.Stat(outFile); os.IsNotExist(err) {
+		t.Errorf("expected output file %q to exist", outFile)
+	}
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("reading output file: %v", err)
+	}
+	if !strings.Contains(string(data), "apiVersion") {
+		t.Errorf("expected output file to contain YAML, got:\n%s", data)
+	}
+}
+
+func TestBuildCommand_MissingProfileFlag(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when --profile is missing")
+	}
+}
+
+func TestBuildCommand_MissingAppFile(t *testing.T) {
+	dir := t.TempDir()
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", "/nonexistent/app.yaml", "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for missing app file")
+	}
+}
+
+func TestBuildCommand_InvalidAppYAML(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", "not: valid: oam: yaml: here")
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for invalid app YAML")
+	}
+}
+
+func TestBuildCommand_UnsupportedComponentType(t *testing.T) {
+	const workerApp = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-worker
+  namespace: default
+spec:
+  components:
+    - name: backend
+      type: worker
+      properties:
+        image: ghcr.io/example/worker:v1.0.0
+`
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", workerApp)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unsupported component type 'worker'")
+	}
+}
+
+func TestBuildCommand_NamespaceOverride(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath, "--namespace", "production"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build with namespace override failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "production") {
+		t.Errorf("expected 'production' namespace in output, got:\n%s", got)
+	}
+}
+
+func TestBuildCommand_IsRegistered(t *testing.T) {
+	cmd := NewKurelCommand()
+	var found bool
+	for _, sub := range cmd.Commands() {
+		if extractCommandName(sub.Use) == "build" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'build' subcommand to be registered")
+	}
+}
+
+func TestNewBuiltinTransformer_Registered(t *testing.T) {
+	transformer := newBuiltinTransformer()
+	if transformer == nil {
+		t.Fatal("expected non-nil transformer")
+	}
+}

--- a/pkg/cmd/kurel/cmd.go
+++ b/pkg/cmd/kurel/cmd.go
@@ -35,6 +35,7 @@ static, GitOps-ready Kubernetes manifests.`,
 	shared.InitConfig("kurel", globalOpts)
 
 	cmd.AddCommand(
+		newBuildCommand(),
 		newConfigCommand(globalOpts),
 		shared.NewCompletionCommand(),
 		shared.NewVersionCommand("kurel"),

--- a/pkg/cmd/kurel/cmd_test.go
+++ b/pkg/cmd/kurel/cmd_test.go
@@ -43,7 +43,7 @@ func TestNewKurelCommand(t *testing.T) {
 func TestKurelCommandSubcommands(t *testing.T) {
 	cmd := NewKurelCommand()
 
-	expectedSubcommands := []string{"config", "completion", "version"}
+	expectedSubcommands := []string{"build", "config", "completion", "version"}
 
 	commandMap := make(map[string]bool)
 	for _, subCmd := range cmd.Commands() {

--- a/pkg/cmd/kurel/testdata/app.yaml
+++ b/pkg/cmd/kurel/testdata/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+      traits:
+        - type: expose
+          properties:
+            controllerType: ingress
+            rules:
+              - host: frontend.example.com
+                paths:
+                  - path: /

--- a/pkg/cmd/kurel/testdata/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx

--- a/pkg/oam/profile.go
+++ b/pkg/oam/profile.go
@@ -1,5 +1,13 @@
 package oam
 
+import (
+	"bytes"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
 // ClusterProfile encodes per-cluster capability bindings for the launcher runtime.
 // It is a YAML document with apiVersion launcher.gokure.dev/v1alpha1, kind ClusterProfile.
 //
@@ -30,4 +38,18 @@ type ClusterProfileSpec struct {
 // See docs/oam/design-cluster-profile.md §2 and docs/oam/design-capability-schema.md §3.6.
 type CapabilityBinding struct {
 	Rendering map[string]any `yaml:"rendering,omitempty" json:"rendering,omitempty"`
+}
+
+// ParseClusterProfile parses a ClusterProfile YAML document in strict mode.
+// Unknown fields are rejected so that stale crane fields (spec.gitops, etc.),
+// metadata fields outside the launcher schema, and typos in the profile
+// structure all fail the build with a clear error.
+func ParseClusterProfile(data []byte) (*ClusterProfile, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	var profile ClusterProfile
+	if err := dec.Decode(&profile); err != nil {
+		return nil, errors.Wrap(err, "parsing ClusterProfile")
+	}
+	return &profile, nil
 }

--- a/pkg/oam/profile.go
+++ b/pkg/oam/profile.go
@@ -51,5 +51,8 @@ func ParseClusterProfile(data []byte) (*ClusterProfile, error) {
 	if err := dec.Decode(&profile); err != nil {
 		return nil, errors.Wrap(err, "parsing ClusterProfile")
 	}
+	if err := validateClusterProfile(&profile); err != nil {
+		return nil, err
+	}
 	return &profile, nil
 }

--- a/pkg/oam/profile_test.go
+++ b/pkg/oam/profile_test.go
@@ -1,0 +1,92 @@
+package oam
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseClusterProfile_Valid(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+`)
+	got, err := ParseClusterProfile(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Metadata.Name != "test-cluster" {
+		t.Errorf("expected name 'test-cluster', got %q", got.Metadata.Name)
+	}
+	cap, ok := got.Spec.Capabilities["expose"]
+	if !ok {
+		t.Fatal("expected 'expose' capability")
+	}
+	if cap.Rendering["controllerType"] != "ingress" {
+		t.Errorf("expected controllerType 'ingress', got %v", cap.Rendering["controllerType"])
+	}
+}
+
+func TestParseClusterProfile_UnknownTopLevelField(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  gitops:
+    url: https://example.com
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for unknown field spec.gitops")
+	}
+	if !strings.Contains(err.Error(), "gitops") {
+		t.Errorf("expected error to mention 'gitops', got: %v", err)
+	}
+}
+
+func TestParseClusterProfile_UnknownMetadataField(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+  labels:
+    app: test
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for unknown metadata field 'labels'")
+	}
+}
+
+func TestParseClusterProfile_EmptyCapabilities(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: minimal
+`)
+	got, err := ParseClusterProfile(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got.Spec.Capabilities) != 0 {
+		t.Errorf("expected no capabilities, got %d", len(got.Spec.Capabilities))
+	}
+}
+
+func TestParseClusterProfile_InvalidYAML(t *testing.T) {
+	_, err := ParseClusterProfile([]byte("not: valid: yaml: ["))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML")
+	}
+}

--- a/pkg/oam/profile_test.go
+++ b/pkg/oam/profile_test.go
@@ -90,3 +90,64 @@ func TestParseClusterProfile_InvalidYAML(t *testing.T) {
 		t.Fatal("expected error for invalid YAML")
 	}
 }
+
+func TestParseClusterProfile_WrongAPIVersion(t *testing.T) {
+	data := []byte(`
+apiVersion: core.oam.dev/v1beta1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for wrong apiVersion")
+	}
+	if !strings.Contains(err.Error(), "apiVersion") {
+		t.Errorf("expected error to mention 'apiVersion', got: %v", err)
+	}
+}
+
+func TestParseClusterProfile_WrongKind(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-cluster
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for wrong kind")
+	}
+	if !strings.Contains(err.Error(), "kind") {
+		t.Errorf("expected error to mention 'kind', got: %v", err)
+	}
+}
+
+func TestParseClusterProfile_MissingName(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: ""
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for missing metadata.name")
+	}
+	if !strings.Contains(err.Error(), "metadata.name") {
+		t.Errorf("expected error to mention 'metadata.name', got: %v", err)
+	}
+}
+
+func TestParseClusterProfile_InvalidName(t *testing.T) {
+	data := []byte(`
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: "Not A Valid DNS Name!"
+`)
+	_, err := ParseClusterProfile(data)
+	if err == nil {
+		t.Fatal("expected error for invalid DNS name")
+	}
+}

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/go-kure/kure/pkg/stack"
 )
@@ -99,6 +100,46 @@ func (t *Transformer) RegisterPolicy(typeName string, h PolicyHandler) {
 		panic("oam: policy handler does not claim type " + typeName)
 	}
 	t.policyHandlers[typeName] = h
+}
+
+// EvaluateProfile validates and applies defaults to all capability renderings in
+// the ClusterProfile. For each capability key whose trait type matches a registered
+// handler that implements ValidateAndApplyDefaults, the rendering map is passed
+// through that handler's VAD method. Returns a new ClusterProfile with updated
+// renderings, or a TransformError wrapping the first validation failure.
+//
+// Capability keys follow the "<type>" or "<type>.<scope>" convention. EvaluateProfile
+// must be called before Transform so that malformed profile renderings are caught at
+// load time rather than silently propagated into the pipeline.
+func (t *Transformer) EvaluateProfile(profile *ClusterProfile) (*ClusterProfile, error) {
+	if profile == nil {
+		return nil, nil
+	}
+	if len(profile.Spec.Capabilities) == 0 {
+		return profile, nil
+	}
+	evaluated := make(map[string]CapabilityBinding, len(profile.Spec.Capabilities))
+	for key, binding := range profile.Spec.Capabilities {
+		typeName, _, _ := strings.Cut(key, ".")
+		handler, ok := t.traitHandlers[typeName]
+		if !ok {
+			evaluated[key] = binding
+			continue
+		}
+		vad, ok := handler.(ValidateAndApplyDefaults)
+		if !ok {
+			evaluated[key] = binding
+			continue
+		}
+		validated, err := vad.ValidateAndApplyDefaults(binding.Rendering)
+		if err != nil {
+			return nil, &TransformError{Message: fmt.Sprintf("capability %q", key), Cause: err}
+		}
+		evaluated[key] = CapabilityBinding{Rendering: validated}
+	}
+	result := *profile
+	result.Spec = ClusterProfileSpec{Capabilities: evaluated}
+	return &result, nil
 }
 
 func (t *Transformer) findComponentHandler(componentType string) ComponentHandler {

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -587,3 +587,145 @@ func TestTransformer_FindHandler_NoMatch(t *testing.T) {
 		t.Errorf("findPolicyHandler(unknown) = %v, want nil", got)
 	}
 }
+
+// --- EvaluateProfile ---
+
+type errVADHandler struct {
+	stubTraitHandler
+	err error
+	out map[string]any
+}
+
+func (h *errVADHandler) CapabilityRequired() bool { return true }
+func (h *errVADHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if h.err != nil {
+		return nil, h.err
+	}
+	if h.out != nil {
+		return h.out, nil
+	}
+	return rendering, nil
+}
+
+func TestEvaluateProfile_NilProfile(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	got, err := tr.EvaluateProfile(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil for nil profile, got %v", got)
+	}
+}
+
+func TestEvaluateProfile_EmptyCapabilities(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	profile := &ClusterProfile{Metadata: ClusterProfileMetadata{Name: "test"}}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != profile {
+		t.Error("expected same pointer for profile with no capabilities")
+	}
+}
+
+func TestEvaluateProfile_UnknownCapability_Passthrough(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"unknown-trait": {Rendering: map[string]any{"x": "y"}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["unknown-trait"].Rendering["x"] != "y" {
+		t.Error("unknown capability rendering should pass through unchanged")
+	}
+}
+
+func TestEvaluateProfile_NonVADHandler_Passthrough(t *testing.T) {
+	// A plain TraitHandler (no CapabilityAware, no ValidateAndApplyDefaults)
+	// is registered successfully; EvaluateProfile must pass its rendering through.
+	tr := NewTransformer(nil, map[string]TraitHandler{
+		"expose": &stubTraitHandler{typ: "expose"},
+	})
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"expose": {Rendering: map[string]any{"controllerType": "ingress"}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["expose"].Rendering["controllerType"] != "ingress" {
+		t.Error("non-VAD handler should pass rendering through unchanged")
+	}
+}
+
+func TestEvaluateProfile_ValidCapability_AppliesDefaults(t *testing.T) {
+	enriched := map[string]any{"controllerType": "ingress", "ingressClassName": "nginx"}
+	handler := &errVADHandler{stubTraitHandler: stubTraitHandler{typ: "expose"}, out: enriched}
+	tr := NewTransformer(nil, map[string]TraitHandler{"expose": handler})
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"expose": {Rendering: map[string]any{"controllerType": "ingress"}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["expose"].Rendering["ingressClassName"] != "nginx" {
+		t.Error("expected enriched rendering from VAD handler")
+	}
+}
+
+func TestEvaluateProfile_InvalidCapability_ReturnsError(t *testing.T) {
+	handler := &errVADHandler{stubTraitHandler: stubTraitHandler{typ: "expose"}, err: errors.New("bad rendering")}
+	tr := NewTransformer(nil, map[string]TraitHandler{"expose": handler})
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"expose": {Rendering: map[string]any{"controllerType": "unknown"}},
+			},
+		},
+	}
+	_, err := tr.EvaluateProfile(profile)
+	if err == nil {
+		t.Fatal("expected error for invalid capability rendering")
+	}
+	var te *TransformError
+	if !errors.As(err, &te) {
+		t.Errorf("expected TransformError, got %T: %v", err, err)
+	}
+}
+
+func TestEvaluateProfile_ScopedKey(t *testing.T) {
+	enriched := map[string]any{"controllerType": "ingress", "ingressClassName": "traefik"}
+	handler := &errVADHandler{stubTraitHandler: stubTraitHandler{typ: "expose"}, out: enriched}
+	tr := NewTransformer(nil, map[string]TraitHandler{"expose": handler})
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"expose.prod": {Rendering: map[string]any{"controllerType": "ingress"}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["expose.prod"].Rendering["ingressClassName"] != "traefik" {
+		t.Error("scoped key should resolve to base type and call VAD handler")
+	}
+}

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -172,11 +172,40 @@ func validateApplicationPolicy(p *ApplicationPolicy, index int, seenNames map[st
 	return nil
 }
 
+// validateClusterProfile checks apiVersion, kind, and metadata.name on a
+// decoded ClusterProfile, mirroring the semantic validation that validate()
+// applies to Application documents.
+func validateClusterProfile(profile *ClusterProfile) error {
+	if profile.APIVersion != SupportedAPIVersion {
+		return profileValidationError("apiVersion", fmt.Sprintf("unsupported apiVersion %q, expected %q",
+			profile.APIVersion, SupportedAPIVersion))
+	}
+	if profile.Kind != "ClusterProfile" {
+		return profileValidationError("kind", fmt.Sprintf("expected kind ClusterProfile, got %q", profile.Kind))
+	}
+	if profile.Metadata.Name == "" {
+		return profileValidationError("metadata.name", "metadata.name is required")
+	}
+	if errs := validation.IsDNS1123Subdomain(profile.Metadata.Name); len(errs) > 0 {
+		return profileValidationError("metadata.name", fmt.Sprintf("metadata.name %q is not a valid DNS-1123 subdomain",
+			profile.Metadata.Name))
+	}
+	return nil
+}
+
 // oamValidationError creates a ValidationError with a custom message.
 func oamValidationError(field, message string) *errors.ValidationError {
 	return &errors.ValidationError{
 		Field:     field,
 		Component: "application",
+		Message:   message,
+	}
+}
+
+func profileValidationError(field, message string) *errors.ValidationError {
+	return &errors.ValidationError{
+		Field:     field,
+		Component: "clusterprofile",
 		Message:   message,
 	}
 }


### PR DESCRIPTION
## Summary

Closes #55.

- Adds `kurel build <app.yaml> --profile <cluster.yaml>` as the first end-to-end proof of the OAM runtime pipeline
- Wires `WebserviceHandler`, `ExposeHandler`, and `IngressHandler` from `pkg/oam/builtin` through the `Transformer`
- Serializes generated manifests to stdout (default) or a directory via `--output`
- Flags: `--profile` (required), `--output/-o`, `--namespace/-n`, `--cluster-id`

## pkg/patch gate (required by #55)

`pkg/patch` is not used anywhere in the OAM build flow — confirmed by grep across `pkg/oam/` and `pkg/cmd/`. It is a standalone YAML post-processing utility that remains in crane's delivery path. No changes needed. See comment on #41.

## Generated output (smoke test)

```
kurel build app.yaml --profile cluster.yaml
```

For a webservice + expose(ingress) application produces:

```
kind: Deployment
kind: Service
kind: ServiceAccount
kind: Ingress
```

## Test plan

- [ ] `GOWORK=off mise run test` — all tests green
- [ ] `GOWORK=off mise run lint` — 0 issues
- [ ] Coverage ≥ 80% (currently 80.5%)
- [ ] Smoke test: `kurel build testdata/app.yaml --profile testdata/cluster.yaml` produces valid YAML
- [ ] Unsupported component type returns a clear error