### PR TITLE
feat(oam): add worker, cronjob, daemonset handlers with fixture parity

### DIFF
--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -110,12 +110,15 @@ func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
 	return writeOutputDir(opts.outputDir, app.Metadata.Name, yamlBytes)
 }
 
-// newBuiltinTransformer creates a Transformer pre-loaded with the supported
-// built-in handlers for this vertical slice (webservice, expose, ingress).
+// newBuiltinTransformer creates a Transformer pre-loaded with all supported
+// built-in component and trait handlers.
 func newBuiltinTransformer() *oam.Transformer {
 	return oam.NewTransformer(
 		map[string]oam.ComponentHandler{
 			"webservice": &components.WebserviceHandler{},
+			"worker":     &components.WorkerHandler{},
+			"cronjob":    &components.CronjobHandler{},
+			"daemonset":  &components.DaemonsetHandler{},
 		},
 		map[string]oam.TraitHandler{
 			"expose":  &traits.ExposeHandler{},

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -158,20 +158,20 @@ func TestBuildCommand_InvalidAppYAML(t *testing.T) {
 }
 
 func TestBuildCommand_UnsupportedComponentType(t *testing.T) {
-	const workerApp = `apiVersion: launcher.gokure.dev/v1alpha1
+	const unknownApp = `apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
-  name: my-worker
+  name: my-app
   namespace: default
 spec:
   components:
     - name: backend
-      type: worker
+      type: statefulset
       properties:
-        image: ghcr.io/example/worker:v1.0.0
+        image: ghcr.io/example/backend:v1.0.0
 `
 	dir := t.TempDir()
-	appPath := writeTempFile(t, dir, "app.yaml", workerApp)
+	appPath := writeTempFile(t, dir, "app.yaml", unknownApp)
 	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
 
 	cmd := NewKurelCommand()
@@ -182,7 +182,7 @@ spec:
 	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error for unsupported component type 'worker'")
+		t.Fatal("expected error for unsupported component type 'statefulset'")
 	}
 }
 

--- a/pkg/cmd/kurel/fixtures_test.go
+++ b/pkg/cmd/kurel/fixtures_test.go
@@ -1,0 +1,69 @@
+package kurel
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestFixtures runs each scenario in testdata/ through the real CLI and compares
+// stdout against expected.yaml. Set UPDATE_GOLDEN=1 to regenerate expected files.
+func TestFixtures(t *testing.T) {
+	scenarios, err := filepath.Glob("testdata/*/app.yaml")
+	if err != nil {
+		t.Fatalf("globbing testdata: %v", err)
+	}
+	if len(scenarios) == 0 {
+		t.Fatal("no fixture scenarios found in testdata/")
+	}
+
+	update := os.Getenv("UPDATE_GOLDEN") == "1"
+
+	for _, appPath := range scenarios {
+		dir := filepath.Dir(appPath)
+		name := filepath.Base(dir)
+
+		t.Run(name, func(t *testing.T) {
+			profilePath := filepath.Join(dir, "cluster.yaml")
+			expectedPath := filepath.Join(dir, "expected.yaml")
+
+			if _, err := os.Stat(profilePath); os.IsNotExist(err) {
+				t.Fatalf("missing cluster.yaml for scenario %q", name)
+			}
+
+			cmd := NewKurelCommand()
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("build failed: %v\noutput: %s", err, out.String())
+			}
+
+			got := out.String()
+
+			if update {
+				if err := os.WriteFile(expectedPath, []byte(got), 0644); err != nil {
+					t.Fatalf("writing expected.yaml: %v", err)
+				}
+				t.Logf("updated %s", expectedPath)
+				return
+			}
+
+			expected, err := os.ReadFile(expectedPath)
+			if os.IsNotExist(err) {
+				t.Fatalf("expected.yaml missing for %q — run with UPDATE_GOLDEN=1 to generate", name)
+			}
+			if err != nil {
+				t.Fatalf("reading expected.yaml: %v", err)
+			}
+
+			if strings.TrimSpace(got) != strings.TrimSpace(string(expected)) {
+				t.Errorf("output mismatch for %q\n--- expected ---\n%s\n--- got ---\n%s", name, expected, got)
+			}
+		})
+	}
+}

--- a/pkg/cmd/kurel/testdata/cronjob-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/cronjob-minimal/app.yaml
@@ -1,0 +1,12 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-cronjob
+  namespace: default
+spec:
+  components:
+    - name: cleanup
+      type: cronjob
+      properties:
+        image: ghcr.io/example/cleanup:v1.0.0
+        schedule: "0 2 * * *"

--- a/pkg/cmd/kurel/testdata/cronjob-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/cronjob-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/cronjob-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/cronjob-minimal/expected.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  labels:
+    app: cleanup
+  name: cleanup
+  namespace: default
+spec:
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    metadata:
+      labels:
+        app: cleanup
+    spec:
+      template:
+        metadata:
+          labels:
+            app: cleanup
+        spec:
+          containers:
+          - image: ghcr.io/example/cleanup:v1.0.0
+            imagePullPolicy: IfNotPresent
+            name: cleanup
+            resources:
+              limits:
+                memory: 128Mi
+              requests:
+                cpu: 100m
+                memory: 128Mi
+          restartPolicy: OnFailure
+          serviceAccountName: cleanup
+  schedule: 0 2 * * *
+  successfulJobsHistoryLimit: 3
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: cleanup
+  name: cleanup
+  namespace: default

--- a/pkg/cmd/kurel/testdata/daemonset-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-minimal/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-daemon
+  namespace: default
+spec:
+  components:
+    - name: agent
+      type: daemonset
+      properties:
+        image: ghcr.io/example/agent:v1.0.0

--- a/pkg/cmd/kurel/testdata/daemonset-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/daemonset-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-minimal/expected.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+      - image: ghcr.io/example/agent:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: agent
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: agent
+  updateStrategy: {}
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default

--- a/pkg/cmd/kurel/testdata/webservice-expose-ingress/app.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-ingress/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+      traits:
+        - type: expose
+          properties:
+            controllerType: ingress
+            rules:
+              - host: frontend.example.com
+                paths:
+                  - path: /

--- a/pkg/cmd/kurel/testdata/webservice-expose-ingress/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-ingress/cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx

--- a/pkg/cmd/kurel/testdata/webservice-expose-ingress/expected.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-ingress/expected.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: ghcr.io/example/frontend:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: frontend
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: frontend
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: frontend
+  name: frontend-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: frontend.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: frontend
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/pkg/cmd/kurel/testdata/webservice-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-minimal/app.yaml
@@ -1,0 +1,12 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080

--- a/pkg/cmd/kurel/testdata/webservice-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/webservice-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-minimal/expected.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: ghcr.io/example/frontend:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: frontend
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: frontend
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default

--- a/pkg/cmd/kurel/testdata/worker-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/worker-minimal/app.yaml
@@ -1,0 +1,11 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-worker
+  namespace: default
+spec:
+  components:
+    - name: backend
+      type: worker
+      properties:
+        image: ghcr.io/example/worker:v1.0.0

--- a/pkg/cmd/kurel/testdata/worker-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/worker-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/worker-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/worker-minimal/expected.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: backend
+  name: backend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: backend
+    spec:
+      containers:
+      - image: ghcr.io/example/worker:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: backend
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: backend
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: backend
+  name: backend
+  namespace: default

--- a/pkg/oam/builtin/components/common.go
+++ b/pkg/oam/builtin/components/common.go
@@ -805,6 +805,90 @@ func parseAffinity(props map[string]any) (AffinityConfig, error) {
 	return cfg, nil
 }
 
+func parseTolerations(props map[string]any) ([]corev1.Toleration, error) {
+	tolList, ok := props["tolerations"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	tolerations := make([]corev1.Toleration, 0, len(tolList))
+	for i, t := range tolList {
+		m, ok := t.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("toleration[%d]: must be a mapping", i)
+		}
+		tol := corev1.Toleration{}
+
+		if raw, exists := m["key"]; exists {
+			keyStr, ok := raw.(string)
+			if !ok {
+				return nil, errors.Errorf("toleration[%d].key: must be a string, got %T", i, raw)
+			}
+			tol.Key = keyStr
+		}
+
+		if raw, exists := m["operator"]; exists {
+			opStr, ok := raw.(string)
+			if !ok {
+				return nil, errors.Errorf("toleration[%d].operator: must be a string, got %T", i, raw)
+			}
+			switch corev1.TolerationOperator(opStr) {
+			case corev1.TolerationOpExists, corev1.TolerationOpEqual:
+				tol.Operator = corev1.TolerationOperator(opStr)
+			default:
+				return nil, errors.Errorf("toleration[%d].operator: invalid value %q, must be 'Exists' or 'Equal'", i, opStr)
+			}
+		} else if tol.Key == "" {
+			tol.Operator = corev1.TolerationOpExists
+		} else {
+			tol.Operator = corev1.TolerationOpEqual
+		}
+
+		if raw, exists := m["value"]; exists {
+			valStr, ok := raw.(string)
+			if !ok {
+				return nil, errors.Errorf("toleration[%d].value: must be a string, got %T", i, raw)
+			}
+			tol.Value = valStr
+		}
+
+		if raw, exists := m["effect"]; exists {
+			effStr, ok := raw.(string)
+			if !ok {
+				return nil, errors.Errorf("toleration[%d].effect: must be a string, got %T", i, raw)
+			}
+			switch corev1.TaintEffect(effStr) {
+			case corev1.TaintEffectNoSchedule, corev1.TaintEffectPreferNoSchedule, corev1.TaintEffectNoExecute, "":
+				tol.Effect = corev1.TaintEffect(effStr)
+			default:
+				return nil, errors.Errorf("toleration[%d].effect: invalid value %q", i, effStr)
+			}
+		}
+
+		tolerations = append(tolerations, tol)
+	}
+	return tolerations, nil
+}
+
+func parseHistoryLimit(field string, v any) (int32, error) {
+	switch n := v.(type) {
+	case int:
+		if n < 0 {
+			return 0, errors.Errorf("%s: must be non-negative, got %d", field, n)
+		}
+		return int32(n), nil //nolint:gosec
+	case float64:
+		if n != float64(int64(n)) {
+			return 0, errors.Errorf("%s: must be an integer, got %g", field, n)
+		}
+		if n < 0 {
+			return 0, errors.Errorf("%s: must be non-negative, got %g", field, n)
+		}
+		return int32(n), nil
+	default:
+		return 0, errors.Errorf("%s: must be an integer, got %T", field, v)
+	}
+}
+
 // --- Builders ---
 
 func buildEnvVars(envs []EnvVar) []corev1.EnvVar {

--- a/pkg/oam/builtin/components/common.go
+++ b/pkg/oam/builtin/components/common.go
@@ -872,16 +872,16 @@ func parseTolerations(props map[string]any) ([]corev1.Toleration, error) {
 func parseHistoryLimit(field string, v any) (int32, error) {
 	switch n := v.(type) {
 	case int:
-		if n < 0 {
-			return 0, errors.Errorf("%s: must be non-negative, got %d", field, n)
+		if n < 0 || n > math.MaxInt32 {
+			return 0, errors.Errorf("%s: must be between 0 and %d, got %d", field, math.MaxInt32, n)
 		}
 		return int32(n), nil //nolint:gosec
 	case float64:
 		if n != float64(int64(n)) {
 			return 0, errors.Errorf("%s: must be an integer, got %g", field, n)
 		}
-		if n < 0 {
-			return 0, errors.Errorf("%s: must be non-negative, got %g", field, n)
+		if n < 0 || n > math.MaxInt32 {
+			return 0, errors.Errorf("%s: must be between 0 and %d, got %g", field, math.MaxInt32, n)
 		}
 		return int32(n), nil
 	default:

--- a/pkg/oam/builtin/components/cronjob.go
+++ b/pkg/oam/builtin/components/cronjob.go
@@ -1,0 +1,210 @@
+package components
+
+import (
+	"regexp"
+
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// cronScheduleRe matches a standard 5-field cron expression (no special @syntax).
+var cronScheduleRe = regexp.MustCompile(`^(\S+\s+){4}\S+$`)
+
+// CronjobHandler handles OAM cronjob components.
+type CronjobHandler struct{}
+
+// CanHandle returns true for cronjob component type.
+func (h *CronjobHandler) CanHandle(componentType string) bool {
+	return componentType == "cronjob"
+}
+
+// ToApplicationConfig converts an OAM cronjob component to a CronjobConfig.
+func (h *CronjobHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	config := &CronjobConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	image, ok := props["image"].(string)
+	if !ok {
+		return nil, errors.New("required property 'image' missing or not a string")
+	}
+	if err := ValidateImageRef(image); err != nil {
+		return nil, err
+	}
+	config.Image = image
+
+	schedule, ok := props["schedule"].(string)
+	if !ok {
+		return nil, errors.New("required property 'schedule' missing or not a string")
+	}
+	if !cronScheduleRe.MatchString(schedule) {
+		return nil, errors.Errorf("invalid cron schedule %q: must be a 5-field cron expression (e.g. \"0 2 * * *\")", schedule)
+	}
+	config.Schedule = schedule
+
+	config.RestartPolicy = corev1.RestartPolicyOnFailure
+	if rp, ok := props["restartPolicy"].(string); ok {
+		switch rp {
+		case "Never":
+			config.RestartPolicy = corev1.RestartPolicyNever
+		case "OnFailure":
+			config.RestartPolicy = corev1.RestartPolicyOnFailure
+		default:
+			return nil, errors.Errorf("invalid restartPolicy %q, must be 'Never' or 'OnFailure'", rp)
+		}
+	}
+
+	config.SuccessfulJobsHistoryLimit = 3
+	if raw, ok := props["successfulJobsHistoryLimit"]; ok {
+		limit, err := parseHistoryLimit("successfulJobsHistoryLimit", raw)
+		if err != nil {
+			return nil, err
+		}
+		config.SuccessfulJobsHistoryLimit = limit
+	}
+
+	config.FailedJobsHistoryLimit = 1
+	if raw, ok := props["failedJobsHistoryLimit"]; ok {
+		limit, err := parseHistoryLimit("failedJobsHistoryLimit", raw)
+		if err != nil {
+			return nil, err
+		}
+		config.FailedJobsHistoryLimit = limit
+	}
+
+	env, err := parseEnv(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Env = env
+	if resources, ok := props["resources"].(map[string]any); ok {
+		config.Resources = parseResources(resources)
+	}
+	config.explicitResources = resourceExplicitFlags(props)
+	config.Command = parseCommand(props)
+	config.Args = parseArgs(props)
+
+	initContainers, err := parseInitContainers(props)
+	if err != nil {
+		return nil, err
+	}
+	config.InitContainers = initContainers
+
+	return config, nil
+}
+
+// CronjobConfig implements stack.ApplicationConfig for cronjob components.
+type CronjobConfig struct {
+	Name                       string
+	Namespace                  string
+	Image                      string
+	Schedule                   string
+	RestartPolicy              corev1.RestartPolicy
+	SuccessfulJobsHistoryLimit int32
+	FailedJobsHistoryLimit     int32
+	Env                        []EnvVar
+	Resources                  ResourceRequirements
+	Command                    []string
+	Args                       []string
+	InitContainers             []InitContainerConfig
+	explicitResources          explicitResourceFlags
+}
+
+// ApplyPolicy applies defaults then enforces limits from the policy.
+// CronJobs don't have replicas, so only resource and registry limits apply.
+func (c *CronjobConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil {
+		return nil
+	}
+
+	if !c.explicitResources.cpuRequest {
+		c.Resources.CPURequest = applyDefaultResource(c.Resources.CPURequest, p.DefaultCPURequest())
+	}
+	if !c.explicitResources.memoryRequest {
+		c.Resources.MemoryRequest = applyDefaultResource(c.Resources.MemoryRequest, p.DefaultMemoryRequest())
+	}
+	if !c.explicitResources.cpuLimit {
+		c.Resources.CPULimit = applyDefaultResource(c.Resources.CPULimit, p.DefaultCPULimit())
+	}
+	if !c.explicitResources.memoryLimit {
+		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
+	}
+
+	if err := enforceMaxResource(c.Resources.CPURequest, p.MaxCPU(), "cpu request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPULimit, p.MaxCPU(), "cpu limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryRequest, p.MaxMemory(), "memory request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryLimit, p.MaxMemory(), "memory limit"); err != nil {
+		return err
+	}
+	if err := enforceAllowedRegistries(c.Image, p.AllowedRegistries()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Generate creates a Kubernetes CronJob and ServiceAccount.
+func (c *CronjobConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": app.Name}
+	cronjob, err := c.createCronJob(app)
+	if err != nil {
+		return nil, err
+	}
+	sa := createServiceAccount(app.Name, app.Namespace, labels)
+
+	obj := client.Object(cronjob)
+	saObj := client.Object(sa)
+
+	return []*client.Object{&obj, &saObj}, nil
+}
+
+func (c *CronjobConfig) createCronJob(app *stack.Application) (*batchv1.CronJob, error) {
+	labels := map[string]string{"app": app.Name}
+
+	container := kubernetes.CreateContainer(app.Name, c.Image, c.Command, c.Args)
+	rr, err := buildResourceRequirements(c.Resources)
+	if err != nil {
+		return nil, errors.Wrap(err, "resource requirements")
+	}
+	_ = kubernetes.SetContainerResources(container, rr)
+	for _, env := range buildEnvVars(c.Env) {
+		_ = kubernetes.AddContainerEnv(container, env)
+	}
+
+	cj := kubernetes.CreateCronJob(app.Name, app.Namespace, c.Schedule)
+	cj.Labels = labels
+	cj.Annotations = nil
+	cj.Spec.JobTemplate.Labels = labels
+	cj.Spec.JobTemplate.Spec.Template.Labels = labels
+	cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = c.RestartPolicy
+	_ = kubernetes.SetCronJobSuccessfulJobsHistoryLimit(cj, c.SuccessfulJobsHistoryLimit)
+	_ = kubernetes.SetCronJobFailedJobsHistoryLimit(cj, c.FailedJobsHistoryLimit)
+	_ = kubernetes.SetCronJobServiceAccountName(cj, app.Name)
+	// Init containers added before the main container so declaration order is
+	// preserved in spec.template.spec.initContainers.
+	for _, ic := range c.InitContainers {
+		initContainer, err := buildInitContainer(ic)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddCronJobInitContainer(cj, initContainer)
+	}
+	_ = kubernetes.AddCronJobContainer(cj, container)
+
+	return cj, nil
+}

--- a/pkg/oam/builtin/components/cronjob_test.go
+++ b/pkg/oam/builtin/components/cronjob_test.go
@@ -186,6 +186,22 @@ func TestCronjobHandler_RestartPolicy_Never(t *testing.T) {
 	t.Error("CronJob not found")
 }
 
+func TestCronjobHandler_HistoryLimit_Overflow_Rejected(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":                      "ghcr.io/org/job:v1.0.0",
+			"schedule":                   "0 2 * * *",
+			"successfulJobsHistoryLimit": 3_000_000_000,
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for out-of-int32-range successfulJobsHistoryLimit")
+	}
+}
+
 func TestCronjobHandler_HistoryLimit_Fractional_Rejected(t *testing.T) {
 	h := &components.CronjobHandler{}
 	_, err := h.ToApplicationConfig(&oam.Component{

--- a/pkg/oam/builtin/components/cronjob_test.go
+++ b/pkg/oam/builtin/components/cronjob_test.go
@@ -1,0 +1,296 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestCronjobHandler_CanHandle(t *testing.T) {
+	h := &components.CronjobHandler{}
+	if !h.CanHandle("cronjob") {
+		t.Error("expected true for cronjob")
+	}
+	if h.CanHandle("worker") {
+		t.Error("expected false for worker")
+	}
+}
+
+func TestCronjobHandler_RequiredImage_Missing(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"schedule": "0 2 * * *",
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing image")
+	}
+}
+
+func TestCronjobHandler_RequiredSchedule_Missing(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/job:v1.0.0",
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing schedule")
+	}
+}
+
+func TestCronjobHandler_InvalidSchedule(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/job:v1.0.0",
+			"schedule": "@daily",
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for non-standard cron schedule")
+	}
+}
+
+func TestCronjobHandler_InvalidRestartPolicy(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":         "ghcr.io/org/job:v1.0.0",
+			"schedule":      "0 2 * * *",
+			"restartPolicy": "Always",
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for invalid restart policy")
+	}
+}
+
+func TestCronjobHandler_Generate_ResourceTypes(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "cleanup",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/cleanup:v1.0.0",
+			"schedule": "0 2 * * *",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("cleanup", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var foundCronJob, foundSA bool
+	for _, obj := range objects {
+		switch (*obj).(type) {
+		case *batchv1.CronJob:
+			foundCronJob = true
+		case *corev1.ServiceAccount:
+			foundSA = true
+		}
+	}
+	if !foundCronJob {
+		t.Error("expected CronJob")
+	}
+	if !foundSA {
+		t.Error("expected ServiceAccount")
+	}
+}
+
+func TestCronjobHandler_Generate_Defaults(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "cleanup",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/cleanup:v1.0.0",
+			"schedule": "0 2 * * *",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("cleanup", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, obj := range objects {
+		if cj, ok := (*obj).(*batchv1.CronJob); ok {
+			if cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyOnFailure {
+				t.Errorf("expected OnFailure restart policy, got %s", cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy)
+			}
+			if cj.Spec.SuccessfulJobsHistoryLimit == nil || *cj.Spec.SuccessfulJobsHistoryLimit != 3 {
+				t.Errorf("expected successfulJobsHistoryLimit=3, got %v", cj.Spec.SuccessfulJobsHistoryLimit)
+			}
+			if cj.Spec.FailedJobsHistoryLimit == nil || *cj.Spec.FailedJobsHistoryLimit != 1 {
+				t.Errorf("expected failedJobsHistoryLimit=1, got %v", cj.Spec.FailedJobsHistoryLimit)
+			}
+			return
+		}
+	}
+	t.Error("CronJob not found")
+}
+
+func TestCronjobHandler_RestartPolicy_Never(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":         "ghcr.io/org/job:v1.0.0",
+			"schedule":      "0 2 * * *",
+			"restartPolicy": "Never",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("job", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, obj := range objects {
+		if cj, ok := (*obj).(*batchv1.CronJob); ok {
+			if cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy != corev1.RestartPolicyNever {
+				t.Errorf("expected Never restart policy, got %s", cj.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy)
+			}
+			return
+		}
+	}
+	t.Error("CronJob not found")
+}
+
+func TestCronjobHandler_HistoryLimit_Fractional_Rejected(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":                      "ghcr.io/org/job:v1.0.0",
+			"schedule":                   "0 2 * * *",
+			"successfulJobsHistoryLimit": 1.5,
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for fractional successfulJobsHistoryLimit")
+	}
+}
+
+func TestCronjobHandler_HistoryLimit_Negative_Rejected(t *testing.T) {
+	h := &components.CronjobHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":                  "ghcr.io/org/job:v1.0.0",
+			"schedule":               "0 2 * * *",
+			"failedJobsHistoryLimit": -1,
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for negative failedJobsHistoryLimit")
+	}
+}
+
+func TestCronjobHandler_HistoryLimit_Custom_Valid(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":                      "ghcr.io/org/job:v1.0.0",
+			"schedule":                   "0 2 * * *",
+			"successfulJobsHistoryLimit": 5,
+			"failedJobsHistoryLimit":     2,
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("job", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, obj := range objects {
+		if cj, ok := (*obj).(*batchv1.CronJob); ok {
+			if cj.Spec.SuccessfulJobsHistoryLimit == nil || *cj.Spec.SuccessfulJobsHistoryLimit != 5 {
+				t.Errorf("expected successfulJobsHistoryLimit=5, got %v", cj.Spec.SuccessfulJobsHistoryLimit)
+			}
+			if cj.Spec.FailedJobsHistoryLimit == nil || *cj.Spec.FailedJobsHistoryLimit != 2 {
+				t.Errorf("expected failedJobsHistoryLimit=2, got %v", cj.Spec.FailedJobsHistoryLimit)
+			}
+			return
+		}
+	}
+	t.Error("CronJob not found")
+}
+
+func TestCronjobConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/job:v1.0.0",
+			"schedule": "0 2 * * *",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy should be a no-op, got: %v", err)
+	}
+}
+
+func TestCronjobConfig_ApplyPolicy_AllowedRegistries(t *testing.T) {
+	h := &components.CronjobHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "job",
+		Type: "cronjob",
+		Properties: map[string]any{
+			"image":    "docker.io/library/job:v1.0.0",
+			"schedule": "0 2 * * *",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPolicy{allowedRegistries: []string{"ghcr.io"}}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error for disallowed registry")
+	}
+}

--- a/pkg/oam/builtin/components/daemonset.go
+++ b/pkg/oam/builtin/components/daemonset.go
@@ -1,0 +1,205 @@
+package components
+
+import (
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// DaemonsetHandler handles OAM daemonset components.
+type DaemonsetHandler struct{}
+
+// CanHandle returns true for daemonset component type.
+func (h *DaemonsetHandler) CanHandle(componentType string) bool {
+	return componentType == "daemonset"
+}
+
+// ToApplicationConfig converts an OAM daemonset component to a DaemonsetConfig.
+func (h *DaemonsetHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	config := &DaemonsetConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	image, ok := props["image"].(string)
+	if !ok {
+		return nil, errors.New("required property 'image' missing or not a string")
+	}
+	if err := ValidateImageRef(image); err != nil {
+		return nil, err
+	}
+	config.Image = image
+
+	env, err := parseEnv(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Env = env
+	if resources, ok := props["resources"].(map[string]any); ok {
+		config.Resources = parseResources(resources)
+	}
+	config.explicitResources = resourceExplicitFlags(props)
+	config.Command = parseCommand(props)
+	config.Args = parseArgs(props)
+	probes, err := parseProbes(props)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid probe configuration")
+	}
+	config.Probes = probes
+
+	tolerations, err := parseTolerations(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Tolerations = tolerations
+	parsed, err := parseVolumes(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Volumes = parsed.Volumes
+	config.VolumeMounts = parsed.Mounts
+	config.PVCs = parsed.PVCs
+
+	initContainers, err := parseInitContainers(props)
+	if err != nil {
+		return nil, err
+	}
+	config.InitContainers = initContainers
+
+	return config, nil
+}
+
+// DaemonsetConfig implements stack.ApplicationConfig for daemonset components.
+type DaemonsetConfig struct {
+	Name              string
+	Namespace         string
+	Image             string
+	Env               []EnvVar
+	Resources         ResourceRequirements
+	Command           []string
+	Args              []string
+	Probes            ProbeConfig
+	Tolerations       []corev1.Toleration
+	Volumes           []corev1.Volume
+	VolumeMounts      []corev1.VolumeMount
+	InitContainers    []InitContainerConfig
+	PVCs              []PVCConfig
+	explicitResources explicitResourceFlags
+}
+
+// ApplyPolicy applies defaults then enforces limits from the policy.
+// DaemonSets don't have replicas, so only resource and registry limits apply.
+func (c *DaemonsetConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil {
+		return nil
+	}
+
+	if !c.explicitResources.cpuRequest {
+		c.Resources.CPURequest = applyDefaultResource(c.Resources.CPURequest, p.DefaultCPURequest())
+	}
+	if !c.explicitResources.memoryRequest {
+		c.Resources.MemoryRequest = applyDefaultResource(c.Resources.MemoryRequest, p.DefaultMemoryRequest())
+	}
+	if !c.explicitResources.cpuLimit {
+		c.Resources.CPULimit = applyDefaultResource(c.Resources.CPULimit, p.DefaultCPULimit())
+	}
+	if !c.explicitResources.memoryLimit {
+		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
+	}
+
+	if err := enforceMaxResource(c.Resources.CPURequest, p.MaxCPU(), "cpu request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPULimit, p.MaxCPU(), "cpu limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryRequest, p.MaxMemory(), "memory request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryLimit, p.MaxMemory(), "memory limit"); err != nil {
+		return err
+	}
+	if err := enforceAllowedRegistries(c.Image, p.AllowedRegistries()); err != nil {
+		return err
+	}
+	for _, pvc := range c.PVCs {
+		if err := enforceMaxStorageSize(pvc.Size, p.MaxStorageSize()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Generate creates a Kubernetes DaemonSet and ServiceAccount.
+func (c *DaemonsetConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": app.Name}
+	ds, err := c.createDaemonSet(app)
+	if err != nil {
+		return nil, err
+	}
+	sa := createServiceAccount(app.Name, app.Namespace, labels)
+
+	dsObj := client.Object(ds)
+	saObj := client.Object(sa)
+
+	objects := []*client.Object{&dsObj, &saObj}
+	for _, pvc := range c.PVCs {
+		p, err := BuildPVC(pvc, app.Namespace, labels)
+		if err != nil {
+			return nil, err
+		}
+		pObj := client.Object(p)
+		objects = append(objects, &pObj)
+	}
+	return objects, nil
+}
+
+func (c *DaemonsetConfig) createDaemonSet(app *stack.Application) (*appsv1.DaemonSet, error) {
+	labels := map[string]string{"app": app.Name}
+
+	container := kubernetes.CreateContainer(app.Name, c.Image, c.Command, c.Args)
+	rr, err := buildResourceRequirements(c.Resources)
+	if err != nil {
+		return nil, errors.Wrap(err, "resource requirements")
+	}
+	_ = kubernetes.SetContainerResources(container, rr)
+	for _, env := range buildEnvVars(c.Env) {
+		_ = kubernetes.AddContainerEnv(container, env)
+	}
+	applyProbes(container, c.Probes)
+	for _, m := range c.VolumeMounts {
+		_ = kubernetes.AddContainerVolumeMount(container, m)
+	}
+
+	ds := kubernetes.CreateDaemonSet(app.Name, app.Namespace)
+	ds.Labels = labels
+	ds.Annotations = nil
+	ds.Spec.Template.Labels = labels
+	_ = kubernetes.SetDaemonSetServiceAccountName(ds, app.Name)
+	// Init containers added before the main container so declaration order is
+	// preserved in spec.template.spec.initContainers.
+	for _, ic := range c.InitContainers {
+		initContainer, err := buildInitContainer(ic)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddDaemonSetInitContainer(ds, initContainer)
+	}
+	_ = kubernetes.AddDaemonSetContainer(ds, container)
+	for i := range c.Tolerations {
+		_ = kubernetes.AddDaemonSetToleration(ds, &c.Tolerations[i])
+	}
+	for i := range c.Volumes {
+		_ = kubernetes.AddDaemonSetVolume(ds, &c.Volumes[i])
+	}
+
+	return ds, nil
+}

--- a/pkg/oam/builtin/components/daemonset_test.go
+++ b/pkg/oam/builtin/components/daemonset_test.go
@@ -1,0 +1,225 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestDaemonsetHandler_CanHandle(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	if !h.CanHandle("daemonset") {
+		t.Error("expected true for daemonset")
+	}
+	if h.CanHandle("worker") {
+		t.Error("expected false for worker")
+	}
+}
+
+func TestDaemonsetHandler_RequiredImage_Missing(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "agent",
+		Type:       "daemonset",
+		Properties: map[string]any{},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing image")
+	}
+}
+
+func TestDaemonsetHandler_Generate_ResourceTypes(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("agent", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var foundDS, foundSA bool
+	for _, obj := range objects {
+		switch (*obj).(type) {
+		case *appsv1.DaemonSet:
+			foundDS = true
+		case *corev1.ServiceAccount:
+			foundSA = true
+		}
+	}
+	if !foundDS {
+		t.Error("expected DaemonSet")
+	}
+	if !foundSA {
+		t.Error("expected ServiceAccount")
+	}
+}
+
+func TestDaemonsetHandler_NoReplicas(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	// DaemonsetConfig must not implement MaxReplicas enforcement (no replicas field)
+	if _, ok := cfg.(interface{ Replicas() int32 }); ok {
+		t.Error("DaemonsetConfig should not expose Replicas()")
+	}
+}
+
+func TestDaemonsetConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy should be a no-op, got: %v", err)
+	}
+}
+
+func TestDaemonsetConfig_ApplyPolicy_AllowedRegistries(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "docker.io/library/agent:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPolicy{allowedRegistries: []string{"ghcr.io"}}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error for disallowed registry")
+	}
+}
+
+func TestDaemonsetHandler_Tolerations_NonStringKey_Rejected(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+			"tolerations": []any{
+				map[string]any{
+					"key":    123,
+					"effect": "NoSchedule",
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for non-string toleration key")
+	}
+}
+
+func TestDaemonsetHandler_Tolerations_InvalidOperator_Rejected(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+			"tolerations": []any{
+				map[string]any{
+					"key":      "node-role.kubernetes.io/control-plane",
+					"operator": "Contains",
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for invalid toleration operator")
+	}
+}
+
+func TestDaemonsetHandler_Tolerations_InvalidEffect_Rejected(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+			"tolerations": []any{
+				map[string]any{
+					"key":    "node-role.kubernetes.io/control-plane",
+					"effect": "NoRun",
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for invalid toleration effect")
+	}
+}
+
+func TestDaemonsetHandler_WithTolerations(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+			"tolerations": []any{
+				map[string]any{
+					"key":      "node-role.kubernetes.io/control-plane",
+					"operator": "Exists",
+					"effect":   "NoSchedule",
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("agent", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, obj := range objects {
+		if ds, ok := (*obj).(*appsv1.DaemonSet); ok {
+			if len(ds.Spec.Template.Spec.Tolerations) != 1 {
+				t.Errorf("expected 1 toleration, got %d", len(ds.Spec.Template.Spec.Tolerations))
+			}
+			return
+		}
+	}
+	t.Error("DaemonSet not found")
+}

--- a/pkg/oam/builtin/components/webservice_test.go
+++ b/pkg/oam/builtin/components/webservice_test.go
@@ -534,3 +534,81 @@ func TestWebserviceConfig_ApplyPolicy_MaxStorageSize(t *testing.T) {
 		t.Error("expected error when PVC size exceeds max")
 	}
 }
+
+func TestWebserviceHandler_WithProbes_NamedPort(t *testing.T) {
+	h := &components.WebserviceHandler{}
+	component := &oam.Component{
+		Name: "app",
+		Type: "webservice",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/app:v1",
+			"livenessProbe": map[string]any{
+				"httpGet": map[string]any{
+					"path": "/healthz",
+					"port": 8080,
+				},
+				"initialDelaySeconds": 10,
+				"periodSeconds":       5,
+			},
+			"readinessProbe": map[string]any{
+				"httpGet": map[string]any{
+					"path": "/ready",
+					"port": "http",
+				},
+			},
+		},
+	}
+	cfg, err := h.ToApplicationConfig(component, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	app := stack.NewApplication("app", "default", cfg)
+	if _, err := cfg.Generate(app); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+}
+
+func TestWebserviceHandler_WithAffinity(t *testing.T) {
+	h := &components.WebserviceHandler{}
+	component := &oam.Component{
+		Name: "app",
+		Type: "webservice",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/app:v1",
+			"affinity": map[string]any{
+				"enablePodAntiAffinity": true,
+				"podAntiAffinityType":   "required",
+				"topologyKey":           "kubernetes.io/hostname",
+				"nodeSelector": map[string]any{
+					"disktype": "ssd",
+				},
+			},
+		},
+	}
+	cfg, err := h.ToApplicationConfig(component, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	app := stack.NewApplication("app", "default", cfg)
+	if _, err := cfg.Generate(app); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+}
+
+func TestWebserviceHandler_InvalidAffinity(t *testing.T) {
+	h := &components.WebserviceHandler{}
+	component := &oam.Component{
+		Name: "app",
+		Type: "webservice",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/app:v1",
+			"affinity": map[string]any{
+				"podAntiAffinityType": "invalid",
+			},
+		},
+	}
+	_, err := h.ToApplicationConfig(component, "default")
+	if err == nil {
+		t.Fatal("expected error for invalid podAntiAffinityType")
+	}
+}

--- a/pkg/oam/builtin/components/worker.go
+++ b/pkg/oam/builtin/components/worker.go
@@ -1,0 +1,243 @@
+package components
+
+import (
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// WorkerHandler handles OAM worker components.
+type WorkerHandler struct{}
+
+// CanHandle returns true for worker component type.
+func (h *WorkerHandler) CanHandle(componentType string) bool {
+	return componentType == "worker"
+}
+
+// ToApplicationConfig converts an OAM worker component to a WorkerConfig.
+func (h *WorkerHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	config := &WorkerConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	image, ok := props["image"].(string)
+	if !ok {
+		return nil, errors.New("required property 'image' missing or not a string")
+	}
+	if err := ValidateImageRef(image); err != nil {
+		return nil, err
+	}
+	config.Image = image
+
+	config.Replicas = parseReplicas(props, 1)
+	config.explicitReplicas = hasExplicitReplicas(props)
+
+	env, err := parseEnv(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Env = env
+	if resources, ok := props["resources"].(map[string]any); ok {
+		config.Resources = parseResources(resources)
+	}
+	config.explicitResources = resourceExplicitFlags(props)
+	config.Command = parseCommand(props)
+	config.Args = parseArgs(props)
+	probes, err := parseProbes(props)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid probe configuration")
+	}
+	config.Probes = probes
+
+	parsed, err := parseVolumes(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Volumes = parsed.Volumes
+	config.VolumeMounts = parsed.Mounts
+	config.PVCs = parsed.PVCs
+
+	initContainers, err := parseInitContainers(props)
+	if err != nil {
+		return nil, err
+	}
+	config.InitContainers = initContainers
+	if ts, ok := props["topologySpread"].(bool); ok && !ts {
+		config.TopologySpreadDisabled = true
+	}
+	affinity, err := parseAffinity(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Affinity = affinity
+
+	sidecars, err := parseSidecars(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Sidecars = sidecars
+
+	return config, nil
+}
+
+// WorkerConfig implements stack.ApplicationConfig for worker components.
+type WorkerConfig struct {
+	Name                   string
+	Namespace              string
+	Image                  string
+	Replicas               int32
+	Env                    []EnvVar
+	Resources              ResourceRequirements
+	Command                []string
+	Args                   []string
+	Probes                 ProbeConfig
+	Volumes                []corev1.Volume
+	VolumeMounts           []corev1.VolumeMount
+	PVCs                   []PVCConfig
+	InitContainers         []InitContainerConfig
+	Sidecars               []SidecarContainerConfig
+	TopologySpreadDisabled bool
+	Affinity               AffinityConfig
+	explicitReplicas       bool
+	explicitResources      explicitResourceFlags
+}
+
+// ApplyPolicy applies defaults then enforces limits from the policy.
+// Defaults are applied first so that enforced checks run on effective post-default values.
+func (c *WorkerConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil {
+		return nil
+	}
+
+	c.Replicas = applyDefaultReplicas(c.Replicas, c.explicitReplicas, p.DefaultReplicas())
+	if !c.explicitResources.cpuRequest {
+		c.Resources.CPURequest = applyDefaultResource(c.Resources.CPURequest, p.DefaultCPURequest())
+	}
+	if !c.explicitResources.memoryRequest {
+		c.Resources.MemoryRequest = applyDefaultResource(c.Resources.MemoryRequest, p.DefaultMemoryRequest())
+	}
+	if !c.explicitResources.cpuLimit {
+		c.Resources.CPULimit = applyDefaultResource(c.Resources.CPULimit, p.DefaultCPULimit())
+	}
+	if !c.explicitResources.memoryLimit {
+		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
+	}
+
+	if err := enforceMaxReplicas(c.Replicas, p.MaxReplicas()); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPURequest, p.MaxCPU(), "cpu request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPULimit, p.MaxCPU(), "cpu limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryRequest, p.MaxMemory(), "memory request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryLimit, p.MaxMemory(), "memory limit"); err != nil {
+		return err
+	}
+	if err := enforceAllowedRegistries(c.Image, p.AllowedRegistries()); err != nil {
+		return err
+	}
+	for _, pvc := range c.PVCs {
+		if err := enforceMaxStorageSize(pvc.Size, p.MaxStorageSize()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Generate creates a Kubernetes Deployment and ServiceAccount (no Service).
+func (c *WorkerConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": app.Name}
+	deployment, err := c.createDeployment(app)
+	if err != nil {
+		return nil, err
+	}
+	sa := createServiceAccount(app.Name, app.Namespace, labels)
+
+	depObj := client.Object(deployment)
+	saObj := client.Object(sa)
+
+	objects := []*client.Object{&depObj, &saObj}
+	for _, pvc := range c.PVCs {
+		p, err := BuildPVC(pvc, app.Namespace, labels)
+		if err != nil {
+			return nil, err
+		}
+		pObj := client.Object(p)
+		objects = append(objects, &pObj)
+	}
+
+	return objects, nil
+}
+
+func (c *WorkerConfig) createDeployment(app *stack.Application) (*appsv1.Deployment, error) {
+	labels := map[string]string{"app": app.Name}
+
+	container := kubernetes.CreateContainer(app.Name, c.Image, c.Command, c.Args)
+	rr, err := buildResourceRequirements(c.Resources)
+	if err != nil {
+		return nil, errors.Wrap(err, "resource requirements")
+	}
+	_ = kubernetes.SetContainerResources(container, rr)
+	for _, env := range buildEnvVars(c.Env) {
+		_ = kubernetes.AddContainerEnv(container, env)
+	}
+	applyProbes(container, c.Probes)
+	for _, m := range c.VolumeMounts {
+		_ = kubernetes.AddContainerVolumeMount(container, m)
+	}
+
+	dep := kubernetes.CreateDeployment(app.Name, app.Namespace)
+	dep.Labels = labels
+	dep.Annotations = nil
+	dep.Spec.Template.Labels = labels
+	_ = kubernetes.SetDeploymentReplicas(dep, c.Replicas)
+	if hasNonRWXPVC(c.PVCs) {
+		if c.Replicas > 1 {
+			return nil, errors.Errorf("deployment %q: non-RWX PVC requires replicas=1, got %d", app.Name, c.Replicas)
+		}
+		_ = kubernetes.SetDeploymentStrategy(dep, appsv1.DeploymentStrategy{Type: appsv1.RecreateDeploymentStrategyType})
+	}
+	_ = kubernetes.SetDeploymentServiceAccountName(dep, app.Name)
+	if !c.TopologySpreadDisabled {
+		for _, tsc := range buildTopologySpreadConstraints(c.Replicas, map[string]string{"app": app.Name}) {
+			_ = kubernetes.AddDeploymentTopologySpreadConstraints(dep, &tsc)
+		}
+	}
+	for _, ic := range c.InitContainers {
+		initContainer, err := buildInitContainer(ic)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddDeploymentInitContainer(dep, initContainer)
+	}
+	_ = kubernetes.AddDeploymentContainer(dep, container)
+	for _, sc := range c.Sidecars {
+		sidecarContainer, err := buildSidecarContainer(sc)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddDeploymentContainer(dep, sidecarContainer)
+	}
+	for i := range c.Volumes {
+		_ = kubernetes.AddDeploymentVolume(dep, &c.Volumes[i])
+	}
+	if aff := buildAffinity(c.Affinity, map[string]string{"app": app.Name}); aff != nil {
+		_ = kubernetes.SetDeploymentAffinity(dep, aff)
+	}
+
+	return dep, nil
+}

--- a/pkg/oam/builtin/components/worker_test.go
+++ b/pkg/oam/builtin/components/worker_test.go
@@ -1,0 +1,115 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestWorkerHandler_CanHandle(t *testing.T) {
+	h := &components.WorkerHandler{}
+	if !h.CanHandle("worker") {
+		t.Error("expected true for worker")
+	}
+	if h.CanHandle("webservice") {
+		t.Error("expected false for webservice")
+	}
+}
+
+func TestWorkerHandler_RequiredImage_Missing(t *testing.T) {
+	h := &components.WorkerHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "app",
+		Type:       "worker",
+		Properties: map[string]any{},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing image")
+	}
+}
+
+func TestWorkerHandler_Generate_NoService(t *testing.T) {
+	h := &components.WorkerHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "backend",
+		Type: "worker",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/backend:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("backend", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var foundDeployment, foundService, foundSA bool
+	for _, obj := range objects {
+		switch (*obj).(type) {
+		case *appsv1.Deployment:
+			foundDeployment = true
+		case *corev1.Service:
+			foundService = true
+		case *corev1.ServiceAccount:
+			foundSA = true
+		}
+	}
+	if !foundDeployment {
+		t.Error("expected Deployment")
+	}
+	if foundService {
+		t.Error("worker must not generate a Service")
+	}
+	if !foundSA {
+		t.Error("expected ServiceAccount")
+	}
+}
+
+func TestWorkerConfig_ApplyPolicy_MaxReplicas(t *testing.T) {
+	h := &components.WorkerHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "app",
+		Type: "worker",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/app:v1",
+			"replicas": 3,
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPolicy{maxReplicas: int32ptr(2)}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when replicas exceed max")
+	}
+}
+
+func TestWorkerConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	h := &components.WorkerHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "app",
+		Type: "worker",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/app:v1",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy should be a no-op, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Ports three OAM component handlers from crane: `worker` (Deployment, no Service), `cronjob` (CronJob), and `daemonset` (DaemonSet), each with a ServiceAccount — closes partial #48
- Adds `parseTolerations` validation to `common.go`: non-string `key`/`operator`/`value`/`effect` fields are now hard errors instead of silently widening scheduling
- Adds `parseHistoryLimit` to `common.go`: cronjob history limits reject fractional floats and negative integers at build time
- Establishes fixture parity infrastructure (closes #54): directory-per-scenario golden files under `pkg/cmd/kurel/testdata/`, a table-driven `fixtures_test.go` that runs the full CLI path via `cobra.Command.Execute()`, and `UPDATE_GOLDEN=1` regeneration support

## Test plan

- [ ] `GOWORK=off go test ./...` — all packages green
- [ ] `GOWORK=off mise run lint` — 0 issues
- [ ] Total coverage ≥ 80% (`go tool cover -func | tail -1`)
- [ ] Smoke: `go run ./cmd/kurel build pkg/cmd/kurel/testdata/worker-minimal/app.yaml --profile pkg/cmd/kurel/testdata/worker-minimal/cluster.yaml`
- [ ] Smoke: `go run ./cmd/kurel build pkg/cmd/kurel/testdata/cronjob-minimal/app.yaml --profile pkg/cmd/kurel/testdata/cronjob-minimal/cluster.yaml`
- [ ] Smoke: `go run ./cmd/kurel build pkg/cmd/kurel/testdata/daemonset-minimal/app.yaml --profile pkg/cmd/kurel/testdata/daemonset-minimal/cluster.yaml`
- [ ] Toleration validation: `key: 123` in a daemonset app.yaml is rejected with a clear error
- [ ] History limit validation: `successfulJobsHistoryLimit: 1.5` or `-1` in a cronjob app.yaml is rejected with a clear error
- [ ] Golden file regeneration: `UPDATE_GOLDEN=1 GOWORK=off go test ./pkg/cmd/kurel/...` updates expected.yaml files