### PR TITLE
feat(oam): add statefulset handler and certificate/scaler/pvc traits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-kure/launcher
 go 1.26.3
 
 require (
+	github.com/cert-manager/cert-manager v1.20.2
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/go-kure/kure v0.2.0-alpha.3
 	github.com/google/go-containerregistry v0.21.5
@@ -22,7 +23,6 @@ require (
 	github.com/backube/volsync v0.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
-	github.com/cert-manager/cert-manager v1.20.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cilium/cilium v1.19.3 // indirect
 	github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9 // indirect

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -115,14 +115,18 @@ func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
 func newBuiltinTransformer() *oam.Transformer {
 	return oam.NewTransformer(
 		map[string]oam.ComponentHandler{
-			"webservice": &components.WebserviceHandler{},
-			"worker":     &components.WorkerHandler{},
-			"cronjob":    &components.CronjobHandler{},
-			"daemonset":  &components.DaemonsetHandler{},
+			"webservice":  &components.WebserviceHandler{},
+			"worker":      &components.WorkerHandler{},
+			"cronjob":     &components.CronjobHandler{},
+			"daemonset":   &components.DaemonsetHandler{},
+			"statefulset": &components.StatefulsetHandler{},
 		},
 		map[string]oam.TraitHandler{
-			"expose":  &traits.ExposeHandler{},
-			"ingress": &traits.IngressHandler{}, //nolint:staticcheck
+			"expose":      &traits.ExposeHandler{},
+			"ingress":     &traits.IngressHandler{}, //nolint:staticcheck
+			"certificate": &traits.CertificateHandler{},
+			"scaler":      &traits.ScalerHandler{},
+			"pvc":         &traits.PVCHandler{},
 		},
 	)
 }

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -166,7 +166,7 @@ metadata:
 spec:
   components:
     - name: backend
-      type: statefulset
+      type: helmrelease
       properties:
         image: ghcr.io/example/backend:v1.0.0
 `
@@ -182,7 +182,7 @@ spec:
 	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error for unsupported component type 'statefulset'")
+		t.Fatal("expected error for unsupported component type 'helmrelease'")
 	}
 }
 

--- a/pkg/cmd/kurel/fixtures_test.go
+++ b/pkg/cmd/kurel/fixtures_test.go
@@ -8,15 +8,17 @@ import (
 	"testing"
 )
 
-// TestFixtures runs each scenario in testdata/ through the real CLI and compares
-// stdout against expected.yaml. Set UPDATE_GOLDEN=1 to regenerate expected files.
+// TestFixtures runs all scenario directories under testdata/.
+// Each scenario directory must contain app.yaml and cluster.yaml.
+// The expected output is compared against expected.yaml.
+// Set UPDATE_GOLDEN=1 to regenerate expected.yaml files.
 func TestFixtures(t *testing.T) {
 	scenarios, err := filepath.Glob("testdata/*/app.yaml")
 	if err != nil {
-		t.Fatalf("globbing testdata: %v", err)
+		t.Fatalf("globbing fixture scenarios: %v", err)
 	}
 	if len(scenarios) == 0 {
-		t.Fatal("no fixture scenarios found in testdata/")
+		t.Fatal("no fixture scenarios found under testdata/*/app.yaml")
 	}
 
 	update := os.Getenv("UPDATE_GOLDEN") == "1"
@@ -29,10 +31,6 @@ func TestFixtures(t *testing.T) {
 			profilePath := filepath.Join(dir, "cluster.yaml")
 			expectedPath := filepath.Join(dir, "expected.yaml")
 
-			if _, err := os.Stat(profilePath); os.IsNotExist(err) {
-				t.Fatalf("missing cluster.yaml for scenario %q", name)
-			}
-
 			cmd := NewKurelCommand()
 			var out bytes.Buffer
 			cmd.SetOut(&out)
@@ -40,29 +38,23 @@ func TestFixtures(t *testing.T) {
 			cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
 
 			if err := cmd.Execute(); err != nil {
-				t.Fatalf("build failed: %v\noutput: %s", err, out.String())
+				t.Fatalf("build command failed: %v\noutput: %s", err, out.String())
 			}
-
 			got := out.String()
 
 			if update {
 				if err := os.WriteFile(expectedPath, []byte(got), 0644); err != nil {
-					t.Fatalf("writing expected.yaml: %v", err)
+					t.Fatalf("writing golden file %q: %v", expectedPath, err)
 				}
-				t.Logf("updated %s", expectedPath)
 				return
 			}
 
-			expected, err := os.ReadFile(expectedPath)
-			if os.IsNotExist(err) {
-				t.Fatalf("expected.yaml missing for %q — run with UPDATE_GOLDEN=1 to generate", name)
-			}
+			data, err := os.ReadFile(expectedPath)
 			if err != nil {
-				t.Fatalf("reading expected.yaml: %v", err)
+				t.Fatalf("reading expected file %q: %v (run with UPDATE_GOLDEN=1 to generate)", expectedPath, err)
 			}
-
-			if strings.TrimSpace(got) != strings.TrimSpace(string(expected)) {
-				t.Errorf("output mismatch for %q\n--- expected ---\n%s\n--- got ---\n%s", name, expected, got)
+			if strings.TrimSpace(got) != strings.TrimSpace(string(data)) {
+				t.Errorf("fixture %q output mismatch:\nwant:\n%s\ngot:\n%s", name, data, got)
 			}
 		})
 	}

--- a/pkg/cmd/kurel/testdata/certificate-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/certificate-minimal/app.yaml
@@ -1,0 +1,18 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+      traits:
+        - type: certificate
+          properties:
+            secretName: frontend-tls
+            dnsNames:
+              - frontend.example.com

--- a/pkg/cmd/kurel/testdata/certificate-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/certificate-minimal/cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    certificate:
+      rendering:
+        issuerRefName: letsencrypt-prod
+        issuerRefKind: ClusterIssuer

--- a/pkg/cmd/kurel/testdata/certificate-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/certificate-minimal/expected.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: ghcr.io/example/frontend:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: frontend
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: frontend
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: frontend-tls
+  namespace: default
+spec:
+  dnsNames:
+  - frontend.example.com
+  duration: 2160h0m0s
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-prod
+  renewBefore: 360h0m0s
+  secretName: frontend-tls

--- a/pkg/cmd/kurel/testdata/pvc-trait/app.yaml
+++ b/pkg/cmd/kurel/testdata/pvc-trait/app.yaml
@@ -1,0 +1,17 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: pvc
+          properties:
+            name: shared-data
+            size: 5Gi

--- a/pkg/cmd/kurel/testdata/pvc-trait/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/pvc-trait/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/pvc-trait/expected.yaml
+++ b/pkg/cmd/kurel/testdata/pvc-trait/expected.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app: api
+  name: shared-data
+  namespace: default
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/pkg/cmd/kurel/testdata/scaler-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-minimal/app.yaml
@@ -1,0 +1,17 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: scaler
+          properties:
+            minReplicas: 2
+            maxReplicas: 10

--- a/pkg/cmd/kurel/testdata/scaler-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/scaler-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-minimal/expected.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: api
+  name: api-hpa
+  namespace: default
+spec:
+  maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api

--- a/pkg/cmd/kurel/testdata/scaler-with-pdb/app.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-with-pdb/app.yaml
@@ -1,0 +1,18 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: scaler
+          properties:
+            minReplicas: 2
+            maxReplicas: 10
+            enablePDB: true

--- a/pkg/cmd/kurel/testdata/scaler-with-pdb/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-with-pdb/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/scaler-with-pdb/expected.yaml
+++ b/pkg/cmd/kurel/testdata/scaler-with-pdb/expected.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  labels:
+    app: api
+  name: api-hpa
+  namespace: default
+spec:
+  maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  labels:
+    app: api
+  name: api-pdb
+  namespace: default
+spec:
+  minAvailable: 50%
+  selector:
+    matchLabels:
+      app: api

--- a/pkg/cmd/kurel/testdata/statefulset-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-minimal/app.yaml
@@ -1,0 +1,16 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  components:
+    - name: db
+      type: statefulset
+      properties:
+        image: ghcr.io/example/postgres:v15.0
+        port: 5432
+        volumeClaimTemplates:
+          - name: data
+            size: 10Gi
+            mountPath: /var/lib/postgresql/data

--- a/pkg/cmd/kurel/testdata/statefulset-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/statefulset-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-minimal/expected.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  serviceName: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - image: ghcr.io/example/postgres:v15.0
+        imagePullPolicy: IfNotPresent
+        name: db
+        ports:
+        - containerPort: 5432
+          name: tcp
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: data
+      serviceAccountName: db
+  updateStrategy: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: db
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default

--- a/pkg/oam/builtin/certificate.go
+++ b/pkg/oam/builtin/certificate.go
@@ -1,0 +1,13 @@
+package builtin
+
+// CertificateRendering defines the platform values for the certificate capability.
+// All fields are valid rendering keys; unknown fields are rejected at
+// ClusterProfile evaluation time via DecodeStrict.
+type CertificateRendering struct {
+	// IssuerRefName is the name of the cert-manager issuer. Required.
+	IssuerRefName string `yaml:"issuerRefName" json:"issuerRefName"`
+
+	// IssuerRefKind is the kind of the cert-manager issuer.
+	// Defaults to "ClusterIssuer" when omitted.
+	IssuerRefKind string `yaml:"issuerRefKind,omitempty" json:"issuerRefKind,omitempty"`
+}

--- a/pkg/oam/builtin/components/common.go
+++ b/pkg/oam/builtin/components/common.go
@@ -1079,6 +1079,56 @@ func createServiceAccount(name, namespace string, labels map[string]string) *cor
 	return sa
 }
 
+// VolumeClaimTemplate represents a PVC template for a StatefulSet.
+type VolumeClaimTemplate struct {
+	Name         string
+	StorageClass string
+	Size         string
+	AccessModes  []string
+	MountPath    string
+}
+
+// parseVolumeClaimTemplates parses volumeClaimTemplates from OAM properties.
+func parseVolumeClaimTemplates(props map[string]any) ([]VolumeClaimTemplate, error) {
+	vctList, ok := props["volumeClaimTemplates"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	var vcts []VolumeClaimTemplate
+	for _, v := range vctList {
+		m, ok := v.(map[string]any)
+		if !ok {
+			return nil, errors.New("volumeClaimTemplates: each entry must be a mapping")
+		}
+		vct := VolumeClaimTemplate{}
+		vct.Name, _ = m["name"].(string)
+		vct.StorageClass, _ = m["storageClass"].(string)
+		vct.Size, _ = m["size"].(string)
+		vct.MountPath, _ = m["mountPath"].(string)
+		if modes, ok := m["accessModes"].([]any); ok {
+			for _, mode := range modes {
+				if s, ok := mode.(string); ok {
+					vct.AccessModes = append(vct.AccessModes, s)
+				}
+			}
+		}
+		if vct.Name == "" {
+			return nil, errors.New("volumeClaimTemplate entry missing required field 'name'")
+		}
+		if vct.Size == "" {
+			return nil, errors.Errorf("volumeClaimTemplate %q missing required field 'size'", vct.Name)
+		}
+		if vct.MountPath == "" {
+			return nil, errors.Errorf("volumeClaimTemplate %q missing required field 'mountPath'", vct.Name)
+		}
+		if _, err := resource.ParseQuantity(vct.Size); err != nil {
+			return nil, errors.Errorf("volumeClaimTemplate %q: invalid size %q: %w", vct.Name, vct.Size, err)
+		}
+		vcts = append(vcts, vct)
+	}
+	return vcts, nil
+}
+
 // BuildPVC creates a PersistentVolumeClaim from a PVCConfig.
 func BuildPVC(pvc PVCConfig, namespace string, labels map[string]string) (*corev1.PersistentVolumeClaim, error) {
 	qty, err := resource.ParseQuantity(pvc.Size)

--- a/pkg/oam/builtin/components/common.go
+++ b/pkg/oam/builtin/components/common.go
@@ -1105,13 +1105,11 @@ func parseVolumeClaimTemplates(props map[string]any) ([]VolumeClaimTemplate, err
 		vct.StorageClass, _ = m["storageClass"].(string)
 		vct.Size, _ = m["size"].(string)
 		vct.MountPath, _ = m["mountPath"].(string)
-		if modes, ok := m["accessModes"].([]any); ok {
-			for _, mode := range modes {
-				if s, ok := mode.(string); ok {
-					vct.AccessModes = append(vct.AccessModes, s)
-				}
-			}
+		accessModes, err := parseAccessModes(m)
+		if err != nil {
+			return nil, errors.Wrapf(err, "volumeClaimTemplate %q", vct.Name)
 		}
+		vct.AccessModes = accessModes
 		if vct.Name == "" {
 			return nil, errors.New("volumeClaimTemplate entry missing required field 'name'")
 		}

--- a/pkg/oam/builtin/components/statefulset.go
+++ b/pkg/oam/builtin/components/statefulset.go
@@ -1,0 +1,309 @@
+package components
+
+import (
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// StatefulsetHandler handles OAM statefulset components.
+type StatefulsetHandler struct{}
+
+// CanHandle returns true for statefulset component type.
+func (h *StatefulsetHandler) CanHandle(componentType string) bool {
+	return componentType == "statefulset"
+}
+
+// ToApplicationConfig converts an OAM statefulset component to a StatefulsetConfig.
+func (h *StatefulsetHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	config := &StatefulsetConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	image, ok := props["image"].(string)
+	if !ok {
+		return nil, errors.New("required property 'image' missing or not a string")
+	}
+	if err := ValidateImageRef(image); err != nil {
+		return nil, err
+	}
+	config.Image = image
+
+	config.Replicas = parseReplicas(props, 1)
+	config.explicitReplicas = hasExplicitReplicas(props)
+
+	if p, ok := toInt32(props["port"]); ok {
+		config.Port = p
+	}
+
+	if sn, ok := props["serviceName"].(string); ok && sn != "" {
+		config.ServiceName = sn
+	} else {
+		config.ServiceName = component.Name
+	}
+
+	env, err := parseEnv(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Env = env
+
+	if resources, ok := props["resources"].(map[string]any); ok {
+		config.Resources = parseResources(resources)
+	}
+	config.explicitResources = resourceExplicitFlags(props)
+	config.Command = parseCommand(props)
+	config.Args = parseArgs(props)
+
+	probes, err := parseProbes(props)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid probe configuration")
+	}
+	config.Probes = probes
+
+	vcts, err := parseVolumeClaimTemplates(props)
+	if err != nil {
+		return nil, err
+	}
+	config.VolumeClaimTemplates = vcts
+
+	parsed, err := parseVolumes(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Volumes = parsed.Volumes
+	config.VolumeMounts = parsed.Mounts
+	config.PVCs = parsed.PVCs
+
+	initContainers, err := parseInitContainers(props)
+	if err != nil {
+		return nil, err
+	}
+	config.InitContainers = initContainers
+
+	affinity, err := parseAffinity(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Affinity = affinity
+
+	sidecars, err := parseSidecars(props)
+	if err != nil {
+		return nil, err
+	}
+	config.Sidecars = sidecars
+
+	return config, nil
+}
+
+// StatefulsetConfig implements stack.ApplicationConfig for statefulset components.
+type StatefulsetConfig struct {
+	Name                 string
+	Namespace            string
+	Image                string
+	Replicas             int32
+	Port                 int32
+	ServiceName          string
+	Env                  []EnvVar
+	Resources            ResourceRequirements
+	Command              []string
+	Args                 []string
+	Probes               ProbeConfig
+	VolumeClaimTemplates []VolumeClaimTemplate
+	Volumes              []corev1.Volume
+	VolumeMounts         []corev1.VolumeMount
+	PVCs                 []PVCConfig
+	InitContainers       []InitContainerConfig
+	Sidecars             []SidecarContainerConfig
+	Affinity             AffinityConfig
+	explicitReplicas     bool
+	explicitResources    explicitResourceFlags
+}
+
+// ApplyPolicy applies defaults then enforces limits from the policy.
+func (c *StatefulsetConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil {
+		return nil
+	}
+
+	c.Replicas = applyDefaultReplicas(c.Replicas, c.explicitReplicas, p.DefaultReplicas())
+	if !c.explicitResources.cpuRequest {
+		c.Resources.CPURequest = applyDefaultResource(c.Resources.CPURequest, p.DefaultCPURequest())
+	}
+	if !c.explicitResources.memoryRequest {
+		c.Resources.MemoryRequest = applyDefaultResource(c.Resources.MemoryRequest, p.DefaultMemoryRequest())
+	}
+	if !c.explicitResources.cpuLimit {
+		c.Resources.CPULimit = applyDefaultResource(c.Resources.CPULimit, p.DefaultCPULimit())
+	}
+	if !c.explicitResources.memoryLimit {
+		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
+	}
+
+	if err := enforceMaxReplicas(c.Replicas, p.MaxReplicas()); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPURequest, p.MaxCPU(), "cpu request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPULimit, p.MaxCPU(), "cpu limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryRequest, p.MaxMemory(), "memory request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryLimit, p.MaxMemory(), "memory limit"); err != nil {
+		return err
+	}
+	if err := enforceAllowedRegistries(c.Image, p.AllowedRegistries()); err != nil {
+		return err
+	}
+	for _, pvc := range c.PVCs {
+		if err := enforceMaxStorageSize(pvc.Size, p.MaxStorageSize()); err != nil {
+			return err
+		}
+	}
+	for _, vct := range c.VolumeClaimTemplates {
+		if err := enforceMaxStorageSize(vct.Size, p.MaxStorageSize()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Generate creates Kubernetes StatefulSet, headless Service, ServiceAccount, and any standalone PVCs.
+func (c *StatefulsetConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": app.Name}
+
+	sts, err := c.createStatefulSet(app)
+	if err != nil {
+		return nil, err
+	}
+	svc := c.createHeadlessService(app)
+	sa := createServiceAccount(app.Name, app.Namespace, labels)
+
+	stsObj := client.Object(sts)
+	svcObj := client.Object(svc)
+	saObj := client.Object(sa)
+
+	objects := []*client.Object{&stsObj, &svcObj, &saObj}
+	for _, pvc := range c.PVCs {
+		p, err := BuildPVC(pvc, app.Namespace, labels)
+		if err != nil {
+			return nil, err
+		}
+		pObj := client.Object(p)
+		objects = append(objects, &pObj)
+	}
+	return objects, nil
+}
+
+func (c *StatefulsetConfig) createStatefulSet(app *stack.Application) (*appsv1.StatefulSet, error) {
+	labels := map[string]string{"app": app.Name}
+
+	container := kubernetes.CreateContainer(app.Name, c.Image, c.Command, c.Args)
+	rr, err := buildResourceRequirements(c.Resources)
+	if err != nil {
+		return nil, errors.Wrap(err, "resource requirements")
+	}
+	_ = kubernetes.SetContainerResources(container, rr)
+	if c.Port > 0 {
+		_ = kubernetes.AddContainerPort(container, corev1.ContainerPort{
+			Name:          "tcp",
+			ContainerPort: c.Port,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
+	for _, env := range buildEnvVars(c.Env) {
+		_ = kubernetes.AddContainerEnv(container, env)
+	}
+	for _, vct := range c.VolumeClaimTemplates {
+		_ = kubernetes.AddContainerVolumeMount(container, corev1.VolumeMount{
+			Name:      vct.Name,
+			MountPath: vct.MountPath,
+		})
+	}
+	for _, m := range c.VolumeMounts {
+		_ = kubernetes.AddContainerVolumeMount(container, m)
+	}
+	applyProbes(container, c.Probes)
+
+	sts := kubernetes.CreateStatefulSet(app.Name, app.Namespace)
+	sts.Labels = labels
+	sts.Annotations = nil
+	sts.Spec.Template.Labels = labels
+	_ = kubernetes.SetStatefulSetReplicas(sts, c.Replicas)
+	_ = kubernetes.SetStatefulSetServiceName(sts, c.ServiceName)
+	_ = kubernetes.SetStatefulSetServiceAccountName(sts, app.Name)
+
+	for _, ic := range c.InitContainers {
+		initContainer, err := buildInitContainer(ic)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddStatefulSetInitContainer(sts, initContainer)
+	}
+	_ = kubernetes.AddStatefulSetContainer(sts, container)
+	for _, sc := range c.Sidecars {
+		sidecarContainer, err := buildSidecarContainer(sc)
+		if err != nil {
+			return nil, err
+		}
+		_ = kubernetes.AddStatefulSetContainer(sts, sidecarContainer)
+	}
+
+	if aff := buildAffinity(c.Affinity, map[string]string{"app": app.Name}); aff != nil {
+		_ = kubernetes.SetStatefulSetAffinity(sts, aff)
+	}
+
+	for _, vct := range c.VolumeClaimTemplates {
+		accessModes := make([]corev1.PersistentVolumeAccessMode, 0, len(vct.AccessModes))
+		for _, mode := range vct.AccessModes {
+			accessModes = append(accessModes, corev1.PersistentVolumeAccessMode(mode))
+		}
+		if len(accessModes) == 0 {
+			accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+		}
+		pvc := kubernetes.CreateVolumeClaimTemplate(vct.Name, kubernetes.VolumeClaimTemplateOptions{
+			StorageClassName: vct.StorageClass,
+			AccessModes:      accessModes,
+			StorageRequest:   resource.MustParse(vct.Size),
+		})
+		_ = kubernetes.AddStatefulSetVolumeClaimTemplate(sts, pvc)
+	}
+	for i := range c.Volumes {
+		_ = kubernetes.AddStatefulSetVolume(sts, &c.Volumes[i])
+	}
+
+	return sts, nil
+}
+
+func (c *StatefulsetConfig) createHeadlessService(app *stack.Application) *corev1.Service {
+	labels := map[string]string{"app": app.Name}
+
+	svc := kubernetes.CreateService(c.ServiceName, app.Namespace)
+	svc.Labels = labels
+	svc.Annotations = nil
+	_ = kubernetes.SetServiceClusterIP(svc, "None")
+	_ = kubernetes.SetServiceSelector(svc, map[string]string{"app": app.Name})
+	if c.Port > 0 {
+		_ = kubernetes.AddServicePort(svc, corev1.ServicePort{
+			Name:       "tcp",
+			Port:       c.Port,
+			TargetPort: intstr.FromInt32(c.Port),
+			Protocol:   corev1.ProtocolTCP,
+		})
+	}
+	return svc
+}

--- a/pkg/oam/builtin/components/statefulset_test.go
+++ b/pkg/oam/builtin/components/statefulset_test.go
@@ -1,0 +1,224 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestStatefulsetHandler_CanHandle(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	if !h.CanHandle("statefulset") {
+		t.Error("expected true for statefulset")
+	}
+	if h.CanHandle("webservice") {
+		t.Error("expected false for webservice")
+	}
+}
+
+func TestStatefulsetHandler_RequiredImage_Missing(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "db",
+		Type:       "statefulset",
+		Properties: map[string]any{},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing image")
+	}
+}
+
+func TestStatefulsetHandler_Generate_BasicResources(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+			"port":  5432,
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("db", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var foundSTS, foundSVC, foundSA bool
+	for _, obj := range objects {
+		switch (*obj).(type) {
+		case *appsv1.StatefulSet:
+			foundSTS = true
+		case *corev1.Service:
+			foundSVC = true
+		case *corev1.ServiceAccount:
+			foundSA = true
+		}
+	}
+	if !foundSTS {
+		t.Error("expected StatefulSet")
+	}
+	if !foundSVC {
+		t.Error("expected headless Service")
+	}
+	if !foundSA {
+		t.Error("expected ServiceAccount")
+	}
+}
+
+func TestStatefulsetHandler_VolumeClaimTemplates(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+			"volumeClaimTemplates": []any{
+				map[string]any{
+					"name":      "data",
+					"size":      "10Gi",
+					"mountPath": "/var/lib/data",
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("db", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var sts *appsv1.StatefulSet
+	for _, obj := range objects {
+		if s, ok := (*obj).(*appsv1.StatefulSet); ok {
+			sts = s
+		}
+	}
+	if sts == nil {
+		t.Fatal("expected StatefulSet in output")
+	}
+	if len(sts.Spec.VolumeClaimTemplates) != 1 {
+		t.Errorf("expected 1 VCT, got %d", len(sts.Spec.VolumeClaimTemplates))
+	}
+}
+
+func TestStatefulsetHandler_VolumeClaimTemplate_MissingName(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+			"volumeClaimTemplates": []any{
+				map[string]any{
+					"size":      "10Gi",
+					"mountPath": "/data",
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for missing VCT name")
+	}
+}
+
+func TestStatefulsetHandler_VolumeClaimTemplate_InvalidSize(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+			"volumeClaimTemplates": []any{
+				map[string]any{
+					"name":      "data",
+					"size":      "not-a-quantity",
+					"mountPath": "/data",
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error for invalid VCT size")
+	}
+}
+
+func TestStatefulsetConfig_ApplyPolicy_MaxReplicas(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image":    "ghcr.io/org/postgres:v15",
+			"replicas": 5,
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPolicy{maxReplicas: int32ptr(3)}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when replicas exceed max")
+	}
+}
+
+func TestStatefulsetConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy should be a no-op, got: %v", err)
+	}
+}
+
+func TestStatefulsetConfig_ApplyPolicy_VCTStorageSize(t *testing.T) {
+	h := &components.StatefulsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db",
+		Type: "statefulset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/postgres:v15",
+			"volumeClaimTemplates": []any{
+				map[string]any{
+					"name":      "data",
+					"size":      "100Gi",
+					"mountPath": "/data",
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPolicy{maxStorageSize: "10Gi"}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when VCT size exceeds max")
+	}
+}

--- a/pkg/oam/builtin/traits/certificate.go
+++ b/pkg/oam/builtin/traits/certificate.go
@@ -1,0 +1,148 @@
+package traits
+
+import (
+	"time"
+
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	"github.com/go-kure/kure/pkg/kubernetes/certmanager"
+	"github.com/go-kure/kure/pkg/stack"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// CertificateHandler handles OAM certificate traits.
+type CertificateHandler struct{}
+
+// CanHandle returns true for certificate trait type.
+func (h *CertificateHandler) CanHandle(traitType string) bool {
+	return traitType == "certificate"
+}
+
+// CapabilityRequired returns true: the certificate trait needs issuerRef from
+// a ClusterProfile capability and cannot produce a valid Certificate CR without it.
+func (h *CertificateHandler) CapabilityRequired() bool { return true }
+
+// ValidateAndApplyDefaults validates and normalises the certificate capability rendering.
+func (h *CertificateHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	r, err := builtin.DecodeStrict[builtin.CertificateRendering](rendering)
+	if err != nil {
+		return nil, errors.Wrap(err, "certificate rendering")
+	}
+	if r.IssuerRefName == "" {
+		return nil, errors.New("certificate rendering: issuerRefName is required")
+	}
+	if r.IssuerRefKind == "" {
+		rendering["issuerRefKind"] = "ClusterIssuer"
+	}
+	return rendering, nil
+}
+
+// Apply creates a cert-manager Certificate resource appended to the bundle.
+func (h *CertificateHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	certApp := stack.NewApplication(
+		app.Name+"-certificate",
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, certApp)
+	return nil
+}
+
+func (h *CertificateHandler) parseProperties(props map[string]any, app *stack.Application) (*CertificateConfig, error) {
+	config := &CertificateConfig{
+		ComponentName: app.Name,
+		Duration:      "2160h",
+		RenewBefore:   "360h",
+	}
+
+	secretName, ok := props["secretName"].(string)
+	if !ok || secretName == "" {
+		return nil, errors.New("required property 'secretName' missing or not a string")
+	}
+	config.SecretName = secretName
+
+	issuerName, ok := props["issuerRefName"].(string)
+	if !ok || issuerName == "" {
+		return nil, errors.New("required property 'issuerRefName' missing or not a string")
+	}
+	config.IssuerName = issuerName
+
+	config.IssuerKind = "ClusterIssuer"
+	if kind, ok := props["issuerRefKind"].(string); ok && kind != "" {
+		config.IssuerKind = kind
+	}
+
+	dnsNamesRaw, ok := props["dnsNames"].([]any)
+	if !ok || len(dnsNamesRaw) == 0 {
+		return nil, errors.New("required property 'dnsNames' missing or empty")
+	}
+	dnsNames := make([]string, 0, len(dnsNamesRaw))
+	for i, v := range dnsNamesRaw {
+		s, ok := v.(string)
+		if !ok {
+			return nil, errors.Errorf("dnsNames[%d]: expected string, got %T", i, v)
+		}
+		dnsNames = append(dnsNames, s)
+	}
+	config.DNSNames = dnsNames
+
+	if dur, ok := props["duration"].(string); ok && dur != "" {
+		config.Duration = dur
+	}
+	if renew, ok := props["renewBefore"].(string); ok && renew != "" {
+		config.RenewBefore = renew
+	}
+
+	return config, nil
+}
+
+// CertificateConfig implements stack.ApplicationConfig for certificate traits.
+type CertificateConfig struct {
+	SecretName    string
+	ComponentName string
+	IssuerName    string
+	IssuerKind    string
+	DNSNames      []string
+	Duration      string
+	RenewBefore   string
+}
+
+// ApplyPolicy is a no-op: certificates have no enforceable policy fields.
+func (c *CertificateConfig) ApplyPolicy(_ oam.Policy) error { return nil }
+
+// Generate creates a cert-manager Certificate resource.
+func (c *CertificateConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	dur, err := time.ParseDuration(c.Duration)
+	if err != nil {
+		return nil, errors.Errorf("invalid duration %q: %w", c.Duration, err)
+	}
+	renewBefore, err := time.ParseDuration(c.RenewBefore)
+	if err != nil {
+		return nil, errors.Errorf("invalid renewBefore %q: %w", c.RenewBefore, err)
+	}
+
+	cert := certmanager.Certificate(&certmanager.CertificateConfig{
+		Name:       c.SecretName,
+		Namespace:  app.Namespace,
+		SecretName: c.SecretName,
+		IssuerRef: cmmeta.IssuerReference{
+			Name: c.IssuerName,
+			Kind: c.IssuerKind,
+		},
+		DNSNames:    c.DNSNames,
+		Duration:    &metav1.Duration{Duration: dur},
+		RenewBefore: &metav1.Duration{Duration: renewBefore},
+	})
+
+	obj := client.Object(cert)
+	return []*client.Object{&obj}, nil
+}

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -1,0 +1,122 @@
+package traits
+
+import (
+	"github.com/go-kure/kure/pkg/stack"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+// PVCHandler handles OAM pvc traits, generating a standalone PersistentVolumeClaim.
+type PVCHandler struct{}
+
+// CanHandle returns true for the pvc trait type.
+func (h *PVCHandler) CanHandle(traitType string) bool {
+	return traitType == "pvc"
+}
+
+// Apply parses the trait properties and appends a standalone PVC to the bundle.
+func (h *PVCHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	pvcApp := stack.NewApplication(
+		config.Name,
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, pvcApp)
+	return nil
+}
+
+func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Application) (*PVCTraitConfig, error) {
+	name, _ := props["name"].(string)
+	if name == "" {
+		return nil, errors.New("required property 'name' missing or not a string")
+	}
+
+	size, _ := props["size"].(string)
+	if size == "" {
+		return nil, errors.New("required property 'size' missing or not a string")
+	}
+	if _, err := resource.ParseQuantity(size); err != nil {
+		return nil, errors.Errorf("invalid PVC size %q: %w", size, err)
+	}
+
+	var storageClass string
+	if s, ok := props["storageClassName"].(string); ok {
+		storageClass = s
+	}
+
+	accessModes := []string{"ReadWriteOnce"}
+	if rawModes, ok := props["accessModes"].([]any); ok {
+		accessModes = nil
+		for i, m := range rawModes {
+			s, ok := m.(string)
+			if !ok {
+				return nil, errors.Errorf("accessModes[%d]: expected string, got %T", i, m)
+			}
+			accessModes = append(accessModes, s)
+		}
+		if len(accessModes) == 0 {
+			return nil, errors.New("accessModes must contain at least one entry when specified")
+		}
+	}
+
+	return &PVCTraitConfig{
+		Name:          name,
+		ComponentName: app.Name,
+		Size:          size,
+		StorageClass:  storageClass,
+		AccessModes:   accessModes,
+	}, nil
+}
+
+// PVCTraitConfig implements stack.ApplicationConfig for standalone PVC traits.
+type PVCTraitConfig struct {
+	Name          string
+	ComponentName string
+	Size          string
+	StorageClass  string
+	AccessModes   []string
+}
+
+// ApplyPolicy enforces the policy storage-size limit against the requested PVC size.
+func (c *PVCTraitConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil || p.MaxStorageSize() == "" {
+		return nil
+	}
+	current, err := resource.ParseQuantity(c.Size)
+	if err != nil {
+		return errors.Errorf("invalid PVC size %q: %w", c.Size, err)
+	}
+	max, err := resource.ParseQuantity(p.MaxStorageSize())
+	if err != nil {
+		return errors.Errorf("invalid maxStorageSize %q in policy: %w", p.MaxStorageSize(), err)
+	}
+	if current.Cmp(max) > 0 {
+		return errors.Errorf("PVC %q size %q exceeds maximum storage size %q", c.Name, c.Size, p.MaxStorageSize())
+	}
+	return nil
+}
+
+// Generate delegates to components.BuildPVC so the trait shares the same PVC construction path.
+func (c *PVCTraitConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": c.ComponentName}
+	pvc, err := components.BuildPVC(components.PVCConfig{
+		Name:         c.Name,
+		Size:         c.Size,
+		StorageClass: c.StorageClass,
+		AccessModes:  c.AccessModes,
+	}, app.Namespace, labels)
+	if err != nil {
+		return nil, err
+	}
+	obj := client.Object(pvc)
+	return []*client.Object{&obj}, nil
+}

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -10,6 +10,13 @@ import (
 	"github.com/go-kure/launcher/pkg/oam/builtin/components"
 )
 
+var validPVCAccessModes = map[string]bool{
+	"ReadWriteOnce":    true,
+	"ReadOnlyMany":     true,
+	"ReadWriteMany":    true,
+	"ReadWriteOncePod": true,
+}
+
 // PVCHandler handles OAM pvc traits, generating a standalone PersistentVolumeClaim.
 type PVCHandler struct{}
 
@@ -54,17 +61,17 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 	}
 
 	accessModes := []string{"ReadWriteOnce"}
-	if rawModes, ok := props["accessModes"].([]any); ok {
+	if rawModes, ok := props["accessModes"].([]any); ok && len(rawModes) > 0 {
 		accessModes = nil
 		for i, m := range rawModes {
 			s, ok := m.(string)
 			if !ok {
 				return nil, errors.Errorf("accessModes[%d]: expected string, got %T", i, m)
 			}
+			if !validPVCAccessModes[s] {
+				return nil, errors.Errorf("invalid accessMode %q: must be one of ReadWriteOnce, ReadOnlyMany, ReadWriteMany, ReadWriteOncePod", s)
+			}
 			accessModes = append(accessModes, s)
-		}
-		if len(accessModes) == 0 {
-			return nil, errors.New("accessModes must contain at least one entry when specified")
 		}
 	}
 

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -61,7 +61,10 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 	}
 
 	accessModes := []string{"ReadWriteOnce"}
-	if rawModes, ok := props["accessModes"].([]any); ok && len(rawModes) > 0 {
+	if rawModes, ok := props["accessModes"].([]any); ok {
+		if len(rawModes) == 0 {
+			return nil, errors.New("accessModes must not be empty when specified")
+		}
 		accessModes = nil
 		for i, m := range rawModes {
 			s, ok := m.(string)

--- a/pkg/oam/builtin/traits/scaler.go
+++ b/pkg/oam/builtin/traits/scaler.go
@@ -1,0 +1,187 @@
+package traits
+
+import (
+	"math"
+
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// ScalerHandler handles OAM scaler traits.
+type ScalerHandler struct{}
+
+// CanHandle returns true for scaler trait type.
+func (h *ScalerHandler) CanHandle(traitType string) bool {
+	return traitType == "scaler"
+}
+
+// Apply creates HPA and optionally PDB resources for the component.
+func (h *ScalerHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	scalerApp := stack.NewApplication(
+		app.Name+"-scaler",
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, scalerApp)
+	return nil
+}
+
+func (h *ScalerHandler) parseProperties(props map[string]any, app *stack.Application) (*ScalerConfig, error) {
+	config := &ScalerConfig{
+		ComponentName: app.Name,
+	}
+
+	minReplicas, ok := toInt32ForScaler(props["minReplicas"])
+	if !ok {
+		return nil, errors.New("required property 'minReplicas' missing or not a number")
+	}
+	config.MinReplicas = minReplicas
+
+	maxReplicas, ok := toInt32ForScaler(props["maxReplicas"])
+	if !ok {
+		return nil, errors.New("required property 'maxReplicas' missing or not a number")
+	}
+	config.MaxReplicas = maxReplicas
+
+	if config.MinReplicas < 1 {
+		return nil, errors.Errorf("minReplicas must be >= 1, got %d", config.MinReplicas)
+	}
+	if config.MaxReplicas < config.MinReplicas {
+		return nil, errors.Errorf("maxReplicas (%d) must be >= minReplicas (%d)", config.MaxReplicas, config.MinReplicas)
+	}
+
+	if _, exists := props["cpuUtilization"]; exists {
+		cpu, ok := toInt32ForScaler(props["cpuUtilization"])
+		if !ok {
+			return nil, errors.New("cpuUtilization must be a whole number")
+		}
+		if cpu < 1 || cpu > 100 {
+			return nil, errors.Errorf("cpuUtilization must be between 1 and 100, got %d", cpu)
+		}
+		config.CPUUtilization = &cpu
+	}
+
+	if _, exists := props["memoryUtilization"]; exists {
+		mem, ok := toInt32ForScaler(props["memoryUtilization"])
+		if !ok {
+			return nil, errors.New("memoryUtilization must be a whole number")
+		}
+		if mem < 1 || mem > 100 {
+			return nil, errors.Errorf("memoryUtilization must be between 1 and 100, got %d", mem)
+		}
+		config.MemoryUtilization = &mem
+	}
+
+	if config.CPUUtilization == nil && config.MemoryUtilization == nil {
+		defaultCPU := int32(80)
+		config.CPUUtilization = &defaultCPU
+	}
+
+	if pdb, ok := props["enablePDB"].(bool); ok {
+		config.EnablePDB = pdb
+	}
+	if config.EnablePDB && config.MinReplicas < 2 {
+		return nil, errors.Errorf("enablePDB requires minReplicas >= 2 (got %d); with 1 replica PDB blocks all voluntary disruptions", config.MinReplicas)
+	}
+
+	return config, nil
+}
+
+// toInt32ForScaler parses v as int32, requiring a whole number.
+func toInt32ForScaler(v any) (int32, bool) {
+	switch n := v.(type) {
+	case float64:
+		if math.IsNaN(n) || math.IsInf(n, 0) || n != math.Trunc(n) {
+			return 0, false
+		}
+		if n < math.MinInt32 || n > math.MaxInt32 {
+			return 0, false
+		}
+		return int32(n), true //nolint:gosec
+	case int:
+		if n < math.MinInt32 || n > math.MaxInt32 {
+			return 0, false
+		}
+		return int32(n), true //nolint:gosec
+	case int32:
+		return n, true
+	case int64:
+		if n < math.MinInt32 || n > math.MaxInt32 {
+			return 0, false
+		}
+		return int32(n), true //nolint:gosec
+	default:
+		return 0, false
+	}
+}
+
+// ScalerConfig implements stack.ApplicationConfig for scaler traits.
+type ScalerConfig struct {
+	ComponentName     string
+	MinReplicas       int32
+	MaxReplicas       int32
+	CPUUtilization    *int32
+	MemoryUtilization *int32
+	EnablePDB         bool
+}
+
+// ApplyPolicy is a no-op: the scaler trait has no enforceable policy fields.
+func (c *ScalerConfig) ApplyPolicy(_ oam.Policy) error { return nil }
+
+// Generate creates HPA and optionally PDB Kubernetes resources.
+func (c *ScalerConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": c.ComponentName}
+
+	var resources []*client.Object
+
+	hpa := c.buildHPA(app, labels)
+	hpaObj := client.Object(hpa)
+	resources = append(resources, &hpaObj)
+
+	if c.EnablePDB {
+		pdb := c.buildPDB(app, labels)
+		pdbObj := client.Object(pdb)
+		resources = append(resources, &pdbObj)
+	}
+
+	return resources, nil
+}
+
+func (c *ScalerConfig) buildHPA(app *stack.Application, labels map[string]string) *autoscalingv2.HorizontalPodAutoscaler {
+	hpa := kubernetes.CreateHorizontalPodAutoscaler(c.ComponentName+"-hpa", app.Namespace)
+	hpa.Labels = labels
+	hpa.Annotations = nil
+	_ = kubernetes.SetHPAScaleTargetRef(hpa, "apps/v1", "Deployment", c.ComponentName)
+	_ = kubernetes.SetHPAMinMaxReplicas(hpa, c.MinReplicas, c.MaxReplicas)
+	if c.CPUUtilization != nil {
+		_ = kubernetes.AddHPACPUMetric(hpa, *c.CPUUtilization)
+	}
+	if c.MemoryUtilization != nil {
+		_ = kubernetes.AddHPAMemoryMetric(hpa, *c.MemoryUtilization)
+	}
+	return hpa
+}
+
+func (c *ScalerConfig) buildPDB(app *stack.Application, labels map[string]string) *policyv1.PodDisruptionBudget {
+	pdb := kubernetes.CreatePodDisruptionBudget(c.ComponentName+"-pdb", app.Namespace)
+	pdb.Labels = labels
+	pdb.Annotations = nil
+	_ = kubernetes.SetPDBMinAvailable(pdb, intstr.FromString("50%"))
+	_ = kubernetes.SetPDBSelector(pdb, &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": c.ComponentName},
+	})
+	return pdb
+}

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -334,3 +334,451 @@ func TestIngressHandler_Apply_NamedSubApp(t *testing.T) {
 		t.Errorf("expected name 'custom-ingress', got %q", bundle.Applications[0].Name)
 	}
 }
+
+// --- CertificateHandler ---
+
+func TestCertificateHandler_CanHandle(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	if !h.CanHandle("certificate") {
+		t.Error("expected true for certificate")
+	}
+	if h.CanHandle("scaler") {
+		t.Error("expected false for scaler")
+	}
+}
+
+func TestCertificateHandler_CapabilityRequired(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	if !h.CapabilityRequired() {
+		t.Error("expected true")
+	}
+}
+
+func TestCertificateHandler_ValidateAndApplyDefaults_OK(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	rendering := map[string]any{
+		"issuerRefName": "letsencrypt-prod",
+	}
+	out, err := h.ValidateAndApplyDefaults(rendering)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["issuerRefKind"] != "ClusterIssuer" {
+		t.Errorf("expected default issuerRefKind 'ClusterIssuer', got %q", out["issuerRefKind"])
+	}
+}
+
+func TestCertificateHandler_ValidateAndApplyDefaults_MissingIssuerRefName(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing issuerRefName")
+	}
+}
+
+func TestCertificateHandler_ValidateAndApplyDefaults_UnknownField(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	rendering := map[string]any{
+		"issuerRefName": "letsencrypt-prod",
+		"unknownField":  "value",
+	}
+	_, err := h.ValidateAndApplyDefaults(rendering)
+	if err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestCertificateHandler_Apply_OK(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"secretName":    "my-tls",
+			"issuerRefName": "letsencrypt-prod",
+			"issuerRefKind": "ClusterIssuer",
+			"dnsNames":      []any{"example.com"},
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Errorf("expected 1 sub-application, got %d", len(bundle.Applications))
+	}
+}
+
+func TestCertificateHandler_Apply_MissingSecretName(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"issuerRefName": "letsencrypt-prod",
+			"dnsNames":      []any{"example.com"},
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err == nil {
+		t.Fatal("expected error for missing secretName")
+	}
+}
+
+func TestCertificateHandler_Apply_MissingDNSNames(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"secretName":    "my-tls",
+			"issuerRefName": "letsencrypt-prod",
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err == nil {
+		t.Fatal("expected error for missing dnsNames")
+	}
+}
+
+func TestCertificateConfig_Generate_OK(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"secretName":    "my-tls",
+			"issuerRefName": "letsencrypt-prod",
+			"issuerRefKind": "ClusterIssuer",
+			"dnsNames":      []any{"example.com"},
+			"duration":      "2160h",
+			"renewBefore":   "360h",
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Errorf("expected 1 Certificate object, got %d", len(objects))
+	}
+}
+
+// --- ScalerHandler ---
+
+func TestScalerHandler_CanHandle(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	if !h.CanHandle("scaler") {
+		t.Error("expected true for scaler")
+	}
+	if h.CanHandle("pvc") {
+		t.Error("expected false for pvc")
+	}
+}
+
+func TestScalerHandler_Apply_OK(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas": 2,
+			"maxReplicas": 10,
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Errorf("expected 1 sub-application, got %d", len(bundle.Applications))
+	}
+}
+
+func TestScalerHandler_Apply_MissingMinReplicas(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"maxReplicas": 10,
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for missing minReplicas")
+	}
+}
+
+func TestScalerHandler_Apply_MinReplicasLessThanOne(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas": 0,
+			"maxReplicas": 10,
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for minReplicas < 1")
+	}
+}
+
+func TestScalerHandler_Apply_MaxLessThanMin(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas": 5,
+			"maxReplicas": 3,
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for maxReplicas < minReplicas")
+	}
+}
+
+func TestScalerHandler_Apply_WithPDB(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas": 2,
+			"maxReplicas": 5,
+			"enablePDB":   true,
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 2 {
+		t.Errorf("expected 2 objects (HPA + PDB), got %d", len(objects))
+	}
+}
+
+func TestScalerHandler_Apply_PDB_RequiresMinReplicas2(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas": 1,
+			"maxReplicas": 5,
+			"enablePDB":   true,
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error: enablePDB requires minReplicas >= 2")
+	}
+}
+
+func TestScalerHandler_Apply_CPUUtilizationOutOfRange(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas":    1,
+			"maxReplicas":    5,
+			"cpuUtilization": 150,
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for cpuUtilization > 100")
+	}
+}
+
+func TestScalerConfig_Generate_HPAOnly(t *testing.T) {
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type: "scaler",
+		Properties: map[string]any{
+			"minReplicas":    2,
+			"maxReplicas":    8,
+			"cpuUtilization": 70,
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Errorf("expected 1 object (HPA only), got %d", len(objects))
+	}
+}
+
+// --- PVCHandler ---
+
+func TestPVCHandler_CanHandle(t *testing.T) {
+	h := &traits.PVCHandler{}
+	if !h.CanHandle("pvc") {
+		t.Error("expected true for pvc")
+	}
+	if h.CanHandle("scaler") {
+		t.Error("expected false for scaler")
+	}
+}
+
+func TestPVCHandler_Apply_OK(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "shared-data",
+			"size": "5Gi",
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Errorf("expected 1 sub-application, got %d", len(bundle.Applications))
+	}
+}
+
+func TestPVCHandler_Apply_MissingName(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"size": "5Gi",
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestPVCHandler_Apply_MissingSize(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "data",
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for missing size")
+	}
+}
+
+func TestPVCHandler_Apply_InvalidSize(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "data",
+			"size": "not-a-quantity",
+		},
+	}
+	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+		t.Fatal("expected error for invalid size")
+	}
+}
+
+func TestPVCTraitConfig_Generate_OK(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "shared-data",
+			"size": "5Gi",
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Errorf("expected 1 PVC object, got %d", len(objects))
+	}
+}
+
+func TestPVCTraitConfig_ApplyPolicy_ExceedsMax(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "data",
+			"size": "100Gi",
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	cfg := bundle.Applications[0].Config
+	enforceable, ok := cfg.(oam.Enforceable)
+	if !ok {
+		t.Fatal("PVCTraitConfig must implement oam.Enforceable")
+	}
+	p := &stubPVCPolicy{maxStorageSize: "10Gi"}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when PVC size exceeds max")
+	}
+}
+
+func TestPVCTraitConfig_ApplyPolicy_WithinMax(t *testing.T) {
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{
+		Type: "pvc",
+		Properties: map[string]any{
+			"name": "data",
+			"size": "5Gi",
+		},
+	}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	cfg := bundle.Applications[0].Config
+	enforceable := cfg.(oam.Enforceable)
+	p := &stubPVCPolicy{maxStorageSize: "10Gi"}
+	if err := enforceable.ApplyPolicy(p); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// stubPVCPolicy implements oam.Policy for PVC trait tests.
+type stubPVCPolicy struct {
+	maxStorageSize string
+}
+
+func (p *stubPVCPolicy) MaxReplicas() *int32             { return nil }
+func (p *stubPVCPolicy) MaxCPU() string                  { return "" }
+func (p *stubPVCPolicy) MaxMemory() string               { return "" }
+func (p *stubPVCPolicy) MaxStorageSize() string          { return p.maxStorageSize }
+func (p *stubPVCPolicy) AllowedRegistries() []string     { return nil }
+func (p *stubPVCPolicy) DefaultReplicas() *int32         { return nil }
+func (p *stubPVCPolicy) DefaultCPURequest() string       { return "" }
+func (p *stubPVCPolicy) DefaultMemoryRequest() string    { return "" }
+func (p *stubPVCPolicy) DefaultCPULimit() string         { return "" }
+func (p *stubPVCPolicy) DefaultMemoryLimit() string      { return "" }
+func (p *stubPVCPolicy) AllowHostNetwork() bool          { return false }
+func (p *stubPVCPolicy) AllowPrivileged() bool           { return false }
+func (p *stubPVCPolicy) AllowHostPID() bool              { return false }
+func (p *stubPVCPolicy) AllowHostIPC() bool              { return false }
+func (p *stubPVCPolicy) AllowHostPathVolumes() bool      { return false }
+func (p *stubPVCPolicy) AllowedCapabilities() []string   { return nil }
+func (p *stubPVCPolicy) ForbiddenCapabilities() []string { return nil }
+func (p *stubPVCPolicy) RequiredCapabilities() []string  { return nil }

--- a/pkg/oam/parser_test.go
+++ b/pkg/oam/parser_test.go
@@ -431,7 +431,7 @@ spec:
 }
 
 func TestParse_RejectsDeferredPhase2TraitType(t *testing.T) {
-	// pvc is a Phase 2 trait (issue #49) — not yet supported in Phase 1.
+	// networkpolicy is a Phase 2 trait (issue #49) — not yet supported.
 	// It must fail at validate time, not silently pass to dispatch.
 	input := `
 apiVersion: launcher.gokure.dev/v1alpha1
@@ -445,20 +445,20 @@ spec:
     properties:
       image: nginx:1.25
     traits:
-    - type: pvc
+    - type: networkpolicy
       properties:
         size: 10Gi
 `
 	_, err := Parse([]byte(input))
 	if err == nil {
-		t.Fatal("expected error for deferred Phase 2 trait pvc, got nil")
+		t.Fatal("expected error for deferred Phase 2 trait networkpolicy, got nil")
 	}
 	var valErr *errors.ValidationError
 	if !stderrors.As(err, &valErr) {
 		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
 	}
-	if valErr.Value != "pvc" {
-		t.Errorf("Value = %q, want %q", valErr.Value, "pvc")
+	if valErr.Value != "networkpolicy" {
+		t.Errorf("Value = %q, want %q", valErr.Value, "networkpolicy")
 	}
 }
 

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -25,7 +25,7 @@ var validComponentTypes = map[string]bool{
 }
 
 // validTraitTypes is the Phase 1 set from design-kurel-package.md §4.3.
-// Deferred until Phase 2 (#49, #50): pvc, networkpolicy, cilium-networkpolicy, volsync.
+// Deferred until Phase 2 (#49, #50): networkpolicy, cilium-networkpolicy, volsync.
 // Updated when Phase 2 handlers land.
 var validTraitTypes = map[string]bool{
 	"expose":          true,
@@ -35,6 +35,7 @@ var validTraitTypes = map[string]bool{
 	"external-secret": true,
 	"configmap":       true,
 	"scaler":          true,
+	"pvc":             true,
 }
 
 // traitComponentRestrictions maps trait types to the component types they support.


### PR DESCRIPTION
## Summary

- **statefulset component** — generates StatefulSet + headless Service (ClusterIP: None) + ServiceAccount; supports `volumeClaimTemplates`, env, resources, probes, affinity, init containers, sidecars; enforces maxReplicas, CPU/memory limits, registry allowlist, and per-VCT storage size via `ApplyPolicy`
- **certificate trait** — CapabilityAware; generates a cert-manager `Certificate` CR; issuerRef is provided by ClusterProfile capability rendering; app provides `secretName`, `dnsNames`, `duration`, `renewBefore`
- **scaler trait** — generates `autoscaling/v2` HPA with optional `policy/v1` PDB; supports CPU/memory utilization targets
- **pvc trait** — Enforceable; generates a standalone `PersistentVolumeClaim`; enforces `maxStorageSize` via `ApplyPolicy`

Advances issues #48 (statefulset component), #49 (certificate/scaler/pvc workload traits), #54 (fixture scenarios).

## Test plan

- [ ] `GOWORK=off go build ./...` — clean
- [ ] `GOWORK=off go test ./...` — all pass (80.6% coverage)
- [ ] `GOWORK=off mise run lint` — 0 issues
- [ ] Five new fixture scenarios with golden files: `statefulset-minimal`, `certificate-minimal`, `scaler-minimal`, `scaler-with-pdb`, `pvc-trait`
- [ ] Unit tests for all new handlers: `statefulset_test.go`, `traits_test.go` (certificate/scaler/pvc sections)