### PR TITLE
feat(oam): add external-secret, configmap, networkpolicy, cilium-networkpolicy, volsync traits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/go-kure/launcher
 go 1.26.3
 
 require (
+	github.com/backube/volsync v0.15.0
 	github.com/cert-manager/cert-manager v1.20.2
+	github.com/cilium/cilium v1.19.3
 	github.com/evanphx/json-patch/v5 v5.9.11
+	github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342
 	github.com/go-kure/kure v0.2.0-alpha.3
 	github.com/google/go-containerregistry v0.21.5
 	github.com/spf13/cobra v1.10.2
@@ -20,11 +23,9 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/avast/retry-go/v5 v5.0.0 // indirect
-	github.com/backube/volsync v0.15.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
-	github.com/cilium/cilium v1.19.3 // indirect
 	github.com/cilium/ebpf v0.20.1-0.20260218191617-ee67e7f43dd9 // indirect
 	github.com/cilium/hive v0.0.0-20260108104938-97756f6ff54c // indirect
 	github.com/cilium/proxy v0.0.0-20250623105955-2136f59a4ea1 // indirect
@@ -37,7 +38,6 @@ require (
 	github.com/controlplaneio-fluxcd/flux-operator v0.40.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342 // indirect
 	github.com/fluxcd/helm-controller/api v1.5.4 // indirect
 	github.com/fluxcd/image-automation-controller/api v1.1.2 // indirect
 	github.com/fluxcd/kustomize-controller/api v1.8.4 // indirect

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -122,11 +122,16 @@ func newBuiltinTransformer() *oam.Transformer {
 			"statefulset": &components.StatefulsetHandler{},
 		},
 		map[string]oam.TraitHandler{
-			"expose":      &traits.ExposeHandler{},
-			"ingress":     &traits.IngressHandler{}, //nolint:staticcheck
-			"certificate": &traits.CertificateHandler{},
-			"scaler":      &traits.ScalerHandler{},
-			"pvc":         &traits.PVCHandler{},
+			"expose":               &traits.ExposeHandler{},
+			"ingress":              &traits.IngressHandler{}, //nolint:staticcheck
+			"certificate":          &traits.CertificateHandler{},
+			"scaler":               &traits.ScalerHandler{},
+			"pvc":                  &traits.PVCHandler{},
+			"external-secret":      &traits.ExternalSecretHandler{},
+			"configmap":            &traits.ConfigMapHandler{},
+			"networkpolicy":        &traits.NetworkPolicyHandler{},
+			"cilium-networkpolicy": &traits.CiliumNetworkPolicyHandler{},
+			"volsync":              &traits.VolSyncHandler{},
 		},
 	)
 }

--- a/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/app.yaml
@@ -1,0 +1,23 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: cilium-networkpolicy
+          properties:
+            name: api-allow-ingress
+            endpointSelector:
+              matchLabels:
+                app: api
+            ingress:
+              - fromEndpoints:
+                  - matchLabels:
+                      app: frontend

--- a/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/cilium-networkpolicy-minimal/expected.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: api-allow-ingress
+  namespace: default
+spec:
+  endpointSelector:
+    matchLabels:
+      app: api
+  ingress:
+  - fromEndpoints:
+    - matchLabels:
+        app: frontend

--- a/pkg/cmd/kurel/testdata/configmap-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-minimal/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: configmap
+          properties:
+            name: api-config
+            data:
+              APP_ENV: production
+              LOG_LEVEL: info

--- a/pkg/cmd/kurel/testdata/configmap-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/configmap-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-minimal/expected.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: v1
+data:
+  APP_ENV: production
+  LOG_LEVEL: info
+kind: ConfigMap
+metadata:
+  labels:
+    app: api
+  name: api-config
+  namespace: default

--- a/pkg/cmd/kurel/testdata/configmap-with-mount/app.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-with-mount/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: configmap
+          properties:
+            name: api-config
+            mountPath: /etc/config
+            data:
+              config.yaml: |
+                env: production

--- a/pkg/cmd/kurel/testdata/configmap-with-mount/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-with-mount/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/configmap-with-mount/expected.yaml
+++ b/pkg/cmd/kurel/testdata/configmap-with-mount/expected.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /etc/config
+          name: api-config
+      serviceAccountName: api
+      volumes:
+      - configMap:
+          name: api-config
+        name: api-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    env: production
+kind: ConfigMap
+metadata:
+  labels:
+    app: api
+  name: api-config
+  namespace: default

--- a/pkg/cmd/kurel/testdata/external-secret-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/external-secret-minimal/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: external-secret
+          properties:
+            secretName: api-credentials
+            data:
+              - secretKey: DB_PASSWORD
+                remoteRef:
+                  key: prod/api/db
+                  property: password

--- a/pkg/cmd/kurel/testdata/external-secret-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/external-secret-minimal/cluster.yaml
@@ -1,0 +1,11 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    external-secret:
+      rendering:
+        secretStoreRef:
+          name: vault-cluster-store
+          kind: ClusterSecretStore

--- a/pkg/cmd/kurel/testdata/external-secret-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/external-secret-minimal/expected.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  labels:
+    app: api
+  name: api-credentials
+  namespace: default
+spec:
+  data:
+  - remoteRef:
+      key: prod/api/db
+      property: password
+    secretKey: DB_PASSWORD
+  refreshInterval: 1h0m0s
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault-cluster-store
+  target:
+    name: api-credentials

--- a/pkg/cmd/kurel/testdata/networkpolicy-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/networkpolicy-minimal/app.yaml
@@ -1,0 +1,23 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: api
+      type: webservice
+      properties:
+        image: ghcr.io/example/api:v1.0.0
+        port: 8080
+      traits:
+        - type: networkpolicy
+          properties:
+            ingress:
+              - from:
+                  - podSelector:
+                      matchLabels:
+                        app: frontend
+                ports:
+                  - port: 8080
+                    protocol: TCP

--- a/pkg/cmd/kurel/testdata/networkpolicy-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/networkpolicy-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/networkpolicy-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/networkpolicy-minimal/expected.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: ghcr.io/example/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app: api
+  name: api-allow
+  namespace: default
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: frontend
+    ports:
+    - port: 8080
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+  - Ingress

--- a/pkg/cmd/kurel/testdata/volsync-minimal/app.yaml
+++ b/pkg/cmd/kurel/testdata/volsync-minimal/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: db
+      type: statefulset
+      properties:
+        image: ghcr.io/example/postgres:v15.0
+        port: 5432
+        volumeClaimTemplates:
+          - name: data
+            size: 10Gi
+            mountPath: /var/lib/postgresql/data
+      traits:
+        - type: volsync
+          properties:
+            sourcePVC: data
+            schedule: "@daily"

--- a/pkg/cmd/kurel/testdata/volsync-minimal/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/volsync-minimal/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  serviceName: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - image: ghcr.io/example/postgres:v15.0
+        imagePullPolicy: IfNotPresent
+        name: db
+        ports:
+        - containerPort: 5432
+          name: tcp
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        volumeMounts:
+        - mountPath: /var/lib/postgresql/data
+          name: data
+      serviceAccountName: db
+  updateStrategy: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi
+    status: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: db
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: data-backup
+  namespace: default
+spec:
+  restic:
+    copyMethod: Snapshot
+    customCA: {}
+    pruneIntervalDays: 14
+    repository: db-volsync-secret
+    retain:
+      daily: 7
+      monthly: 3
+      weekly: 4
+  sourcePVC: data
+  trigger:
+    schedule: '@daily'

--- a/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
@@ -76,7 +76,7 @@ metadata:
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
-  name: data-backup
+  name: db-data-backup
   namespace: default
 spec:
   restic:

--- a/pkg/oam/builtin/cilium_networkpolicy.go
+++ b/pkg/oam/builtin/cilium_networkpolicy.go
@@ -1,0 +1,5 @@
+package builtin
+
+// CiliumNetworkPolicyRendering holds no rendering keys; ValidateAndApplyDefaults rejects
+// any key the operator accidentally provides (design-capability-schema.md §2.4).
+type CiliumNetworkPolicyRendering struct{}

--- a/pkg/oam/builtin/configmap.go
+++ b/pkg/oam/builtin/configmap.go
@@ -1,0 +1,5 @@
+package builtin
+
+// ConfigmapRendering holds no rendering keys; ValidateAndApplyDefaults rejects
+// any key the operator accidentally provides (design-capability-schema.md §2.4).
+type ConfigmapRendering struct{}

--- a/pkg/oam/builtin/external_secret.go
+++ b/pkg/oam/builtin/external_secret.go
@@ -1,0 +1,15 @@
+package builtin
+
+// ExternalSecretRendering defines the platform values for the external-secret capability.
+// The secretStoreRef is provided by the cluster operator in the ClusterProfile.
+type ExternalSecretRendering struct {
+	SecretStoreRef  ExternalSecretStoreRef `yaml:"secretStoreRef" json:"secretStoreRef"`
+	RefreshInterval string                 `yaml:"refreshInterval,omitempty" json:"refreshInterval,omitempty"`
+}
+
+// ExternalSecretStoreRef identifies the ExternalSecrets SecretStore or ClusterSecretStore.
+type ExternalSecretStoreRef struct {
+	Name string `yaml:"name" json:"name"`
+	// Kind defaults to "ClusterSecretStore" if not specified.
+	Kind string `yaml:"kind,omitempty" json:"kind,omitempty"`
+}

--- a/pkg/oam/builtin/networkpolicy.go
+++ b/pkg/oam/builtin/networkpolicy.go
@@ -1,0 +1,5 @@
+package builtin
+
+// NetworkPolicyRendering holds no rendering keys; ValidateAndApplyDefaults rejects
+// any key the operator accidentally provides (design-capability-schema.md §2.4).
+type NetworkPolicyRendering struct{}

--- a/pkg/oam/builtin/traits/cilium_networkpolicy.go
+++ b/pkg/oam/builtin/traits/cilium_networkpolicy.go
@@ -1,0 +1,117 @@
+package traits
+
+import (
+	"encoding/json"
+
+	ciliumapi "github.com/cilium/cilium/pkg/policy/api"
+	kurecilium "github.com/go-kure/kure/pkg/kubernetes/cilium"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// CiliumNetworkPolicyHandler handles OAM cilium-networkpolicy traits.
+// Supports namespaced CiliumNetworkPolicy only; CiliumClusterWideNetworkPolicy is deferred.
+type CiliumNetworkPolicyHandler struct{}
+
+// CanHandle returns true for cilium-networkpolicy trait type.
+func (h *CiliumNetworkPolicyHandler) CanHandle(traitType string) bool {
+	return traitType == "cilium-networkpolicy"
+}
+
+// ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
+func (h *CiliumNetworkPolicyHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if _, err := builtin.DecodeStrict[builtin.CiliumNetworkPolicyRendering](rendering); err != nil {
+		return nil, errors.Wrap(err, "cilium-networkpolicy rendering")
+	}
+	return rendering, nil
+}
+
+// Apply creates a CiliumNetworkPolicy resource appended to the bundle.
+func (h *CiliumNetworkPolicyHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties)
+	if err != nil {
+		return err
+	}
+
+	cnpApp := stack.NewApplication(
+		config.Name,
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, cnpApp)
+	return nil
+}
+
+func (h *CiliumNetworkPolicyHandler) parseProperties(props map[string]any) (*CiliumNetworkPolicyConfig, error) {
+	name, ok := props["name"].(string)
+	if !ok || name == "" {
+		return nil, errors.New("required property 'name' missing or not a string")
+	}
+
+	_, hasEgress := props["egress"]
+	_, hasIngress := props["ingress"]
+	if !hasEgress && !hasIngress {
+		return nil, errors.New("at least one of 'egress' or 'ingress' must be specified")
+	}
+
+	return &CiliumNetworkPolicyConfig{
+		Name:             name,
+		EndpointSelector: props["endpointSelector"],
+		Egress:           props["egress"],
+		Ingress:          props["ingress"],
+	}, nil
+}
+
+// CiliumNetworkPolicyConfig implements stack.ApplicationConfig for cilium-networkpolicy traits.
+type CiliumNetworkPolicyConfig struct {
+	Name             string
+	EndpointSelector any
+	Egress           any
+	Ingress          any
+}
+
+// Generate creates a cilium.io/v2 CiliumNetworkPolicy via JSON round-trip.
+func (c *CiliumNetworkPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	rule, err := c.toAPIRule()
+	if err != nil {
+		return nil, errors.Errorf("cilium-networkpolicy %q: %w", c.Name, err)
+	}
+
+	cnp := kurecilium.CiliumNetworkPolicy(&kurecilium.CiliumNetworkPolicyConfig{
+		Name:      c.Name,
+		Namespace: app.Namespace,
+		Spec:      rule,
+	})
+
+	obj := client.Object(cnp)
+	return []*client.Object{&obj}, nil
+}
+
+func (c *CiliumNetworkPolicyConfig) toAPIRule() (*ciliumapi.Rule, error) {
+	raw := map[string]any{}
+	if c.EndpointSelector != nil {
+		raw["endpointSelector"] = c.EndpointSelector
+	}
+	if c.Egress != nil {
+		raw["egress"] = c.Egress
+	}
+	if c.Ingress != nil {
+		raw["ingress"] = c.Ingress
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal spec")
+	}
+
+	var rule ciliumapi.Rule
+	if err := json.Unmarshal(data, &rule); err != nil {
+		return nil, errors.Wrap(err, "unmarshal into api.Rule")
+	}
+
+	return &rule, nil
+}

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -1,0 +1,163 @@
+package traits
+
+import (
+	"fmt"
+
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// ConfigMapHandler handles OAM configmap traits.
+type ConfigMapHandler struct{}
+
+// CanHandle returns true for configmap trait type.
+func (h *ConfigMapHandler) CanHandle(traitType string) bool {
+	return traitType == "configmap"
+}
+
+// ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
+func (h *ConfigMapHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if _, err := builtin.DecodeStrict[builtin.ConfigmapRendering](rendering); err != nil {
+		return nil, errors.Wrap(err, "configmap rendering")
+	}
+	return rendering, nil
+}
+
+// Apply creates a ConfigMap resource and optionally wraps the component's config
+// with a decorator that mounts the ConfigMap as a volume.
+func (h *ConfigMapHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	props := trait.Properties
+
+	name, ok := props["name"].(string)
+	if !ok || name == "" {
+		return errors.New("required property 'name' missing or not a string")
+	}
+
+	var mountPath string
+	if mp, ok := props["mountPath"].(string); ok {
+		mountPath = mp
+	}
+
+	data := make(map[string]string)
+	if rawData, ok := props["data"].(map[string]any); ok {
+		for k, v := range rawData {
+			data[k] = fmt.Sprintf("%v", v)
+		}
+	}
+
+	cmConfig := &ConfigMapConfig{
+		Name:          name,
+		ComponentName: app.Name,
+		Data:          data,
+	}
+	cmApp := stack.NewApplication(name, app.Namespace, cmConfig)
+	bundle.Applications = append(bundle.Applications, cmApp)
+
+	if mountPath != "" {
+		app.Config = &ConfigMapDecorator{
+			Inner:         app.Config,
+			ConfigMapName: name,
+			MountPath:     mountPath,
+		}
+	}
+
+	return nil
+}
+
+// ConfigMapConfig implements stack.ApplicationConfig for configmap traits.
+type ConfigMapConfig struct {
+	Name          string
+	ComponentName string
+	Data          map[string]string
+}
+
+// Generate creates a Kubernetes ConfigMap resource.
+func (c *ConfigMapConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	cm := kubernetes.CreateConfigMap(app.Name, app.Namespace)
+	kubernetes.SetConfigMapLabels(cm, map[string]string{"app": c.ComponentName})
+	cm.Annotations = nil
+	if len(c.Data) > 0 {
+		kubernetes.AddConfigMapDataMap(cm, c.Data)
+	}
+
+	obj := client.Object(cm)
+	return []*client.Object{&obj}, nil
+}
+
+// ConfigMapDecorator wraps an ApplicationConfig to add a volume and volumeMount
+// for a ConfigMap to any supported workload in the generated resources.
+type ConfigMapDecorator struct {
+	Inner         stack.ApplicationConfig
+	ConfigMapName string
+	MountPath     string
+}
+
+// Generate calls the inner config's Generate and mounts the ConfigMap into any
+// Deployment, StatefulSet, DaemonSet, or CronJob resource found.
+func (d *ConfigMapDecorator) Generate(app *stack.Application) ([]*client.Object, error) {
+	objects, err := d.Inner.Generate(app)
+	if err != nil {
+		return nil, err
+	}
+
+	volume := corev1.Volume{
+		Name: d.ConfigMapName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: d.ConfigMapName},
+			},
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      d.ConfigMapName,
+		MountPath: d.MountPath,
+	}
+
+	mounted := false
+	for _, objPtr := range objects {
+		switch w := (*objPtr).(type) {
+		case *appsv1.Deployment:
+			w.Spec.Template.Spec.Volumes = append(w.Spec.Template.Spec.Volumes, volume)
+			if len(w.Spec.Template.Spec.Containers) > 0 {
+				w.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+					w.Spec.Template.Spec.Containers[0].VolumeMounts, mount)
+			}
+			mounted = true
+		case *appsv1.StatefulSet:
+			w.Spec.Template.Spec.Volumes = append(w.Spec.Template.Spec.Volumes, volume)
+			if len(w.Spec.Template.Spec.Containers) > 0 {
+				w.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+					w.Spec.Template.Spec.Containers[0].VolumeMounts, mount)
+			}
+			mounted = true
+		case *appsv1.DaemonSet:
+			w.Spec.Template.Spec.Volumes = append(w.Spec.Template.Spec.Volumes, volume)
+			if len(w.Spec.Template.Spec.Containers) > 0 {
+				w.Spec.Template.Spec.Containers[0].VolumeMounts = append(
+					w.Spec.Template.Spec.Containers[0].VolumeMounts, mount)
+			}
+			mounted = true
+		case *batchv1.CronJob:
+			podSpec := &w.Spec.JobTemplate.Spec.Template.Spec
+			podSpec.Volumes = append(podSpec.Volumes, volume)
+			if len(podSpec.Containers) > 0 {
+				podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, mount)
+			}
+			mounted = true
+		}
+	}
+
+	if !mounted {
+		return nil, errors.New("configmap mountPath requires a Deployment, StatefulSet, DaemonSet, or CronJob component; no supported workload resource was found")
+	}
+
+	return objects, nil
+}

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -222,6 +222,29 @@ func (h *ExternalSecretHandler) parseProperties(props map[string]any, app *stack
 		}
 	}
 
+	// Shorthand: top-level remoteRef maps to a single data entry where secretKey=secretName.
+	// Matches the shape used in launcher examples (e.g. examples/04-webservice-full.yaml).
+	if rawRef, ok := props["remoteRef"].(map[string]any); ok {
+		if len(config.Data) > 0 || len(config.DataFrom) > 0 {
+			return nil, errors.New("external-secret: 'remoteRef' cannot be combined with 'data' or 'dataFrom'")
+		}
+		key, _ := rawRef["key"].(string)
+		if key == "" {
+			return nil, errors.New("external-secret: remoteRef.key is required")
+		}
+		ref := esRemoteRef{Key: key}
+		if p, ok := rawRef["property"].(string); ok {
+			ref.Property = p
+		}
+		if v, ok := rawRef["version"].(string); ok {
+			ref.Version = v
+		}
+		config.Data = append(config.Data, esDataEntry{
+			SecretKey: config.SecretName,
+			RemoteRef: ref,
+		})
+	}
+
 	return config, nil
 }
 

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -1,0 +1,375 @@
+package traits
+
+import (
+	"fmt"
+	"time"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/go-kure/kure/pkg/kubernetes/externalsecrets"
+	"github.com/go-kure/kure/pkg/stack"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// ExternalSecretHandler handles OAM external-secret traits.
+type ExternalSecretHandler struct{}
+
+// CanHandle returns true for external-secret trait type.
+func (h *ExternalSecretHandler) CanHandle(traitType string) bool {
+	return traitType == "external-secret"
+}
+
+// CapabilityRequired returns true: the external-secret trait needs secretStoreRef
+// from a ClusterProfile capability.
+func (h *ExternalSecretHandler) CapabilityRequired() bool { return true }
+
+// ValidateAndApplyDefaults validates the external-secret capability rendering.
+func (h *ExternalSecretHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	r, err := builtin.DecodeStrict[builtin.ExternalSecretRendering](rendering)
+	if err != nil {
+		return nil, errors.Wrap(err, "external-secret rendering")
+	}
+	rawRef, _ := rendering["secretStoreRef"].(map[string]any)
+	if rawRef == nil || r.SecretStoreRef.Name == "" {
+		return nil, errors.New("external-secret rendering: secretStoreRef.name is required")
+	}
+	if r.SecretStoreRef.Kind == "" {
+		if rawRef == nil {
+			rendering["secretStoreRef"] = map[string]any{"kind": "ClusterSecretStore"}
+		} else {
+			rawRef["kind"] = "ClusterSecretStore"
+		}
+	}
+	return rendering, nil
+}
+
+// Apply creates an ExternalSecret resource appended to the bundle.
+func (h *ExternalSecretHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	esApp := stack.NewApplication(
+		app.Name+"-external-secret-"+config.SecretName,
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, esApp)
+	return nil
+}
+
+func (h *ExternalSecretHandler) parseProperties(props map[string]any, app *stack.Application) (*ExternalSecretConfig, error) {
+	config := &ExternalSecretConfig{
+		ComponentName:   app.Name,
+		RefreshInterval: "1h",
+	}
+
+	secretName, ok := props["secretName"].(string)
+	if !ok || secretName == "" {
+		return nil, errors.New("required property 'secretName' missing or not a string")
+	}
+	config.SecretName = secretName
+
+	rawStoreRef, _ := props["secretStoreRef"].(map[string]any)
+	if rawStoreRef == nil {
+		return nil, errors.New("required capability property 'secretStoreRef' missing; configure external-secret in ClusterProfile")
+	}
+	storeName, _ := rawStoreRef["name"].(string)
+	if storeName == "" {
+		return nil, errors.New("external-secret: secretStoreRef.name is required")
+	}
+	config.StoreRefName = storeName
+	config.StoreRefKind = "ClusterSecretStore"
+	if kind, ok := rawStoreRef["kind"].(string); ok && kind != "" {
+		config.StoreRefKind = kind
+	}
+
+	if ri, ok := props["refreshInterval"].(string); ok && ri != "" {
+		config.RefreshInterval = ri
+	}
+
+	config.TargetSecretName = secretName
+	if tsn, ok := props["targetSecretName"].(string); ok && tsn != "" {
+		config.TargetSecretName = tsn
+	}
+
+	if rawTarget, ok := props["target"].(map[string]any); ok {
+		if cp, ok := rawTarget["creationPolicy"].(string); ok && cp != "" {
+			validCreationPolicies := map[creationPolicy]bool{
+				creationPolicyOwner:  true,
+				creationPolicyOrphan: true,
+				creationPolicyMerge:  true,
+				creationPolicyNone:   true,
+			}
+			if !validCreationPolicies[creationPolicy(cp)] {
+				return nil, errors.Errorf("target.creationPolicy %q is invalid; must be one of Owner, Orphan, Merge, None", cp)
+			}
+			config.CreationPolicy = creationPolicy(cp)
+		}
+		if dp, ok := rawTarget["deletionPolicy"].(string); ok && dp != "" {
+			validDeletionPolicies := map[deletionPolicy]bool{
+				deletionPolicyDelete: true,
+				deletionPolicyMerge:  true,
+				deletionPolicyRetain: true,
+			}
+			if !validDeletionPolicies[deletionPolicy(dp)] {
+				return nil, errors.Errorf("target.deletionPolicy %q is invalid; must be one of Delete, Merge, Retain", dp)
+			}
+			config.DeletionPolicy = deletionPolicy(dp)
+		}
+		if rawTemplate, ok := rawTarget["template"].(map[string]any); ok {
+			tmpl := &esTemplate{}
+			if t, ok := rawTemplate["type"].(string); ok {
+				tmpl.Type = t
+			}
+			if rawData, ok := rawTemplate["data"].(map[string]any); ok {
+				tmpl.Data = make(map[string]string, len(rawData))
+				for k, v := range rawData {
+					tmpl.Data[k] = fmt.Sprintf("%v", v)
+				}
+			}
+			config.Template = tmpl
+		}
+	}
+
+	if rawData, ok := props["data"].([]any); ok {
+		for i, item := range rawData {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("data[%d]: expected object", i)
+			}
+			secretKey, _ := entry["secretKey"].(string)
+			if secretKey == "" {
+				return nil, errors.Errorf("data[%d]: required field 'secretKey' missing or empty", i)
+			}
+			rawRef, ok := entry["remoteRef"].(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("data[%d]: required field 'remoteRef' missing or not an object", i)
+			}
+			key, _ := rawRef["key"].(string)
+			if key == "" {
+				return nil, errors.Errorf("data[%d].remoteRef: required field 'key' missing or empty", i)
+			}
+			ref := esRemoteRef{Key: key}
+			if p, ok := rawRef["property"].(string); ok {
+				ref.Property = p
+			}
+			if v, ok := rawRef["version"].(string); ok {
+				ref.Version = v
+			}
+			if ds, ok := rawRef["decodingStrategy"].(string); ok {
+				ref.DecodingStrategy = ds
+			}
+			config.Data = append(config.Data, esDataEntry{
+				SecretKey: secretKey,
+				RemoteRef: ref,
+			})
+		}
+	}
+
+	if rawDataFrom, ok := props["dataFrom"].([]any); ok {
+		for i, item := range rawDataFrom {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("dataFrom[%d]: expected object", i)
+			}
+			dfEntry := esDataFromEntry{}
+			if rawExtract, ok := entry["extract"].(map[string]any); ok {
+				key, _ := rawExtract["key"].(string)
+				if key == "" {
+					return nil, errors.Errorf("dataFrom[%d].extract: required field 'key' missing or empty", i)
+				}
+				ref := &esExtractRef{Key: key}
+				if ds, ok := rawExtract["decodingStrategy"].(string); ok {
+					ref.DecodingStrategy = ds
+				}
+				if cs, ok := rawExtract["conversionStrategy"].(string); ok {
+					ref.ConversionStrategy = cs
+				}
+				if mp, ok := rawExtract["metadataPolicy"].(string); ok {
+					ref.MetadataPolicy = mp
+				}
+				dfEntry.Extract = ref
+			}
+			if rawFind, ok := entry["find"].(map[string]any); ok {
+				find := &esFind{}
+				if rawName, ok := rawFind["name"].(map[string]any); ok {
+					if re, ok := rawName["regexp"].(string); ok {
+						find.Name = &esFindName{RegExp: re}
+					}
+				}
+				if rawTags, ok := rawFind["tags"].(map[string]any); ok {
+					find.Tags = make(map[string]string, len(rawTags))
+					for k, v := range rawTags {
+						find.Tags[k] = fmt.Sprintf("%v", v)
+					}
+				}
+				dfEntry.Find = find
+				if find.Name == nil && len(find.Tags) == 0 {
+					return nil, errors.Errorf("dataFrom[%d].find: must have at least 'name' or 'tags'", i)
+				}
+			}
+			if dfEntry.Extract == nil && dfEntry.Find == nil {
+				return nil, errors.Errorf("dataFrom[%d]: must have 'extract' or 'find'", i)
+			}
+			config.DataFrom = append(config.DataFrom, dfEntry)
+		}
+	}
+
+	return config, nil
+}
+
+type creationPolicy string
+
+const (
+	creationPolicyOwner  creationPolicy = "Owner"
+	creationPolicyOrphan creationPolicy = "Orphan"
+	creationPolicyMerge  creationPolicy = "Merge"
+	creationPolicyNone   creationPolicy = "None"
+)
+
+type deletionPolicy string
+
+const (
+	deletionPolicyDelete deletionPolicy = "Delete"
+	deletionPolicyMerge  deletionPolicy = "Merge"
+	deletionPolicyRetain deletionPolicy = "Retain"
+)
+
+type esDataEntry struct {
+	SecretKey string
+	RemoteRef esRemoteRef
+}
+
+type esRemoteRef struct {
+	Key              string
+	Property         string
+	Version          string
+	DecodingStrategy string
+}
+
+type esExtractRef struct {
+	Key                string
+	DecodingStrategy   string
+	ConversionStrategy string
+	MetadataPolicy     string
+}
+
+type esDataFromEntry struct {
+	Extract *esExtractRef
+	Find    *esFind
+}
+
+type esFind struct {
+	Name *esFindName
+	Tags map[string]string
+}
+
+type esFindName struct {
+	RegExp string
+}
+
+type esTemplate struct {
+	Type string
+	Data map[string]string
+}
+
+// ExternalSecretConfig implements stack.ApplicationConfig for external-secret traits.
+type ExternalSecretConfig struct {
+	SecretName       string
+	ComponentName    string
+	StoreRefName     string
+	StoreRefKind     string
+	RefreshInterval  string
+	TargetSecretName string
+	CreationPolicy   creationPolicy
+	DeletionPolicy   deletionPolicy
+	Template         *esTemplate
+	Data             []esDataEntry
+	DataFrom         []esDataFromEntry
+}
+
+// Generate creates an ExternalSecret CRD resource.
+func (c *ExternalSecretConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	dur, err := time.ParseDuration(c.RefreshInterval)
+	if err != nil {
+		return nil, errors.Errorf("invalid refreshInterval %q: %w", c.RefreshInterval, err)
+	}
+
+	es := externalsecrets.ExternalSecret(&externalsecrets.ExternalSecretConfig{
+		Name:      c.SecretName,
+		Namespace: app.Namespace,
+		SecretStoreRef: esv1.SecretStoreRef{
+			Name: c.StoreRefName,
+			Kind: c.StoreRefKind,
+		},
+	})
+	externalsecrets.AddExternalSecretLabel(es, "app", c.ComponentName)
+	externalsecrets.SetRefreshInterval(es, metav1.Duration{Duration: dur})
+
+	target := esv1.ExternalSecretTarget{Name: c.TargetSecretName}
+	if c.CreationPolicy != "" {
+		target.CreationPolicy = esv1.ExternalSecretCreationPolicy(c.CreationPolicy)
+	}
+	if c.DeletionPolicy != "" {
+		target.DeletionPolicy = esv1.ExternalSecretDeletionPolicy(c.DeletionPolicy)
+	}
+	if c.Template != nil {
+		target.Template = &esv1.ExternalSecretTemplate{
+			Type: corev1.SecretType(c.Template.Type),
+			Data: c.Template.Data,
+		}
+	}
+	externalsecrets.SetTarget(es, target)
+
+	for _, d := range c.Data {
+		ref := esv1.ExternalSecretDataRemoteRef{Key: d.RemoteRef.Key}
+		if d.RemoteRef.Property != "" {
+			ref.Property = d.RemoteRef.Property
+		}
+		if d.RemoteRef.Version != "" {
+			ref.Version = d.RemoteRef.Version
+		}
+		if d.RemoteRef.DecodingStrategy != "" {
+			ref.DecodingStrategy = esv1.ExternalSecretDecodingStrategy(d.RemoteRef.DecodingStrategy)
+		}
+		externalsecrets.AddExternalSecretData(es, esv1.ExternalSecretData{
+			SecretKey: d.SecretKey,
+			RemoteRef: ref,
+		})
+	}
+
+	for _, df := range c.DataFrom {
+		entry := esv1.ExternalSecretDataFromRemoteRef{}
+		if df.Extract != nil {
+			extract := &esv1.ExternalSecretDataRemoteRef{Key: df.Extract.Key}
+			if df.Extract.DecodingStrategy != "" {
+				extract.DecodingStrategy = esv1.ExternalSecretDecodingStrategy(df.Extract.DecodingStrategy)
+			}
+			if df.Extract.ConversionStrategy != "" {
+				extract.ConversionStrategy = esv1.ExternalSecretConversionStrategy(df.Extract.ConversionStrategy)
+			}
+			if df.Extract.MetadataPolicy != "" {
+				extract.MetadataPolicy = esv1.ExternalSecretMetadataPolicy(df.Extract.MetadataPolicy)
+			}
+			entry.Extract = extract
+		}
+		if df.Find != nil {
+			find := &esv1.ExternalSecretFind{Tags: df.Find.Tags}
+			if df.Find.Name != nil {
+				find.Name = &esv1.FindName{RegExp: df.Find.Name.RegExp}
+			}
+			entry.Find = find
+		}
+		externalsecrets.AddDataFrom(es, entry)
+	}
+
+	obj := client.Object(es)
+	return []*client.Object{&obj}, nil
+}

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -239,6 +239,9 @@ func (h *ExternalSecretHandler) parseProperties(props map[string]any, app *stack
 		if v, ok := rawRef["version"].(string); ok {
 			ref.Version = v
 		}
+		if ds, ok := rawRef["decodingStrategy"].(string); ok {
+			ref.DecodingStrategy = ds
+		}
 		config.Data = append(config.Data, esDataEntry{
 			SecretKey: config.SecretName,
 			RemoteRef: ref,

--- a/pkg/oam/builtin/traits/networkpolicy.go
+++ b/pkg/oam/builtin/traits/networkpolicy.go
@@ -1,0 +1,366 @@
+package traits
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// NetworkPolicyHandler handles OAM networkpolicy traits.
+type NetworkPolicyHandler struct{}
+
+// CanHandle returns true for networkpolicy trait type.
+func (h *NetworkPolicyHandler) CanHandle(traitType string) bool {
+	return traitType == "networkpolicy"
+}
+
+// ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
+func (h *NetworkPolicyHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if _, err := builtin.DecodeStrict[builtin.NetworkPolicyRendering](rendering); err != nil {
+		return nil, errors.Wrap(err, "networkpolicy rendering")
+	}
+	return rendering, nil
+}
+
+// Apply creates a NetworkPolicy resource appended to the bundle.
+func (h *NetworkPolicyHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	npApp := stack.NewApplication(
+		app.Name+"-networkpolicy",
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, npApp)
+	return nil
+}
+
+func (h *NetworkPolicyHandler) parseProperties(props map[string]any, app *stack.Application) (*NetworkPolicyConfig, error) {
+	config := &NetworkPolicyConfig{
+		ComponentName: app.Name,
+	}
+
+	rawIngress, hasIngress := props["ingress"]
+	rawEgress, hasEgress := props["egress"]
+
+	if !hasIngress && !hasEgress {
+		return nil, errors.New("at least one of 'ingress' or 'egress' must be specified")
+	}
+
+	if hasIngress {
+		ingressRules, ok := rawIngress.([]any)
+		if !ok {
+			return nil, errors.New("'ingress' must be an array")
+		}
+		for i, rawRule := range ingressRules {
+			rule, err := parseNPIngressRule(rawRule, i)
+			if err != nil {
+				return nil, err
+			}
+			config.Ingress = append(config.Ingress, rule)
+		}
+	}
+
+	if hasEgress {
+		egressRules, ok := rawEgress.([]any)
+		if !ok {
+			return nil, errors.New("'egress' must be an array")
+		}
+		for i, rawRule := range egressRules {
+			rule, err := parseNPEgressRule(rawRule, i)
+			if err != nil {
+				return nil, err
+			}
+			config.Egress = append(config.Egress, rule)
+		}
+	}
+
+	return config, nil
+}
+
+func parseNPIngressRule(raw any, index int) (npIngressRule, error) {
+	ruleMap, ok := raw.(map[string]any)
+	if !ok {
+		return npIngressRule{}, errors.Errorf("ingress[%d]: expected object", index)
+	}
+
+	var rule npIngressRule
+
+	if rawFrom, ok := ruleMap["from"].([]any); ok {
+		for j, rawPeer := range rawFrom {
+			peer, err := parseNPPeer(rawPeer, fmt.Sprintf("ingress[%d].from[%d]", index, j))
+			if err != nil {
+				return npIngressRule{}, err
+			}
+			rule.From = append(rule.From, peer)
+		}
+	}
+
+	if rawPorts, ok := ruleMap["ports"].([]any); ok {
+		for j, rawPort := range rawPorts {
+			port, err := parseNPPort(rawPort, fmt.Sprintf("ingress[%d].ports[%d]", index, j))
+			if err != nil {
+				return npIngressRule{}, err
+			}
+			rule.Ports = append(rule.Ports, port)
+		}
+	}
+
+	return rule, nil
+}
+
+func parseNPEgressRule(raw any, index int) (npEgressRule, error) {
+	ruleMap, ok := raw.(map[string]any)
+	if !ok {
+		return npEgressRule{}, errors.Errorf("egress[%d]: expected object", index)
+	}
+
+	var rule npEgressRule
+
+	if rawTo, ok := ruleMap["to"].([]any); ok {
+		for j, rawPeer := range rawTo {
+			peer, err := parseNPPeer(rawPeer, fmt.Sprintf("egress[%d].to[%d]", index, j))
+			if err != nil {
+				return npEgressRule{}, err
+			}
+			rule.To = append(rule.To, peer)
+		}
+	}
+
+	if rawPorts, ok := ruleMap["ports"].([]any); ok {
+		for j, rawPort := range rawPorts {
+			port, err := parseNPPort(rawPort, fmt.Sprintf("egress[%d].ports[%d]", index, j))
+			if err != nil {
+				return npEgressRule{}, err
+			}
+			rule.Ports = append(rule.Ports, port)
+		}
+	}
+
+	return rule, nil
+}
+
+var validNPPeerKeys = map[string]bool{
+	"podSelector":       true,
+	"namespaceSelector": true,
+	"ipBlock":           true,
+}
+
+func parseNPPeer(raw any, path string) (npPeer, error) {
+	peerMap, ok := raw.(map[string]any)
+	if !ok {
+		return npPeer{}, errors.Errorf("%s: expected object", path)
+	}
+
+	for key := range peerMap {
+		if !validNPPeerKeys[key] {
+			return npPeer{}, errors.Errorf("%s: unsupported key %q", path, key)
+		}
+	}
+
+	var peer npPeer
+
+	if rawPS, ok := peerMap["podSelector"].(map[string]any); ok {
+		labels := make(map[string]string)
+		if ml, ok := rawPS["matchLabels"].(map[string]any); ok {
+			for k, v := range ml {
+				labels[k] = fmt.Sprintf("%v", v)
+			}
+		}
+		peer.PodSelector = &metav1.LabelSelector{MatchLabels: labels}
+	}
+
+	if rawNS, ok := peerMap["namespaceSelector"].(map[string]any); ok {
+		labels := make(map[string]string)
+		if ml, ok := rawNS["matchLabels"].(map[string]any); ok {
+			for k, v := range ml {
+				labels[k] = fmt.Sprintf("%v", v)
+			}
+		}
+		peer.NamespaceSelector = &metav1.LabelSelector{MatchLabels: labels}
+	}
+
+	if rawIB, ok := peerMap["ipBlock"].(map[string]any); ok {
+		cidr, ok := rawIB["cidr"].(string)
+		if !ok || cidr == "" {
+			return npPeer{}, errors.Errorf("%s.ipBlock: 'cidr' is required", path)
+		}
+		ipBlock := &networkingv1.IPBlock{CIDR: cidr}
+		if rawExcept, ok := rawIB["except"].([]any); ok {
+			for _, e := range rawExcept {
+				s, ok := e.(string)
+				if !ok {
+					return npPeer{}, errors.Errorf("%s.ipBlock.except: expected string values", path)
+				}
+				ipBlock.Except = append(ipBlock.Except, s)
+			}
+		}
+		peer.IPBlock = ipBlock
+	}
+
+	return peer, nil
+}
+
+var validNPProtocols = map[string]corev1.Protocol{
+	"TCP":  corev1.ProtocolTCP,
+	"UDP":  corev1.ProtocolUDP,
+	"SCTP": corev1.ProtocolSCTP,
+}
+
+func parseNPPort(raw any, path string) (npPort, error) {
+	portMap, ok := raw.(map[string]any)
+	if !ok {
+		return npPort{}, errors.Errorf("%s: expected object", path)
+	}
+
+	var port npPort
+
+	switch v := portMap["port"].(type) {
+	case float64:
+		port.Port = intstr.FromInt32(int32(v)) //nolint:gosec
+	case int:
+		port.Port = intstr.FromInt32(int32(v)) //nolint:gosec
+	case string:
+		if v == "" {
+			return npPort{}, errors.Errorf("%s: 'port' must be a number or named port string", path)
+		}
+		port.Port = intstr.FromString(v)
+	default:
+		return npPort{}, errors.Errorf("%s: 'port' must be a number or named port string", path)
+	}
+
+	port.Protocol = corev1.ProtocolTCP
+	if proto, ok := portMap["protocol"].(string); ok {
+		upper := strings.ToUpper(proto)
+		p, valid := validNPProtocols[upper]
+		if !valid {
+			return npPort{}, errors.Errorf("%s: invalid protocol %q (must be TCP, UDP, or SCTP)", path, proto)
+		}
+		port.Protocol = p
+	}
+
+	return port, nil
+}
+
+// NetworkPolicyConfig implements stack.ApplicationConfig for networkpolicy traits.
+type NetworkPolicyConfig struct {
+	ComponentName string
+	Ingress       []npIngressRule
+	Egress        []npEgressRule
+}
+
+type npIngressRule struct {
+	From  []npPeer
+	Ports []npPort
+}
+
+type npEgressRule struct {
+	To    []npPeer
+	Ports []npPort
+}
+
+type npPeer struct {
+	PodSelector       *metav1.LabelSelector
+	NamespaceSelector *metav1.LabelSelector
+	IPBlock           *networkingv1.IPBlock
+}
+
+type npPort struct {
+	Port     intstr.IntOrString
+	Protocol corev1.Protocol
+}
+
+// Generate creates a Kubernetes NetworkPolicy resource.
+func (c *NetworkPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	np := kubernetes.CreateNetworkPolicy(c.ComponentName+"-allow", app.Namespace)
+	np.Labels = map[string]string{"app": c.ComponentName}
+	np.Annotations = nil
+	if err := kubernetes.SetNetworkPolicyPodSelector(np, metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": c.ComponentName},
+	}); err != nil {
+		return nil, errors.Wrap(err, "set pod selector")
+	}
+
+	if len(c.Ingress) > 0 {
+		if err := kubernetes.AddNetworkPolicyPolicyType(np, networkingv1.PolicyTypeIngress); err != nil {
+			return nil, errors.Wrap(err, "add ingress policy type")
+		}
+		for _, rule := range c.Ingress {
+			ingressRule := networkingv1.NetworkPolicyIngressRule{}
+			for _, peer := range rule.From {
+				p := networkingv1.NetworkPolicyPeer{}
+				if peer.PodSelector != nil {
+					p.PodSelector = peer.PodSelector
+				}
+				if peer.NamespaceSelector != nil {
+					p.NamespaceSelector = peer.NamespaceSelector
+				}
+				if peer.IPBlock != nil {
+					p.IPBlock = peer.IPBlock
+				}
+				kubernetes.AddNetworkPolicyIngressPeer(&ingressRule, p)
+			}
+			for _, port := range rule.Ports {
+				proto := port.Protocol
+				portVal := port.Port
+				kubernetes.AddNetworkPolicyIngressPort(&ingressRule, networkingv1.NetworkPolicyPort{
+					Protocol: &proto,
+					Port:     &portVal,
+				})
+			}
+			if err := kubernetes.AddNetworkPolicyIngressRule(np, ingressRule); err != nil {
+				return nil, errors.Wrap(err, "add ingress rule")
+			}
+		}
+	}
+
+	if len(c.Egress) > 0 {
+		if err := kubernetes.AddNetworkPolicyPolicyType(np, networkingv1.PolicyTypeEgress); err != nil {
+			return nil, errors.Wrap(err, "add egress policy type")
+		}
+		for _, rule := range c.Egress {
+			egressRule := networkingv1.NetworkPolicyEgressRule{}
+			for _, peer := range rule.To {
+				p := networkingv1.NetworkPolicyPeer{}
+				if peer.PodSelector != nil {
+					p.PodSelector = peer.PodSelector
+				}
+				if peer.NamespaceSelector != nil {
+					p.NamespaceSelector = peer.NamespaceSelector
+				}
+				if peer.IPBlock != nil {
+					p.IPBlock = peer.IPBlock
+				}
+				kubernetes.AddNetworkPolicyEgressPeer(&egressRule, p)
+			}
+			for _, port := range rule.Ports {
+				proto := port.Protocol
+				portVal := port.Port
+				kubernetes.AddNetworkPolicyEgressPort(&egressRule, networkingv1.NetworkPolicyPort{
+					Protocol: &proto,
+					Port:     &portVal,
+				})
+			}
+			if err := kubernetes.AddNetworkPolicyEgressRule(np, egressRule); err != nil {
+				return nil, errors.Wrap(err, "add egress rule")
+			}
+		}
+	}
+
+	obj := client.Object(np)
+	return []*client.Object{&obj}, nil
+}

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -1373,6 +1373,25 @@ func TestExternalSecretHandler_Apply_RemoteRefConflictsWithData(t *testing.T) {
 	}
 }
 
+func TestExternalSecretHandler_Apply_RemoteRefDecodingStrategy(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	bundle := newBundle()
+	if err := h.Apply(&oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "my-creds",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"remoteRef":      map[string]any{"key": "prod/x", "decodingStrategy": "Base64"},
+		},
+	}, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	cfg := bundle.Applications[0].Config.(*traits.ExternalSecretConfig)
+	if cfg.Data[0].RemoteRef.DecodingStrategy != "Base64" {
+		t.Errorf("expected decodingStrategy 'Base64', got %q", cfg.Data[0].RemoteRef.DecodingStrategy)
+	}
+}
+
 func TestExternalSecretHandler_Apply_RemoteRefMissingKey(t *testing.T) {
 	h := &traits.ExternalSecretHandler{}
 	err := h.Apply(&oam.Trait{

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/oam"
 	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
@@ -782,3 +786,454 @@ func (p *stubPVCPolicy) AllowHostPathVolumes() bool      { return false }
 func (p *stubPVCPolicy) AllowedCapabilities() []string   { return nil }
 func (p *stubPVCPolicy) ForbiddenCapabilities() []string { return nil }
 func (p *stubPVCPolicy) RequiredCapabilities() []string  { return nil }
+
+// --- ExternalSecretHandler ---
+
+func TestExternalSecretHandler_CanHandle(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	if !h.CanHandle("external-secret") {
+		t.Error("expected CanHandle to return true for 'external-secret'")
+	}
+	if h.CanHandle("configmap") {
+		t.Error("expected CanHandle to return false for 'configmap'")
+	}
+}
+
+func TestExternalSecretHandler_CapabilityRequired(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	if !h.CapabilityRequired() {
+		t.Error("expected CapabilityRequired to return true")
+	}
+}
+
+func TestExternalSecretHandler_ValidateAndApplyDefaults_ValidWithName(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	rendering := map[string]any{
+		"secretStoreRef": map[string]any{
+			"name": "vault-store",
+		},
+	}
+	got, err := h.ValidateAndApplyDefaults(rendering)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	ref, _ := got["secretStoreRef"].(map[string]any)
+	if ref["kind"] != "ClusterSecretStore" {
+		t.Errorf("expected default kind ClusterSecretStore, got %v", ref["kind"])
+	}
+}
+
+func TestExternalSecretHandler_ValidateAndApplyDefaults_MissingSecretStoreRef(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing secretStoreRef")
+	}
+}
+
+func TestExternalSecretHandler_Apply_MissingSecretName(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretStoreRef": map[string]any{
+				"name": "vault-store",
+				"kind": "ClusterSecretStore",
+			},
+		},
+	}
+	err := h.Apply(trait, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing secretName")
+	}
+}
+
+func TestExternalSecretHandler_Apply_AppendsToBundleAndNamedCorrectly(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName": "my-secret",
+			"secretStoreRef": map[string]any{
+				"name": "vault-store",
+				"kind": "ClusterSecretStore",
+			},
+		},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
+	}
+	if bundle.Applications[0].Name != "api-external-secret-my-secret" {
+		t.Errorf("expected name 'api-external-secret-my-secret', got %q", bundle.Applications[0].Name)
+	}
+}
+
+// --- ConfigMapHandler ---
+
+func TestConfigMapHandler_CanHandle(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	if !h.CanHandle("configmap") {
+		t.Error("expected CanHandle to return true for 'configmap'")
+	}
+	if h.CanHandle("networkpolicy") {
+		t.Error("expected CanHandle to return false for 'networkpolicy'")
+	}
+}
+
+func TestConfigMapHandler_ValidateAndApplyDefaults_RejectsUnknownKey(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{"unknownKey": "value"})
+	if err == nil {
+		t.Fatal("expected error for unknown rendering key")
+	}
+}
+
+func TestConfigMapHandler_Apply_MissingName(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	err := h.Apply(&oam.Trait{Type: "configmap", Properties: map[string]any{}}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestConfigMapHandler_Apply_NoMountPath_AppendsBundleOnly(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	trait := &oam.Trait{
+		Type: "configmap",
+		Properties: map[string]any{
+			"name": "app-config",
+			"data": map[string]any{"KEY": "value"},
+		},
+	}
+	app := newApp("api", "default")
+	originalConfig := app.Config
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
+	}
+	if app.Config != originalConfig {
+		t.Error("expected app.Config unchanged when no mountPath")
+	}
+}
+
+func TestConfigMapHandler_Apply_WithMountPath_WrapsConfig(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	trait := &oam.Trait{
+		Type: "configmap",
+		Properties: map[string]any{
+			"name":      "app-config",
+			"mountPath": "/etc/config",
+		},
+	}
+	app := newApp("api", "default")
+	originalConfig := app.Config
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if app.Config == originalConfig {
+		t.Error("expected app.Config to be wrapped with decorator")
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application for ConfigMap, got %d", len(bundle.Applications))
+	}
+}
+
+// stubStatefulSetConfig is a stub ApplicationConfig that returns a StatefulSet.
+type stubStatefulSetConfig struct{}
+
+func (s *stubStatefulSetConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	ss := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "db", Namespace: "default"},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "db", Image: "postgres:15"}},
+				},
+			},
+		},
+	}
+	obj := client.Object(ss)
+	return []*client.Object{&obj}, nil
+}
+
+// stubUnsupportedConfig returns a Service (non-workload type).
+type stubUnsupportedConfig struct{}
+
+func (s *stubUnsupportedConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	svc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc"}}
+	obj := client.Object(svc)
+	return []*client.Object{&obj}, nil
+}
+
+func TestConfigMapDecorator_StatefulSet_MountsVolume(t *testing.T) {
+	dec := &traits.ConfigMapDecorator{
+		Inner:         &stubStatefulSetConfig{},
+		ConfigMapName: "my-config",
+		MountPath:     "/etc/config",
+	}
+	app := newApp("db", "default")
+	objects, err := dec.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+	ss, ok := (*objects[0]).(*appsv1.StatefulSet)
+	if !ok {
+		t.Fatalf("expected *appsv1.StatefulSet, got %T", *objects[0])
+	}
+	if len(ss.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("expected 1 volume, got %d", len(ss.Spec.Template.Spec.Volumes))
+	}
+	if len(ss.Spec.Template.Spec.Containers[0].VolumeMounts) != 1 {
+		t.Errorf("expected 1 volumeMount, got %d", len(ss.Spec.Template.Spec.Containers[0].VolumeMounts))
+	}
+	if ss.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath != "/etc/config" {
+		t.Errorf("unexpected mountPath: %q", ss.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
+	}
+}
+
+func TestConfigMapDecorator_UnsupportedComponent_ReturnsError(t *testing.T) {
+	dec := &traits.ConfigMapDecorator{
+		Inner:         &stubUnsupportedConfig{},
+		ConfigMapName: "my-config",
+		MountPath:     "/etc/config",
+	}
+	_, err := dec.Generate(newApp("svc", "default"))
+	if err == nil {
+		t.Fatal("expected error for unsupported workload type")
+	}
+	if !strings.Contains(err.Error(), "no supported workload resource was found") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+// --- NetworkPolicyHandler ---
+
+func TestNetworkPolicyHandler_CanHandle(t *testing.T) {
+	h := &traits.NetworkPolicyHandler{}
+	if !h.CanHandle("networkpolicy") {
+		t.Error("expected CanHandle to return true for 'networkpolicy'")
+	}
+	if h.CanHandle("cilium-networkpolicy") {
+		t.Error("expected CanHandle to return false for 'cilium-networkpolicy'")
+	}
+}
+
+func TestNetworkPolicyHandler_ValidateAndApplyDefaults_RejectsUnknownKey(t *testing.T) {
+	h := &traits.NetworkPolicyHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{"foo": "bar"})
+	if err == nil {
+		t.Fatal("expected error for unknown rendering key")
+	}
+}
+
+func TestNetworkPolicyHandler_Apply_MissingIngressAndEgress(t *testing.T) {
+	h := &traits.NetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{Type: "networkpolicy", Properties: map[string]any{}}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error when neither ingress nor egress specified")
+	}
+}
+
+func TestNetworkPolicyHandler_Apply_AppendsToBundleWithIngress(t *testing.T) {
+	h := &traits.NetworkPolicyHandler{}
+	trait := &oam.Trait{
+		Type: "networkpolicy",
+		Properties: map[string]any{
+			"ingress": []any{
+				map[string]any{
+					"from": []any{
+						map[string]any{"podSelector": map[string]any{"matchLabels": map[string]any{"app": "frontend"}}},
+					},
+					"ports": []any{
+						map[string]any{"port": float64(8080), "protocol": "TCP"},
+					},
+				},
+			},
+		},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
+	}
+	if bundle.Applications[0].Name != "api-networkpolicy" {
+		t.Errorf("expected name 'api-networkpolicy', got %q", bundle.Applications[0].Name)
+	}
+}
+
+// --- CiliumNetworkPolicyHandler ---
+
+func TestCiliumNetworkPolicyHandler_CanHandle(t *testing.T) {
+	h := &traits.CiliumNetworkPolicyHandler{}
+	if !h.CanHandle("cilium-networkpolicy") {
+		t.Error("expected CanHandle to return true for 'cilium-networkpolicy'")
+	}
+	if h.CanHandle("networkpolicy") {
+		t.Error("expected CanHandle to return false for 'networkpolicy'")
+	}
+}
+
+func TestCiliumNetworkPolicyHandler_ValidateAndApplyDefaults_RejectsUnknownKey(t *testing.T) {
+	h := &traits.CiliumNetworkPolicyHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{"foo": "bar"})
+	if err == nil {
+		t.Fatal("expected error for unknown rendering key")
+	}
+}
+
+func TestCiliumNetworkPolicyHandler_Apply_MissingName(t *testing.T) {
+	h := &traits.CiliumNetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{
+		Type:       "cilium-networkpolicy",
+		Properties: map[string]any{"ingress": []any{}},
+	}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing name")
+	}
+}
+
+func TestCiliumNetworkPolicyHandler_Apply_MissingIngressAndEgress(t *testing.T) {
+	h := &traits.CiliumNetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{
+		Type:       "cilium-networkpolicy",
+		Properties: map[string]any{"name": "my-policy"},
+	}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error when neither ingress nor egress specified")
+	}
+}
+
+func TestCiliumNetworkPolicyHandler_Apply_AppendsToBundle(t *testing.T) {
+	h := &traits.CiliumNetworkPolicyHandler{}
+	trait := &oam.Trait{
+		Type: "cilium-networkpolicy",
+		Properties: map[string]any{
+			"name": "api-allow",
+			"ingress": []any{
+				map[string]any{"fromEndpoints": []any{map[string]any{"matchLabels": map[string]any{"app": "frontend"}}}},
+			},
+		},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
+	}
+	if bundle.Applications[0].Name != "api-allow" {
+		t.Errorf("expected name 'api-allow', got %q", bundle.Applications[0].Name)
+	}
+}
+
+// --- VolSyncHandler ---
+
+func TestVolSyncHandler_CanHandle(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	if !h.CanHandle("volsync") {
+		t.Error("expected CanHandle to return true for 'volsync'")
+	}
+	if h.CanHandle("configmap") {
+		t.Error("expected CanHandle to return false for 'configmap'")
+	}
+}
+
+func TestVolSyncHandler_ValidateAndApplyDefaults_RejectsUnknownKey(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{"foo": "bar"})
+	if err == nil {
+		t.Fatal("expected error for unknown rendering key")
+	}
+}
+
+func TestVolSyncHandler_Apply_MissingSourcePVC(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	err := h.Apply(&oam.Trait{
+		Type:       "volsync",
+		Properties: map[string]any{"schedule": "@daily"},
+	}, newApp("db", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing sourcePVC")
+	}
+}
+
+func TestVolSyncHandler_Apply_MissingSchedule(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	err := h.Apply(&oam.Trait{
+		Type:       "volsync",
+		Properties: map[string]any{"sourcePVC": "data"},
+	}, newApp("db", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing schedule")
+	}
+}
+
+func TestVolSyncHandler_Apply_AppendsToBundle(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	trait := &oam.Trait{
+		Type:       "volsync",
+		Properties: map[string]any{"sourcePVC": "data", "schedule": "@daily"},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("db", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
+	}
+	if bundle.Applications[0].Name != "data-backup" {
+		t.Errorf("expected name 'data-backup', got %q", bundle.Applications[0].Name)
+	}
+}
+
+func TestVolSyncHandler_Apply_DefaultRepository(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	trait := &oam.Trait{
+		Type:       "volsync",
+		Properties: map[string]any{"sourcePVC": "data", "schedule": "@daily"},
+	}
+	bundle := newBundle()
+	app := newApp("mydb", "default")
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	cfg, ok := bundle.Applications[0].Config.(*traits.VolsyncConfig)
+	if !ok {
+		t.Fatalf("expected *traits.VolsyncConfig, got %T", bundle.Applications[0].Config)
+	}
+	if cfg.Repository != "mydb-volsync-secret" {
+		t.Errorf("expected default repository 'mydb-volsync-secret', got %q", cfg.Repository)
+	}
+}
+
+func TestVolSyncHandler_Apply_InvalidCopyMethod(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	trait := &oam.Trait{
+		Type: "volsync",
+		Properties: map[string]any{
+			"sourcePVC":  "data",
+			"schedule":   "@daily",
+			"copyMethod": "Invalid",
+		},
+	}
+	err := h.Apply(trait, newApp("db", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for invalid copyMethod")
+	}
+	if !strings.Contains(err.Error(), "unsupported copyMethod") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -973,6 +973,24 @@ func (s *stubUnsupportedConfig) Generate(_ *stack.Application) ([]*client.Object
 	return []*client.Object{&obj}, nil
 }
 
+// stubDaemonSetConfig returns a DaemonSet.
+type stubDaemonSetConfig struct{}
+
+func (s *stubDaemonSetConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	ds := &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "default"},
+		Spec: appsv1.DaemonSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "agent", Image: "agent:1"}},
+				},
+			},
+		},
+	}
+	obj := client.Object(ds)
+	return []*client.Object{&obj}, nil
+}
+
 func TestConfigMapDecorator_StatefulSet_MountsVolume(t *testing.T) {
 	dec := &traits.ConfigMapDecorator{
 		Inner:         &stubStatefulSetConfig{},
@@ -999,6 +1017,25 @@ func TestConfigMapDecorator_StatefulSet_MountsVolume(t *testing.T) {
 	}
 	if ss.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath != "/etc/config" {
 		t.Errorf("unexpected mountPath: %q", ss.Spec.Template.Spec.Containers[0].VolumeMounts[0].MountPath)
+	}
+}
+
+func TestConfigMapDecorator_DaemonSet_MountsVolume(t *testing.T) {
+	dec := &traits.ConfigMapDecorator{
+		Inner:         &stubDaemonSetConfig{},
+		ConfigMapName: "agent-config",
+		MountPath:     "/etc/agent",
+	}
+	objects, err := dec.Generate(newApp("agent", "default"))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ds, ok := (*objects[0]).(*appsv1.DaemonSet)
+	if !ok {
+		t.Fatalf("expected *appsv1.DaemonSet, got %T", *objects[0])
+	}
+	if len(ds.Spec.Template.Spec.Volumes) != 1 {
+		t.Errorf("expected 1 volume, got %d", len(ds.Spec.Template.Spec.Volumes))
 	}
 }
 
@@ -1194,8 +1231,8 @@ func TestVolSyncHandler_Apply_AppendsToBundle(t *testing.T) {
 	if len(bundle.Applications) != 1 {
 		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
 	}
-	if bundle.Applications[0].Name != "data-backup" {
-		t.Errorf("expected name 'data-backup', got %q", bundle.Applications[0].Name)
+	if bundle.Applications[0].Name != "db-data-backup" {
+		t.Errorf("expected name 'db-data-backup', got %q", bundle.Applications[0].Name)
 	}
 }
 
@@ -1235,5 +1272,343 @@ func TestVolSyncHandler_Apply_InvalidCopyMethod(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported copyMethod") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestVolSyncHandler_Apply_NonIntegerPruneIntervalDays(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "volsync",
+		Properties: map[string]any{
+			"sourcePVC":         "data",
+			"schedule":          "@daily",
+			"pruneIntervalDays": float64(1.5),
+		},
+	}, newApp("db", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for non-integer pruneIntervalDays")
+	}
+}
+
+func TestVolSyncHandler_Apply_NegativePruneIntervalDays(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "volsync",
+		Properties: map[string]any{
+			"sourcePVC":         "data",
+			"schedule":          "@daily",
+			"pruneIntervalDays": -1,
+		},
+	}, newApp("db", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for negative pruneIntervalDays")
+	}
+}
+
+func TestVolSyncHandler_Apply_BundleNameIsComponentScoped(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	bundle := newBundle()
+	if err := h.Apply(&oam.Trait{
+		Type:       "volsync",
+		Properties: map[string]any{"sourcePVC": "data", "schedule": "@daily"},
+	}, newApp("mydb", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if bundle.Applications[0].Name != "mydb-data-backup" {
+		t.Errorf("expected 'mydb-data-backup', got %q", bundle.Applications[0].Name)
+	}
+}
+
+// --- ExternalSecretHandler remoteRef shorthand ---
+
+func TestExternalSecretHandler_Apply_RemoteRefShorthand(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName": "my-creds",
+			"secretStoreRef": map[string]any{
+				"name": "vault",
+				"kind": "ClusterSecretStore",
+			},
+			"remoteRef": map[string]any{
+				"key": "prod/my-app/db",
+			},
+		},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply with remoteRef shorthand: %v", err)
+	}
+	cfg := bundle.Applications[0].Config.(*traits.ExternalSecretConfig)
+	if len(cfg.Data) != 1 {
+		t.Fatalf("expected 1 data entry from remoteRef shorthand, got %d", len(cfg.Data))
+	}
+	if cfg.Data[0].SecretKey != "my-creds" {
+		t.Errorf("expected secretKey %q, got %q", "my-creds", cfg.Data[0].SecretKey)
+	}
+	if cfg.Data[0].RemoteRef.Key != "prod/my-app/db" {
+		t.Errorf("expected remoteRef.key %q, got %q", "prod/my-app/db", cfg.Data[0].RemoteRef.Key)
+	}
+}
+
+func TestExternalSecretHandler_Apply_RemoteRefConflictsWithData(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "my-creds",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"remoteRef":      map[string]any{"key": "prod/x"},
+			"data": []any{
+				map[string]any{
+					"secretKey": "K",
+					"remoteRef": map[string]any{"key": "prod/y"},
+				},
+			},
+		},
+	}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error when remoteRef combined with data")
+	}
+}
+
+func TestExternalSecretHandler_Apply_RemoteRefMissingKey(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "my-creds",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"remoteRef":      map[string]any{},
+		},
+	}, newApp("api", "default"), newBundle())
+	if err == nil {
+		t.Fatal("expected error for missing remoteRef.key")
+	}
+}
+
+// --- Generate() tests for coverage ---
+
+func TestCiliumNetworkPolicyConfig_Generate(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.CiliumNetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "cilium-networkpolicy",
+		Properties: map[string]any{
+			"name": "test-policy",
+			"ingress": []any{
+				map[string]any{"fromEndpoints": []any{map[string]any{"matchLabels": map[string]any{"app": "frontend"}}}},
+			},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestConfigMapConfig_Generate(t *testing.T) {
+	cfg := &traits.ConfigMapConfig{
+		Name:          "my-config",
+		ComponentName: "api",
+		Data:          map[string]string{"KEY": "value"},
+	}
+	app := newApp("my-config", "default")
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestNetworkPolicyConfig_Generate(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.NetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "networkpolicy",
+		Properties: map[string]any{
+			"egress": []any{
+				map[string]any{
+					"to": []any{
+						map[string]any{"podSelector": map[string]any{"matchLabels": map[string]any{"app": "backend"}}},
+					},
+					"ports": []any{
+						map[string]any{"port": float64(5432), "protocol": "TCP"},
+					},
+				},
+			},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestNetworkPolicyConfig_Generate_BothIngressAndEgress(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.NetworkPolicyHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "networkpolicy",
+		Properties: map[string]any{
+			"ingress": []any{
+				map[string]any{
+					"from": []any{
+						map[string]any{
+							"namespaceSelector": map[string]any{"matchLabels": map[string]any{"ns": "prod"}},
+							"podSelector":       map[string]any{"matchLabels": map[string]any{"app": "web"}},
+						},
+					},
+				},
+			},
+			"egress": []any{
+				map[string]any{
+					"to": []any{
+						map[string]any{
+							"ipBlock": map[string]any{
+								"cidr":   "10.0.0.0/8",
+								"except": []any{"10.1.0.0/16"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestExternalSecretConfig_Generate(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.ExternalSecretHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName": "my-secret",
+			"secretStoreRef": map[string]any{
+				"name": "vault",
+				"kind": "ClusterSecretStore",
+			},
+			"data": []any{
+				map[string]any{
+					"secretKey": "DB_PASS",
+					"remoteRef": map[string]any{"key": "prod/db", "property": "password"},
+				},
+			},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestExternalSecretConfig_Generate_WithDataFromAndTemplate(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.ExternalSecretHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":       "bulk-secret",
+			"targetSecretName": "my-k8s-secret",
+			"secretStoreRef": map[string]any{
+				"name": "vault",
+				"kind": "ClusterSecretStore",
+			},
+			"target": map[string]any{
+				"creationPolicy": "Merge",
+				"deletionPolicy": "Retain",
+				"template": map[string]any{
+					"type": "kubernetes.io/dockerconfigjson",
+					"data": map[string]any{".dockerconfigjson": "{{ .secret }}"},
+				},
+			},
+			"dataFrom": []any{
+				map[string]any{
+					"extract": map[string]any{
+						"key":                "prod/my-app",
+						"decodingStrategy":   "None",
+						"conversionStrategy": "Default",
+						"metadataPolicy":     "None",
+					},
+				},
+				map[string]any{
+					"find": map[string]any{
+						"name": map[string]any{"regexp": "prod/.*"},
+						"tags": map[string]any{"env": "prod"},
+					},
+				},
+			},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+func TestVolsyncConfig_Generate(t *testing.T) {
+	bundle := newBundle()
+	h := &traits.VolSyncHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "volsync",
+		Properties: map[string]any{
+			"sourcePVC":               "data",
+			"schedule":                "@daily",
+			"storageClassName":        "fast",
+			"volumeSnapshotClassName": "csi-snapclass",
+			"pruneIntervalDays":       float64(7),
+			"retain": map[string]any{
+				"daily":   float64(3),
+				"weekly":  float64(2),
+				"monthly": float64(1),
+			},
+		},
+	}, newApp("db", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objects))
 	}
 }

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -1,6 +1,8 @@
 package traits
 
 import (
+	"math"
+
 	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
 	kurevol "github.com/go-kure/kure/pkg/kubernetes/volsync"
 	"github.com/go-kure/kure/pkg/stack"
@@ -34,7 +36,7 @@ func (h *VolSyncHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 		return err
 	}
 
-	rsApp := stack.NewApplication(config.SourcePVC+"-backup", app.Namespace, config)
+	rsApp := stack.NewApplication(app.Name+"-"+config.SourcePVC+"-backup", app.Namespace, config)
 	bundle.Applications = append(bundle.Applications, rsApp)
 	return nil
 }
@@ -82,19 +84,33 @@ func (h *VolSyncHandler) parseProperties(props map[string]any, app *stack.Applic
 		config.VolumeSnapshotClassName = vsc
 	}
 
-	if pid, ok := yamlToInt(props["pruneIntervalDays"]); ok {
+	if v, ok := props["pruneIntervalDays"]; ok {
+		pid, ok := yamlToInt(v)
+		if !ok {
+			return nil, errors.New("'pruneIntervalDays' must be a positive integer")
+		}
+		if pid <= 0 || pid > math.MaxInt32 {
+			return nil, errors.Errorf("'pruneIntervalDays' must be between 1 and %d", math.MaxInt32)
+		}
 		config.PruneIntervalDays = pid
 	}
 
 	if rawRetain, ok := props["retain"].(map[string]any); ok {
-		if d, ok := yamlToInt(rawRetain["daily"]); ok {
-			config.RetainDaily = d
-		}
-		if w, ok := yamlToInt(rawRetain["weekly"]); ok {
-			config.RetainWeekly = w
-		}
-		if m, ok := yamlToInt(rawRetain["monthly"]); ok {
-			config.RetainMonthly = m
+		for field, dst := range map[string]*int{
+			"daily":   &config.RetainDaily,
+			"weekly":  &config.RetainWeekly,
+			"monthly": &config.RetainMonthly,
+		} {
+			if v, ok := rawRetain[field]; ok {
+				n, ok := yamlToInt(v)
+				if !ok {
+					return nil, errors.Errorf("'retain.%s' must be a non-negative integer", field)
+				}
+				if n < 0 || n > math.MaxInt32 {
+					return nil, errors.Errorf("'retain.%s' must be between 0 and %d", field, math.MaxInt32)
+				}
+				*dst = n
+			}
 		}
 	}
 
@@ -117,11 +133,15 @@ type VolsyncConfig struct {
 }
 
 // yamlToInt converts a numeric value (int, float64) from YAML to int.
+// Non-integer float values (e.g. 1.5) are rejected.
 func yamlToInt(v any) (int, bool) {
 	switch n := v.(type) {
 	case int:
 		return n, true
 	case float64:
+		if n != float64(int(n)) {
+			return 0, false
+		}
 		return int(n), true
 	}
 	return 0, false

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -1,0 +1,169 @@
+package traits
+
+import (
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	kurevol "github.com/go-kure/kure/pkg/kubernetes/volsync"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
+)
+
+// VolSyncHandler handles OAM volsync traits.
+type VolSyncHandler struct{}
+
+// CanHandle returns true for volsync trait type.
+func (h *VolSyncHandler) CanHandle(traitType string) bool {
+	return traitType == "volsync"
+}
+
+// ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
+func (h *VolSyncHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if _, err := builtin.DecodeStrict[builtin.VolSyncRendering](rendering); err != nil {
+		return nil, errors.Wrap(err, "volsync rendering")
+	}
+	return rendering, nil
+}
+
+// Apply creates a VolSync ReplicationSource resource appended to the bundle.
+func (h *VolSyncHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	rsApp := stack.NewApplication(config.SourcePVC+"-backup", app.Namespace, config)
+	bundle.Applications = append(bundle.Applications, rsApp)
+	return nil
+}
+
+func (h *VolSyncHandler) parseProperties(props map[string]any, app *stack.Application) (*VolsyncConfig, error) {
+	sourcePVC, ok := props["sourcePVC"].(string)
+	if !ok || sourcePVC == "" {
+		return nil, errors.New("required property 'sourcePVC' missing or not a string")
+	}
+
+	schedule, ok := props["schedule"].(string)
+	if !ok || schedule == "" {
+		return nil, errors.New("required property 'schedule' missing or not a string")
+	}
+
+	config := &VolsyncConfig{
+		ComponentName:     app.Name,
+		SourcePVC:         sourcePVC,
+		Schedule:          schedule,
+		CopyMethod:        "Snapshot",
+		PruneIntervalDays: 14,
+		RetainDaily:       7,
+		RetainWeekly:      4,
+		RetainMonthly:     3,
+		Repository:        app.Name + "-volsync-secret",
+	}
+
+	if repo, ok := props["repository"].(string); ok && repo != "" {
+		config.Repository = repo
+	}
+
+	if cm, ok := props["copyMethod"].(string); ok && cm != "" {
+		switch cm {
+		case "Snapshot", "Direct", "Clone":
+			config.CopyMethod = cm
+		default:
+			return nil, errors.Errorf("unsupported copyMethod %q; supported: Snapshot, Direct, Clone", cm)
+		}
+	}
+
+	if sc, ok := props["storageClassName"].(string); ok {
+		config.StorageClassName = sc
+	}
+	if vsc, ok := props["volumeSnapshotClassName"].(string); ok {
+		config.VolumeSnapshotClassName = vsc
+	}
+
+	if pid, ok := yamlToInt(props["pruneIntervalDays"]); ok {
+		config.PruneIntervalDays = pid
+	}
+
+	if rawRetain, ok := props["retain"].(map[string]any); ok {
+		if d, ok := yamlToInt(rawRetain["daily"]); ok {
+			config.RetainDaily = d
+		}
+		if w, ok := yamlToInt(rawRetain["weekly"]); ok {
+			config.RetainWeekly = w
+		}
+		if m, ok := yamlToInt(rawRetain["monthly"]); ok {
+			config.RetainMonthly = m
+		}
+	}
+
+	return config, nil
+}
+
+// VolsyncConfig implements stack.ApplicationConfig for volsync traits.
+type VolsyncConfig struct {
+	ComponentName           string
+	SourcePVC               string
+	Schedule                string
+	Repository              string
+	CopyMethod              string
+	StorageClassName        string
+	VolumeSnapshotClassName string
+	PruneIntervalDays       int
+	RetainDaily             int
+	RetainWeekly            int
+	RetainMonthly           int
+}
+
+// yamlToInt converts a numeric value (int, float64) from YAML to int.
+func yamlToInt(v any) (int, bool) {
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
+}
+
+// Generate creates a VolSync ReplicationSource resource.
+func (c *VolsyncConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	pruneInterval := int32(c.PruneIntervalDays) //nolint:gosec
+	daily := int32(c.RetainDaily)               //nolint:gosec
+	weekly := int32(c.RetainWeekly)             //nolint:gosec
+	monthly := int32(c.RetainMonthly)           //nolint:gosec
+
+	mover := &kurevol.SourceResticConfig{
+		Repository:        c.Repository,
+		PruneIntervalDays: &pruneInterval,
+		ReplicationSourceVolumeOptions: volsyncv1alpha1.ReplicationSourceVolumeOptions{
+			CopyMethod: kurevol.CopyMethod(c.CopyMethod),
+		},
+		Retain: &volsyncv1alpha1.ResticRetainPolicy{
+			Daily:   &daily,
+			Weekly:  &weekly,
+			Monthly: &monthly,
+		},
+	}
+	if c.StorageClassName != "" {
+		sc := c.StorageClassName
+		mover.StorageClassName = &sc
+	}
+	if c.VolumeSnapshotClassName != "" {
+		vsc := c.VolumeSnapshotClassName
+		mover.VolumeSnapshotClassName = &vsc
+	}
+
+	schedule := c.Schedule
+	rs := kurevol.ReplicationSource(&kurevol.ReplicationSourceConfig{
+		Name:      app.Name,
+		Namespace: app.Namespace,
+		SourcePVC: c.SourcePVC,
+		Trigger:   &kurevol.TriggerConfig{Schedule: &schedule},
+		Mover:     mover,
+	})
+
+	obj := client.Object(rs)
+	return []*client.Object{&obj}, nil
+}

--- a/pkg/oam/builtin/volsync.go
+++ b/pkg/oam/builtin/volsync.go
@@ -1,0 +1,5 @@
+package builtin
+
+// VolSyncRendering holds no rendering keys; ValidateAndApplyDefaults rejects
+// any key the operator accidentally provides (design-capability-schema.md §2.4).
+type VolSyncRendering struct{}

--- a/pkg/oam/parser_test.go
+++ b/pkg/oam/parser_test.go
@@ -430,38 +430,6 @@ spec:
 	}
 }
 
-func TestParse_RejectsDeferredPhase2TraitType(t *testing.T) {
-	// networkpolicy is a Phase 2 trait (issue #49) — not yet supported.
-	// It must fail at validate time, not silently pass to dispatch.
-	input := `
-apiVersion: launcher.gokure.dev/v1alpha1
-kind: Application
-metadata:
-  name: hello
-spec:
-  components:
-  - name: web
-    type: webservice
-    properties:
-      image: nginx:1.25
-    traits:
-    - type: networkpolicy
-      properties:
-        size: 10Gi
-`
-	_, err := Parse([]byte(input))
-	if err == nil {
-		t.Fatal("expected error for deferred Phase 2 trait networkpolicy, got nil")
-	}
-	var valErr *errors.ValidationError
-	if !stderrors.As(err, &valErr) {
-		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
-	}
-	if valErr.Value != "networkpolicy" {
-		t.Errorf("Value = %q, want %q", valErr.Value, "networkpolicy")
-	}
-}
-
 func TestParse_RejectsDuplicateComponentNames(t *testing.T) {
 	input := `
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -24,18 +24,19 @@ var validComponentTypes = map[string]bool{
 	"statefulset": true,
 }
 
-// validTraitTypes is the Phase 1 set from design-kurel-package.md §4.3.
-// Deferred until Phase 2 (#49, #50): networkpolicy, cilium-networkpolicy, volsync.
-// Updated when Phase 2 handlers land.
+// validTraitTypes is the set of supported trait types from design-kurel-package.md §4.3.
 var validTraitTypes = map[string]bool{
-	"expose":          true,
-	"ingress":         true,
-	"httproute":       true,
-	"certificate":     true,
-	"external-secret": true,
-	"configmap":       true,
-	"scaler":          true,
-	"pvc":             true,
+	"expose":               true,
+	"ingress":              true,
+	"httproute":            true,
+	"certificate":          true,
+	"external-secret":      true,
+	"configmap":            true,
+	"networkpolicy":        true,
+	"cilium-networkpolicy": true,
+	"volsync":              true,
+	"scaler":               true,
+	"pvc":                  true,
 }
 
 // traitComponentRestrictions maps trait types to the component types they support.


### PR DESCRIPTION
## Summary

- **external-secret**: CapabilityAware handler; `secretStoreRef` injected from ClusterProfile capability; supports `data[]`, `dataFrom[]`, `target` creation/deletion policies, and template
- **configmap**: creates standalone ConfigMap; optional `mountPath` wraps the component config with a decorator injecting volumes into Deployment, StatefulSet, DaemonSet, and CronJob resources; explicit error for unsupported workload types
- **networkpolicy**: generates `networking.k8s.io/v1` NetworkPolicy with ingress/egress rules; supports podSelector, namespaceSelector, ipBlock, port/protocol filtering
- **cilium-networkpolicy**: generates `cilium.io/v2` CiliumNetworkPolicy (namespaced only; cluster-wide deferred) via JSON round-trip against Cilium API types
- **volsync**: generates VolSync ReplicationSource with Restic mover; defaults for copyMethod=Snapshot, pruneIntervalDays=14, retain policy, and repository name

All five handlers registered in `kurel build`, added to `validTraitTypes`, with empty-struct `ValidateAndApplyDefaults` for no-rendering traits (design-capability-schema.md §2.4).

## Test plan

- [ ] Unit tests for all 5 handlers in `traits_test.go` (CanHandle, VAD, Apply, error cases)
- [ ] `ConfigMapDecorator_StatefulSet` — verifies volume injection on StatefulSet
- [ ] `ConfigMapDecorator_UnsupportedComponent` — verifies explicit error when no workload found
- [ ] 6 golden fixture scenarios: external-secret-minimal, configmap-minimal, configmap-with-mount, networkpolicy-minimal, cilium-networkpolicy-minimal, volsync-minimal
- [ ] `GOWORK=off go test ./...` — all pass
- [ ] `GOWORK=off mise run lint` — 0 issues

Closes #49 (external-secret). Advances #50 (networkpolicy, configmap, cilium-networkpolicy namespaced, volsync — cluster-wide cilium deferred).