### PR TITLE
feat(oam): add postgresql component handler

### DIFF
--- a/examples/10-postgresql-ha.yaml
+++ b/examples/10-postgresql-ha.yaml
@@ -7,10 +7,8 @@ spec:
   - name: db
     type: postgresql
     properties:
-      instances: 3
-      storage:
-        size: "50Gi"
-        storageClass: fast-ssd
+      replicas: 3
+      storageSize: "50Gi"
       postgresql:
         parameters:
           max_connections: "200"

--- a/examples/14-full-stack.yaml
+++ b/examples/14-full-stack.yaml
@@ -116,10 +116,8 @@ spec:
   - name: db
     type: postgresql
     properties:
-      instances: 3
-      storage:
-        size: "50Gi"
-        storageClass: fast-ssd
+      replicas: 3
+      storageSize: "50Gi"
       resources:
         requests:
           cpu: "500m"

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,8 @@ require (
 	github.com/backube/volsync v0.15.0
 	github.com/cert-manager/cert-manager v1.20.2
 	github.com/cilium/cilium v1.19.3
+	github.com/cloudnative-pg/cloudnative-pg v1.29.0
+	github.com/cloudnative-pg/plugin-barman-cloud v0.12.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342
 	github.com/go-kure/kure v0.2.0-alpha.3
@@ -32,7 +34,6 @@ require (
 	github.com/cilium/statedb v0.5.6 // indirect
 	github.com/cilium/stream v0.0.1 // indirect
 	github.com/cloudnative-pg/barman-cloud v0.5.1 // indirect
-	github.com/cloudnative-pg/cloudnative-pg v1.29.0 // indirect
 	github.com/cloudnative-pg/cnpg-i v0.5.0 // indirect
 	github.com/cloudnative-pg/machinery v0.4.0 // indirect
 	github.com/controlplaneio-fluxcd/flux-operator v0.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXj
 github.com/cloudnative-pg/cnpg-i v0.5.0/go.mod h1:7Gh4+UzhBpGhr4DreB1GN9wGYfvxwXCXZUyVt3zE/3I=
 github.com/cloudnative-pg/machinery v0.4.0 h1:3sfqrBptH4QQSVB4g10Z+7aiQRnh4g+6AsqsK0ibKaQ=
 github.com/cloudnative-pg/machinery v0.4.0/go.mod h1:OIwaTYAnLv8PmBmBvEf0BvMK2JBX6J+naTMg9UgV1FQ=
+github.com/cloudnative-pg/plugin-barman-cloud v0.12.0 h1:zq1hJYpyfRsVXp1CJ2ncZGQoIDfus614x6VYMtWfwEQ=
+github.com/cloudnative-pg/plugin-barman-cloud v0.12.0/go.mod h1:7pMLhJalzyTO0sx9uelGT7bKA53o+uWbrG4ktVIBWQM=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 h1:6xNmx7iTtyBRev0+D/Tv1FZd4SCg8axKApyNyRsAt/w=
 github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5/go.mod h1:KdCmV+x/BuvyMxRnYBlmVaq4OLiKW6iRQfvC62cvdkI=
 github.com/controlplaneio-fluxcd/flux-operator v0.40.0 h1:LoUtsOagXI7nVpg6uhKzA/gWgcmvssy/7B2UKRPF5X0=

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -120,6 +120,7 @@ func newBuiltinTransformer() *oam.Transformer {
 			"cronjob":     &components.CronjobHandler{},
 			"daemonset":   &components.DaemonsetHandler{},
 			"statefulset": &components.StatefulsetHandler{},
+			"postgresql":  &components.PostgresqlHandler{},
 		},
 		map[string]oam.TraitHandler{
 			"expose":               &traits.ExposeHandler{},

--- a/pkg/cmd/kurel/testdata/postgresql-backup/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-backup/app.yaml
@@ -1,0 +1,17 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      backup:
+        retentionPolicy: "30d"
+        destinationPath: "s3://my-bucket/backups"
+        endpointURL: "https://s3.amazonaws.com"
+        secretName: "backup-creds"

--- a/pkg/cmd/kurel/testdata/postgresql-backup/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-backup/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-backup/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-backup/expected.yaml
@@ -1,0 +1,29 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  backup:
+    barmanObjectStore:
+      destinationPath: s3://my-bucket/backups
+      endpointURL: https://s3.amazonaws.com
+      s3Credentials:
+        accessKeyId:
+          key: ACCESS_KEY_ID
+          name: backup-creds
+        secretAccessKey:
+          key: SECRET_ACCESS_KEY
+          name: backup-creds
+    retentionPolicy: 30d
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-basic/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-basic/app.yaml
@@ -1,11 +1,12 @@
 apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
-  name: my-database
+  name: test-db
+  namespace: default
 spec:
   components:
-  - name: db
+  - name: postgres
     type: postgresql
     properties:
-      replicas: 1
+      version: "16"
       storageSize: "10Gi"

--- a/pkg/cmd/kurel/testdata/postgresql-basic/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-basic/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-basic/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-basic/expected.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-databases/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-databases/app.yaml
@@ -1,0 +1,22 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      databases:
+      - name: myapp
+        owner: myapp_user
+      - name: analytics
+        owner: analytics_user
+        databaseReclaimPolicy: delete
+        extensions:
+        - name: pg_stat_statements
+        - name: pgvector
+          ensure: absent

--- a/pkg/cmd/kurel/testdata/postgresql-databases/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-databases/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-databases/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-databases/expected.yaml
@@ -1,0 +1,45 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: postgres-myapp
+  namespace: default
+spec:
+  cluster:
+    name: postgres
+  name: myapp
+  owner: myapp_user
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: postgres-analytics
+  namespace: default
+spec:
+  cluster:
+    name: postgres
+  databaseReclaimPolicy: delete
+  extensions:
+  - ensure: present
+    name: pg_stat_statements
+  - ensure: absent
+    name: pgvector
+  name: analytics
+  owner: analytics_user

--- a/pkg/cmd/kurel/testdata/postgresql-full/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-full/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db-full
+  namespace: production
+spec:
+  components:
+  - name: main-db
+    type: postgresql
+    properties:
+      version: "15"
+      storageSize: "100Gi"
+      replicas: 3
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "4"
+          memory: 8Gi

--- a/pkg/cmd/kurel/testdata/postgresql-full/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-full/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-full/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-full/expected.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: main-db
+  namespace: production
+spec:
+  affinity: {}
+  enablePDB: true
+  imageName: ghcr.io/cloudnative-pg/postgresql:15
+  instances: 3
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: "1"
+      memory: 2Gi
+  storage:
+    size: 100Gi

--- a/pkg/cmd/kurel/testdata/postgresql-imagename/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-imagename/app.yaml
@@ -1,11 +1,12 @@
 apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
-  name: my-database
+  name: test-db
+  namespace: default
 spec:
   components:
-  - name: db
+  - name: postgres
     type: postgresql
     properties:
-      replicas: 1
+      imageName: ghcr.io/tensorchord/pgvecto-rs:pg16-v0.3.0
       storageSize: "10Gi"

--- a/pkg/cmd/kurel/testdata/postgresql-imagename/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-imagename/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-imagename/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-imagename/expected.yaml
@@ -1,0 +1,17 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/tensorchord/pgvecto-rs:pg16-v0.3.0
+  instances: 1
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/app.yaml
@@ -1,0 +1,18 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      inheritedMetadata:
+        labels:
+          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+          reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: app-ns
+        annotations:
+          backup.velero.io/backup-volumes: data

--- a/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-inheritedmetadata/expected.yaml
@@ -1,0 +1,23 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  inheritedMetadata:
+    annotations:
+      backup.velero.io/backup-volumes: data
+    labels:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: app-ns
+  instances: 1
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-managed-roles/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-managed-roles/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      managedRoles:
+      - name: app_user
+        login: true
+        passwordSecret: app-db-creds
+        comment: Application user
+      - name: readonly_user
+        login: true
+        inRoles:
+          - pg_read_all_data

--- a/pkg/cmd/kurel/testdata/postgresql-managed-roles/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-managed-roles/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-managed-roles/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-managed-roles/expected.yaml
@@ -1,0 +1,28 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  managed:
+    roles:
+    - comment: Application user
+      login: true
+      name: app_user
+      passwordSecret:
+        name: app-db-creds
+    - inRoles:
+      - pg_read_all_data
+      login: true
+      name: readonly_user
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-monitoring/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-monitoring/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      monitoring:
+        enabled: true
+        customQueries:
+        - name: pg-stat-statements
+          key: queries
+        - name: pg-custom-metrics
+          key: custom-queries

--- a/pkg/cmd/kurel/testdata/postgresql-monitoring/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-monitoring/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-monitoring/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-monitoring/expected.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  monitoring:
+    customQueriesConfigMap:
+    - key: queries
+      name: pg-stat-statements
+    - key: custom-queries
+      name: pg-custom-metrics
+    enablePodMonitor: true
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/cmd/kurel/testdata/postgresql-objectstore/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-objectstore/app.yaml
@@ -1,0 +1,17 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      objectStore:
+        destinationPath: s3://my-bucket/postgres/
+        endpointURL: https://s3.example.com
+        secretName: postgres-backup-creds
+        retentionPolicy: 30d

--- a/pkg/cmd/kurel/testdata/postgresql-objectstore/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-objectstore/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-objectstore/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-objectstore/expected.yaml
@@ -1,0 +1,42 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  plugins:
+  - isWALArchiver: true
+    name: barman-cloud.barmancloud.cnpg.io
+    parameters:
+      objectStoreName: postgres
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  configuration:
+    destinationPath: s3://my-bucket/postgres/
+    endpointURL: https://s3.example.com
+    s3Credentials:
+      accessKeyId:
+        key: ACCESS_KEY_ID
+        name: postgres-backup-creds
+      secretAccessKey:
+        key: SECRET_ACCESS_KEY
+        name: postgres-backup-creds
+  instanceSidecarConfiguration:
+    resources: {}
+  retentionPolicy: 30d

--- a/pkg/cmd/kurel/testdata/postgresql-pooler/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-pooler/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      replicas: 3
+      pooler:
+        enabled: true
+        instances: 3
+        type: "rw"
+        poolMode: "transaction"
+        parameters:
+          max_client_conn: "1000"
+          default_pool_size: "25"

--- a/pkg/cmd/kurel/testdata/postgresql-pooler/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-pooler/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-pooler/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-pooler/expected.yaml
@@ -1,0 +1,33 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: true
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 3
+  postgresql:
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: postgres-pooler
+  namespace: default
+spec:
+  cluster:
+    name: postgres
+  instances: 3
+  pgbouncer:
+    parameters:
+      default_pool_size: "25"
+      max_client_conn: "1000"
+    poolMode: transaction
+  type: rw

--- a/pkg/cmd/kurel/testdata/postgresql-production/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-production/app.yaml
@@ -1,0 +1,38 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db-prod
+  namespace: production
+spec:
+  components:
+  - name: main-db
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "100Gi"
+      replicas: 3
+      resources:
+        requests:
+          cpu: "1"
+          memory: 2Gi
+        limits:
+          cpu: "4"
+          memory: 8Gi
+      monitoring:
+        enabled: true
+      replication:
+        synchronous:
+          method: "any"
+          number: 1
+          dataDurability: "required"
+      postgresql:
+        parameters:
+          shared_buffers: "256MB"
+          effective_cache_size: "768MB"
+          max_connections: "200"
+      affinity:
+        enablePodAntiAffinity: true
+        topologyKey: "kubernetes.io/hostname"
+        podAntiAffinityType: "required"
+        nodeSelector:
+          workload-type: "database"

--- a/pkg/cmd/kurel/testdata/postgresql-production/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-production/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-production/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-production/expected.yaml
@@ -1,0 +1,39 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: main-db
+  namespace: production
+spec:
+  affinity:
+    enablePodAntiAffinity: true
+    nodeSelector:
+      workload-type: database
+    podAntiAffinityType: required
+    topologyKey: kubernetes.io/hostname
+  enablePDB: true
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 3
+  monitoring:
+    enablePodMonitor: true
+  postgresql:
+    parameters:
+      effective_cache_size: 768MB
+      max_connections: "200"
+      shared_buffers: 256MB
+    syncReplicaElectionConstraint:
+      enabled: false
+    synchronous:
+      dataDurability: required
+      failoverQuorum: false
+      method: any
+      number: 1
+  primaryUpdateStrategy: unsupervised
+  resources:
+    limits:
+      cpu: "4"
+      memory: 8Gi
+    requests:
+      cpu: "1"
+      memory: 2Gi
+  storage:
+    size: 100Gi

--- a/pkg/cmd/kurel/testdata/postgresql-sharedpreload/app.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-sharedpreload/app.yaml
@@ -1,0 +1,15 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: test-db
+  namespace: default
+spec:
+  components:
+  - name: postgres
+    type: postgresql
+    properties:
+      version: "16"
+      storageSize: "10Gi"
+      postgresql:
+        parameters:
+          shared_preload_libraries: vectors.so,pg_stat_statements

--- a/pkg/cmd/kurel/testdata/postgresql-sharedpreload/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-sharedpreload/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/postgresql-sharedpreload/expected.yaml
+++ b/pkg/cmd/kurel/testdata/postgresql-sharedpreload/expected.yaml
@@ -1,0 +1,19 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgres
+  namespace: default
+spec:
+  affinity: {}
+  enablePDB: false
+  imageName: ghcr.io/cloudnative-pg/postgresql:16
+  instances: 1
+  postgresql:
+    parameters:
+      shared_preload_libraries: vectors.so,pg_stat_statements
+    syncReplicaElectionConstraint:
+      enabled: false
+  primaryUpdateStrategy: unsupervised
+  resources: {}
+  storage:
+    size: 10Gi

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -1,0 +1,737 @@
+package components
+
+import (
+	"fmt"
+
+	kurecnpg "github.com/go-kure/kure/pkg/kubernetes/cnpg"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// PostgresqlHandler handles OAM postgresql components.
+type PostgresqlHandler struct{}
+
+// CanHandle returns true for postgresql component type.
+func (h *PostgresqlHandler) CanHandle(componentType string) bool {
+	return componentType == "postgresql"
+}
+
+// ToApplicationConfig converts an OAM postgresql component to a PostgresqlConfig.
+func (h *PostgresqlHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	config := &PostgresqlConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	config.Provider = "cnpg"
+	if provider, ok := props["provider"].(string); ok {
+		switch provider {
+		case "cnpg":
+			config.Provider = provider
+		default:
+			return nil, errors.Errorf("unsupported postgresql provider %q, supported: cnpg", provider)
+		}
+	}
+
+	config.Version = "16"
+	if version, ok := props["version"].(string); ok {
+		config.Version = version
+	}
+
+	config.StorageSize = "1Gi"
+	if size, ok := props["storageSize"].(string); ok {
+		config.StorageSize = size
+	}
+	config.explicitStorageSize = props["storageSize"] != nil
+
+	config.Replicas = parseReplicas(props, 1)
+	config.explicitReplicas = hasExplicitReplicas(props)
+
+	if resources, ok := props["resources"].(map[string]any); ok {
+		config.Resources = parseResources(resources)
+	}
+	config.explicitResources = resourceExplicitFlags(props)
+
+	if backup, ok := props["backup"].(map[string]any); ok {
+		if v, ok := backup["retentionPolicy"].(string); ok {
+			config.BackupRetentionPolicy = v
+		}
+		if v, ok := backup["destinationPath"].(string); ok {
+			config.BackupDestinationPath = v
+		}
+		if v, ok := backup["endpointURL"].(string); ok {
+			config.BackupEndpointURL = v
+		}
+		if v, ok := backup["secretName"].(string); ok {
+			config.BackupSecretName = v
+		}
+	}
+
+	if monitoring, ok := props["monitoring"].(map[string]any); ok {
+		if enabled, ok := monitoring["enabled"].(bool); ok {
+			config.MonitoringEnabled = enabled
+		}
+		if cqList, ok := monitoring["customQueries"].([]any); ok {
+			for i, cq := range cqList {
+				cqMap, ok := cq.(map[string]any)
+				if !ok {
+					continue
+				}
+				name, _ := cqMap["name"].(string)
+				if name == "" {
+					return nil, errors.Errorf("monitoring.customQueries[%d]: 'name' is required", i)
+				}
+				key, _ := cqMap["key"].(string)
+				if key == "" {
+					return nil, errors.Errorf("monitoring.customQueries[%d]: 'key' is required", i)
+				}
+				config.MonitoringCustomQueries = append(config.MonitoringCustomQueries, CustomQueryRef{Name: name, Key: key})
+			}
+		}
+	}
+
+	if pooler, ok := props["pooler"].(map[string]any); ok {
+		if enabled, ok := pooler["enabled"].(bool); ok {
+			config.PoolerEnabled = enabled
+		}
+		config.PoolerInstances = 3
+		if v := pooler["instances"]; v != nil {
+			n, ok := toInt32(v)
+			if !ok {
+				return nil, errors.Errorf("invalid pooler instances value: %v", v)
+			}
+			config.PoolerInstances = n
+		}
+		if typ, ok := pooler["type"].(string); ok {
+			switch typ {
+			case "rw", "ro":
+				config.PoolerType = typ
+			default:
+				return nil, errors.Errorf("unsupported pooler type %q, supported: rw, ro", typ)
+			}
+		} else {
+			config.PoolerType = "rw"
+		}
+		if mode, ok := pooler["poolMode"].(string); ok {
+			switch PoolMode(mode) {
+			case PoolModeSession, PoolModeTransaction, PoolModeStatement:
+				config.PoolerPoolMode = PoolMode(mode)
+			default:
+				return nil, errors.Errorf("unsupported pooler pool mode %q, supported: session, transaction, statement", mode)
+			}
+		} else {
+			config.PoolerPoolMode = PoolModeSession
+		}
+		if params, ok := pooler["parameters"].(map[string]any); ok {
+			config.PoolerParameters = stringMap(params)
+		}
+	}
+
+	if bootstrap, ok := props["bootstrap"].(map[string]any); ok {
+		_, hasRecovery := bootstrap["recovery"].(map[string]any)
+		_, hasPgBasebackup := bootstrap["pg_basebackup"].(map[string]any)
+		if hasRecovery && hasPgBasebackup {
+			return nil, errors.New("bootstrap: recovery and pg_basebackup are mutually exclusive")
+		}
+		if recovery, ok := bootstrap["recovery"].(map[string]any); ok {
+			if source, ok := recovery["source"].(string); ok {
+				config.BootstrapRecoverySource = source
+			}
+		}
+		if pgbb, ok := bootstrap["pg_basebackup"].(map[string]any); ok {
+			if source, ok := pgbb["source"].(string); ok {
+				config.BootstrapPgBasebackupSource = source
+			}
+		}
+	}
+
+	if ecList, ok := props["externalClusters"].([]any); ok {
+		for _, ec := range ecList {
+			ecMap, ok := ec.(map[string]any)
+			if !ok {
+				continue
+			}
+			ext := ExternalCluster{}
+			if n, ok := ecMap["name"].(string); ok {
+				ext.Name = n
+			}
+			if bos, ok := ecMap["barmanObjectStore"].(map[string]any); ok {
+				ext.BarmanObjectStore = bos
+			}
+			if cp, ok := ecMap["connectionParameters"].(map[string]any); ok {
+				ext.ConnectionParameters = stringMap(cp)
+			}
+			if ext.Name != "" {
+				config.ExternalClusters = append(config.ExternalClusters, ext)
+			}
+		}
+	}
+
+	if replication, ok := props["replication"].(map[string]any); ok {
+		if sync, ok := replication["synchronous"].(map[string]any); ok {
+			if method, ok := sync["method"].(string); ok {
+				switch method {
+				case "any", "first":
+					config.SynchronousMethod = method
+				default:
+					return nil, errors.Errorf("unsupported replication synchronous method %q, supported: any, first", method)
+				}
+			}
+			config.SynchronousNumber = 1
+			if v := sync["number"]; v != nil {
+				n, ok := toInt32(v)
+				if !ok {
+					return nil, errors.Errorf("invalid replication synchronous number value: %v", v)
+				}
+				config.SynchronousNumber = n
+			}
+			if config.SynchronousNumber < 0 {
+				return nil, errors.Errorf("replication synchronous number must be >= 0, got %d", config.SynchronousNumber)
+			}
+			if dd, ok := sync["dataDurability"].(string); ok {
+				switch dd {
+				case "required", "preferred":
+					config.SynchronousDataDurability = dd
+				default:
+					return nil, errors.Errorf("unsupported replication synchronous dataDurability %q, supported: required, preferred", dd)
+				}
+			}
+		}
+	}
+
+	if pg, ok := props["postgresql"].(map[string]any); ok {
+		if params, ok := pg["parameters"].(map[string]any); ok {
+			config.PostgresqlParameters = stringMap(params)
+		}
+	}
+
+	if img, ok := props["imageName"].(string); ok {
+		config.ImageName = img
+	}
+
+	if im, ok := props["inheritedMetadata"].(map[string]any); ok {
+		if labels, ok := im["labels"].(map[string]any); ok {
+			config.InheritedLabels = stringMap(labels)
+		}
+		if annotations, ok := im["annotations"].(map[string]any); ok {
+			config.InheritedAnnotations = stringMap(annotations)
+		}
+	}
+
+	if roleList, ok := props["managedRoles"].([]any); ok {
+		for i, r := range roleList {
+			rMap, ok := r.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("managedRoles[%d]: must be an object", i)
+			}
+			name, _ := rMap["name"].(string)
+			if name == "" {
+				return nil, errors.Errorf("managedRoles[%d]: 'name' is required", i)
+			}
+			role := ManagedRoleConfig{Name: name}
+			if ensure, ok := rMap["ensure"].(string); ok {
+				switch ensure {
+				case "present", "absent":
+					role.Ensure = ensure
+				default:
+					return nil, errors.Errorf("managedRoles[%d]: unsupported ensure %q, supported: present, absent", i, ensure)
+				}
+			}
+			if v, ok := rMap["login"].(bool); ok {
+				role.Login = v
+			}
+			if v, ok := rMap["superuser"].(bool); ok {
+				role.Superuser = v
+			}
+			if v, ok := rMap["createdb"].(bool); ok {
+				role.CreateDB = v
+			}
+			if v, ok := rMap["createrole"].(bool); ok {
+				role.CreateRole = v
+			}
+			if v, ok := rMap["replication"].(bool); ok {
+				role.Replication = v
+			}
+			if v, ok := rMap["inherit"].(bool); ok {
+				role.Inherit = &v
+			}
+			if v := rMap["connectionLimit"]; v != nil {
+				n, ok := toInt32(v)
+				if !ok {
+					return nil, errors.Errorf("managedRoles[%d]: invalid connectionLimit value: %v", i, v)
+				}
+				n64 := int64(n)
+				role.ConnectionLimit = &n64
+			}
+			if v, ok := rMap["passwordSecret"].(string); ok {
+				role.PasswordSecret = v
+			}
+			if v, ok := rMap["comment"].(string); ok {
+				role.Comment = v
+			}
+			if inRoles, ok := rMap["inRoles"].([]any); ok {
+				for _, ir := range inRoles {
+					if s, ok := ir.(string); ok {
+						role.InRoles = append(role.InRoles, s)
+					}
+				}
+			}
+			config.ManagedRoles = append(config.ManagedRoles, role)
+		}
+	}
+
+	if osMap, ok := props["objectStore"].(map[string]any); ok {
+		dp, _ := osMap["destinationPath"].(string)
+		if dp == "" {
+			return nil, errors.New("objectStore: 'destinationPath' is required")
+		}
+		os := &ObjectStoreConfig{DestinationPath: dp}
+		if eu, ok := osMap["endpointURL"].(string); ok {
+			os.EndpointURL = eu
+		}
+		if sn, ok := osMap["secretName"].(string); ok {
+			os.SecretName = sn
+		}
+		if rp, ok := osMap["retentionPolicy"].(string); ok {
+			os.RetentionPolicy = rp
+		}
+		if sv, ok := osMap["serverName"].(string); ok {
+			os.ServerName = sv
+		}
+		config.ObjectStore = os
+	}
+
+	if dbList, ok := props["databases"].([]any); ok {
+		for i, d := range dbList {
+			dMap, ok := d.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("databases[%d]: must be an object", i)
+			}
+			name, _ := dMap["name"].(string)
+			if name == "" {
+				return nil, errors.Errorf("databases[%d]: 'name' is required", i)
+			}
+			owner, _ := dMap["owner"].(string)
+			if owner == "" {
+				return nil, errors.Errorf("databases[%d]: 'owner' is required", i)
+			}
+			entry := DatabaseEntry{Name: name, Owner: owner}
+			if ensure, ok := dMap["ensure"].(string); ok {
+				switch ensure {
+				case "present", "absent":
+					entry.Ensure = ensure
+				default:
+					return nil, errors.Errorf("databases[%d]: unsupported ensure %q, supported: present, absent", i, ensure)
+				}
+			}
+			if rp, ok := dMap["databaseReclaimPolicy"].(string); ok {
+				switch rp {
+				case "retain", "delete":
+					entry.ReclaimPolicy = rp
+				default:
+					return nil, errors.Errorf("databases[%d]: unsupported databaseReclaimPolicy %q, supported: retain, delete", i, rp)
+				}
+			}
+			if extList, ok := dMap["extensions"].([]any); ok {
+				for j, e := range extList {
+					eMap, ok := e.(map[string]any)
+					if !ok {
+						continue
+					}
+					extName, _ := eMap["name"].(string)
+					if extName == "" {
+						return nil, errors.Errorf("databases[%d].extensions[%d]: 'name' is required", i, j)
+					}
+					ext := DatabaseExtension{Name: extName}
+					if ensure, ok := eMap["ensure"].(string); ok {
+						switch ensure {
+						case "present", "absent":
+							ext.Ensure = ensure
+						default:
+							return nil, errors.Errorf("databases[%d].extensions[%d]: unsupported ensure %q, supported: present, absent", i, j, ensure)
+						}
+					}
+					entry.Extensions = append(entry.Extensions, ext)
+				}
+			}
+			config.Databases = append(config.Databases, entry)
+		}
+	}
+
+	if affinity, ok := props["affinity"].(map[string]any); ok {
+		config.AffinityEnabled = true
+		config.AffinityEnablePodAntiAffinity = true
+		if enabled, ok := affinity["enablePodAntiAffinity"].(bool); ok {
+			config.AffinityEnablePodAntiAffinity = enabled
+		}
+		config.AffinityTopologyKey = "kubernetes.io/hostname"
+		if tk, ok := affinity["topologyKey"].(string); ok {
+			config.AffinityTopologyKey = tk
+		}
+		if paat, ok := affinity["podAntiAffinityType"].(string); ok {
+			config.AffinityPodAntiAffinityType = paat
+		}
+		if ns, ok := affinity["nodeSelector"].(map[string]any); ok {
+			config.AffinityNodeSelector = stringMap(ns)
+		}
+	}
+
+	return config, nil
+}
+
+// PoolMode identifies the PgBouncer connection pooling mode.
+type PoolMode string
+
+const (
+	PoolModeSession     PoolMode = "session"
+	PoolModeTransaction PoolMode = "transaction"
+	PoolModeStatement   PoolMode = "statement"
+)
+
+// CustomQueryRef references a ConfigMap containing custom monitoring queries.
+type CustomQueryRef struct {
+	Name string
+	Key  string
+}
+
+// ExternalCluster defines an external cluster for bootstrap or replica sources.
+type ExternalCluster struct {
+	Name                 string
+	BarmanObjectStore    map[string]any
+	ConnectionParameters map[string]string
+}
+
+// ManagedRoleConfig holds config for a single CNPG managed role.
+type ManagedRoleConfig struct {
+	Name            string
+	Ensure          string
+	Login           bool
+	Superuser       bool
+	CreateDB        bool
+	CreateRole      bool
+	Replication     bool
+	Inherit         *bool
+	ConnectionLimit *int64
+	PasswordSecret  string
+	Comment         string
+	InRoles         []string
+}
+
+// ObjectStoreConfig holds config for a CNPG ObjectStore CR.
+type ObjectStoreConfig struct {
+	DestinationPath string
+	EndpointURL     string
+	SecretName      string
+	RetentionPolicy string
+	ServerName      string
+}
+
+// DatabaseEntry holds config for a single CNPG Database CR.
+type DatabaseEntry struct {
+	Name          string
+	Owner         string
+	Ensure        string
+	ReclaimPolicy string
+	Extensions    []DatabaseExtension
+}
+
+// DatabaseExtension holds config for a single extension within a Database CR.
+type DatabaseExtension struct {
+	Name   string
+	Ensure string
+}
+
+// PostgresqlConfig implements stack.ApplicationConfig for postgresql components.
+type PostgresqlConfig struct {
+	Name        string
+	Namespace   string
+	Provider    string
+	Version     string
+	StorageSize string
+	Replicas    int32
+	Resources   ResourceRequirements
+	ImageName   string
+
+	BackupRetentionPolicy string
+	BackupDestinationPath string
+	BackupEndpointURL     string
+	BackupSecretName      string
+
+	MonitoringEnabled       bool
+	MonitoringCustomQueries []CustomQueryRef
+
+	PoolerEnabled    bool
+	PoolerInstances  int32
+	PoolerType       string
+	PoolerPoolMode   PoolMode
+	PoolerParameters map[string]string
+
+	BootstrapRecoverySource     string
+	BootstrapPgBasebackupSource string
+	ExternalClusters            []ExternalCluster
+
+	SynchronousMethod         string
+	SynchronousNumber         int32
+	SynchronousDataDurability string
+
+	PostgresqlParameters map[string]string
+
+	InheritedLabels      map[string]string
+	InheritedAnnotations map[string]string
+
+	ManagedRoles []ManagedRoleConfig
+	ObjectStore  *ObjectStoreConfig
+	Databases    []DatabaseEntry
+
+	AffinityEnabled               bool
+	AffinityEnablePodAntiAffinity bool
+	AffinityTopologyKey           string
+	AffinityPodAntiAffinityType   string
+	AffinityNodeSelector          map[string]string
+
+	explicitReplicas    bool
+	explicitResources   explicitResourceFlags
+	explicitStorageSize bool
+}
+
+// ApplyPolicy applies defaults then enforces limits from the policy.
+// Faithful port of crane's PostgresqlConfig.ApplyPolicy: enforces replicas, resources, storageSize only.
+func (c *PostgresqlConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil {
+		return nil
+	}
+
+	c.Replicas = applyDefaultReplicas(c.Replicas, c.explicitReplicas, p.DefaultReplicas())
+	if !c.explicitResources.cpuRequest {
+		c.Resources.CPURequest = applyDefaultResource(c.Resources.CPURequest, p.DefaultCPURequest())
+	}
+	if !c.explicitResources.memoryRequest {
+		c.Resources.MemoryRequest = applyDefaultResource(c.Resources.MemoryRequest, p.DefaultMemoryRequest())
+	}
+	if !c.explicitResources.cpuLimit {
+		c.Resources.CPULimit = applyDefaultResource(c.Resources.CPULimit, p.DefaultCPULimit())
+	}
+	if !c.explicitResources.memoryLimit {
+		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
+	}
+
+	if err := enforceMaxReplicas(c.Replicas, p.MaxReplicas()); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPURequest, p.MaxCPU(), "cpu request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.CPULimit, p.MaxCPU(), "cpu limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryRequest, p.MaxMemory(), "memory request"); err != nil {
+		return err
+	}
+	if err := enforceMaxResource(c.Resources.MemoryLimit, p.MaxMemory(), "memory limit"); err != nil {
+		return err
+	}
+	if err := enforceMaxStorageSize(c.StorageSize, p.MaxStorageSize()); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Generate creates CloudNative-PG resources: Cluster, optional Pooler, ObjectStore, and Database CRs.
+func (c *PostgresqlConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	cluster, err := c.createCluster(app)
+	if err != nil {
+		return nil, err
+	}
+	resources := []*client.Object{&cluster}
+
+	if c.PoolerEnabled {
+		pooler := c.createPooler(app)
+		resources = append(resources, &pooler)
+	}
+
+	if c.ObjectStore != nil {
+		os := c.createObjectStore(app)
+		resources = append(resources, &os)
+	}
+
+	for _, db := range c.Databases {
+		dbRes := c.createDatabase(app, db)
+		resources = append(resources, &dbRes)
+	}
+
+	return resources, nil
+}
+
+func (c *PostgresqlConfig) createCluster(app *stack.Application) (client.Object, error) {
+	imageName := c.ImageName
+	if imageName == "" {
+		imageName = fmt.Sprintf("ghcr.io/cloudnative-pg/postgresql:%s", c.Version)
+	}
+
+	opts := &kurecnpg.ClusterOptions{
+		Instances:            c.Replicas,
+		ImageName:            imageName,
+		StorageSize:          c.StorageSize,
+		InheritedLabels:      c.InheritedLabels,
+		InheritedAnnotations: c.InheritedAnnotations,
+		PostgresParams:       c.PostgresqlParameters,
+	}
+
+	if c.Resources.CPURequest != "" || c.Resources.MemoryRequest != "" ||
+		c.Resources.CPULimit != "" || c.Resources.MemoryLimit != "" {
+		opts.Resources = &kurecnpg.ResourceOptions{
+			RequestsCPU:    c.Resources.CPURequest,
+			RequestsMemory: c.Resources.MemoryRequest,
+			LimitsCPU:      c.Resources.CPULimit,
+			LimitsMemory:   c.Resources.MemoryLimit,
+		}
+	}
+
+	if c.BackupRetentionPolicy != "" || c.BackupDestinationPath != "" {
+		backup := &kurecnpg.BackupOptions{
+			DestinationPath: c.BackupDestinationPath,
+			EndpointURL:     c.BackupEndpointURL,
+			RetentionPolicy: c.BackupRetentionPolicy,
+		}
+		if c.BackupSecretName != "" {
+			backup.S3Credentials = &kurecnpg.S3CredentialOptions{SecretName: c.BackupSecretName}
+		}
+		opts.Backup = backup
+	}
+
+	if c.MonitoringEnabled {
+		mon := &kurecnpg.MonitoringOptions{EnablePodMonitor: true}
+		for _, cq := range c.MonitoringCustomQueries {
+			mon.CustomQueriesConfigMap = append(mon.CustomQueriesConfigMap, kurecnpg.ConfigMapKeyRefOptions{
+				Name: cq.Name,
+				Key:  cq.Key,
+			})
+		}
+		opts.Monitoring = mon
+	}
+
+	if c.BootstrapRecoverySource != "" || c.BootstrapPgBasebackupSource != "" {
+		opts.Bootstrap = &kurecnpg.BootstrapOptions{
+			RecoverySource:     c.BootstrapRecoverySource,
+			PgBasebackupSource: c.BootstrapPgBasebackupSource,
+		}
+	}
+
+	if len(c.ExternalClusters) > 0 {
+		ecs := make([]kurecnpg.ExternalClusterOptions, len(c.ExternalClusters))
+		for i, ec := range c.ExternalClusters {
+			ecs[i] = kurecnpg.ExternalClusterOptions{
+				Name:                 ec.Name,
+				ConnectionParameters: ec.ConnectionParameters,
+				BarmanObjectStore:    ec.BarmanObjectStore,
+			}
+		}
+		opts.ExternalClusters = ecs
+	}
+
+	if c.SynchronousMethod != "" {
+		opts.Synchronous = &kurecnpg.SynchronousOptions{
+			Method:         c.SynchronousMethod,
+			Number:         c.SynchronousNumber,
+			DataDurability: c.SynchronousDataDurability,
+		}
+	}
+
+	if c.ObjectStore != nil {
+		opts.ObjectStoreName = app.Name
+	}
+
+	if c.AffinityEnabled {
+		opts.Affinity = &kurecnpg.AffinityOptions{
+			EnablePodAntiAffinity: c.AffinityEnablePodAntiAffinity,
+			TopologyKey:           c.AffinityTopologyKey,
+			PodAntiAffinityType:   c.AffinityPodAntiAffinityType,
+			NodeSelector:          c.AffinityNodeSelector,
+		}
+	}
+
+	if len(c.ManagedRoles) > 0 {
+		roles := make([]kurecnpg.ManagedRoleOptions, len(c.ManagedRoles))
+		for i, role := range c.ManagedRoles {
+			roles[i] = kurecnpg.ManagedRoleOptions{
+				Name:            role.Name,
+				Ensure:          role.Ensure,
+				Comment:         role.Comment,
+				Login:           role.Login,
+				Superuser:       role.Superuser,
+				CreateDB:        role.CreateDB,
+				CreateRole:      role.CreateRole,
+				Replication:     role.Replication,
+				Inherit:         role.Inherit,
+				ConnectionLimit: role.ConnectionLimit,
+				PasswordSecret:  role.PasswordSecret,
+				InRoles:         role.InRoles,
+			}
+		}
+		opts.ManagedRoles = roles
+	}
+
+	return kurecnpg.Cluster(&kurecnpg.ClusterConfig{
+		Name:      app.Name,
+		Namespace: app.Namespace,
+		Options:   opts,
+	})
+}
+
+func (c *PostgresqlConfig) createPooler(app *stack.Application) client.Object {
+	pgBouncer := &kurecnpg.PgBouncerOptions{
+		PoolMode: string(c.PoolerPoolMode),
+	}
+	if len(c.PoolerParameters) > 0 {
+		pgBouncer.Parameters = c.PoolerParameters
+	}
+	return kurecnpg.Pooler(&kurecnpg.PoolerConfig{
+		Name:      app.Name + "-pooler",
+		Namespace: app.Namespace,
+		Options: &kurecnpg.PoolerOptions{
+			ClusterName: app.Name,
+			Instances:   c.PoolerInstances,
+			Type:        c.PoolerType,
+			PgBouncer:   pgBouncer,
+		},
+	})
+}
+
+func (c *PostgresqlConfig) createObjectStore(app *stack.Application) client.Object {
+	return kurecnpg.ObjectStore(&kurecnpg.ObjectStoreConfig{
+		Name:      app.Name,
+		Namespace: app.Namespace,
+		Options: &kurecnpg.ObjectStoreOptions{
+			DestinationPath: c.ObjectStore.DestinationPath,
+			EndpointURL:     c.ObjectStore.EndpointURL,
+			ServerName:      c.ObjectStore.ServerName,
+			SecretName:      c.ObjectStore.SecretName,
+			RetentionPolicy: c.ObjectStore.RetentionPolicy,
+		},
+	})
+}
+
+func (c *PostgresqlConfig) createDatabase(app *stack.Application, db DatabaseEntry) client.Object {
+	exts := make([]kurecnpg.ExtensionOptions, len(db.Extensions))
+	for i, ext := range db.Extensions {
+		exts[i] = kurecnpg.ExtensionOptions{Name: ext.Name, Ensure: ext.Ensure}
+	}
+	return kurecnpg.Database(&kurecnpg.DatabaseConfig{
+		Name:      app.Name + "-" + db.Name,
+		Namespace: app.Namespace,
+		Options: &kurecnpg.DatabaseOptions{
+			ClusterName:   app.Name,
+			DBName:        db.Name,
+			Owner:         db.Owner,
+			ReclaimPolicy: db.ReclaimPolicy,
+			Ensure:        db.Ensure,
+			Extensions:    exts,
+		},
+	})
+}

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -83,12 +83,9 @@ func (h *PostgresqlHandler) ToApplicationConfig(component *oam.Component, namesp
 					continue
 				}
 				name, _ := cqMap["name"].(string)
-				if name == "" {
-					return nil, errors.Errorf("monitoring.customQueries[%d]: 'name' is required", i)
-				}
 				key, _ := cqMap["key"].(string)
-				if key == "" {
-					return nil, errors.Errorf("monitoring.customQueries[%d]: 'key' is required", i)
+				if name == "" || key == "" {
+					return nil, errors.Errorf("monitoring.customQueries[%d]: both 'name' and 'key' are required", i)
 				}
 				config.MonitoringCustomQueries = append(config.MonitoringCustomQueries, CustomQueryRef{Name: name, Key: key})
 			}

--- a/pkg/oam/builtin/components/postgresql_test.go
+++ b/pkg/oam/builtin/components/postgresql_test.go
@@ -1,0 +1,803 @@
+package components_test
+
+import (
+	"testing"
+
+	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
+	barmanv1 "github.com/cloudnative-pg/plugin-barman-cloud/api/v1"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestPostgresqlHandler_CanHandle(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	if !h.CanHandle("postgresql") {
+		t.Error("expected CanHandle(postgresql) == true")
+	}
+	if h.CanHandle("webservice") {
+		t.Error("expected CanHandle(webservice) == false")
+	}
+}
+
+func TestPostgresqlHandler_Defaults(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "db",
+		Type:       "postgresql",
+		Properties: map[string]any{},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	pc := cfg.(*components.PostgresqlConfig)
+	if pc.Provider != "cnpg" {
+		t.Errorf("Provider: got %q, want %q", pc.Provider, "cnpg")
+	}
+	if pc.Version != "16" {
+		t.Errorf("Version: got %q, want %q", pc.Version, "16")
+	}
+	if pc.StorageSize != "1Gi" {
+		t.Errorf("StorageSize: got %q, want %q", pc.StorageSize, "1Gi")
+	}
+	if pc.Replicas != 1 {
+		t.Errorf("Replicas: got %d, want 1", pc.Replicas)
+	}
+}
+
+func TestPostgresqlHandler_InvalidProvider(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{"provider": "zalando"},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for unsupported provider")
+	}
+}
+
+func TestPostgresqlHandler_PoolerValidation(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"pooler": map[string]any{"enabled": true, "type": "invalid"},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid pooler type")
+	}
+
+	_, err = h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"pooler": map[string]any{"enabled": true, "poolMode": "invalid"},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid pooler poolMode")
+	}
+}
+
+func TestPostgresqlHandler_BootstrapMutualExclusion(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"bootstrap": map[string]any{
+				"recovery":      map[string]any{"source": "src"},
+				"pg_basebackup": map[string]any{"source": "src"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for mutually exclusive bootstrap options")
+	}
+}
+
+func TestPostgresqlHandler_BootstrapRecovery(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"bootstrap": map[string]any{
+				"recovery": map[string]any{"source": "backup-cluster"},
+			},
+			"externalClusters": []any{
+				map[string]any{
+					"name": "backup-cluster",
+					"connectionParameters": map[string]any{
+						"host": "db.example.com",
+					},
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	pc := cfg.(*components.PostgresqlConfig)
+	if pc.BootstrapRecoverySource != "backup-cluster" {
+		t.Errorf("BootstrapRecoverySource: got %q, want %q", pc.BootstrapRecoverySource, "backup-cluster")
+	}
+	if len(pc.ExternalClusters) != 1 {
+		t.Fatalf("ExternalClusters: got %d, want 1", len(pc.ExternalClusters))
+	}
+	if pc.ExternalClusters[0].Name != "backup-cluster" {
+		t.Errorf("ExternalClusters[0].Name: got %q", pc.ExternalClusters[0].Name)
+	}
+}
+
+func TestPostgresqlHandler_SynchronousValidation(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"replication": map[string]any{
+				"synchronous": map[string]any{"method": "bad"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid synchronous method")
+	}
+
+	_, err = h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"replication": map[string]any{
+				"synchronous": map[string]any{"method": "any", "dataDurability": "bad"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid dataDurability")
+	}
+}
+
+func TestPostgresqlHandler_ObjectStore_MissingDestinationPath(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"objectStore": map[string]any{"endpointURL": "https://s3.example.com"},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing objectStore.destinationPath")
+	}
+}
+
+func TestPostgresqlHandler_Databases_MissingName(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"databases": []any{
+				map[string]any{"owner": "myuser"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing databases[0].name")
+	}
+}
+
+func TestPostgresqlHandler_Databases_MissingOwner(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"databases": []any{
+				map[string]any{"name": "mydb"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing databases[0].owner")
+	}
+}
+
+func TestPostgresqlHandler_Databases_InvalidEnsure(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"databases": []any{
+				map[string]any{"name": "mydb", "owner": "u", "ensure": "wrong"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid databases[0].ensure")
+	}
+}
+
+func TestPostgresqlHandler_Databases_InvalidReclaimPolicy(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"databases": []any{
+				map[string]any{"name": "mydb", "owner": "u", "databaseReclaimPolicy": "wrong"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid databases[0].databaseReclaimPolicy")
+	}
+}
+
+func TestPostgresqlHandler_ManagedRoles_MissingName(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"managedRoles": []any{
+				map[string]any{"login": true},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing managedRoles[0].name")
+	}
+}
+
+func TestPostgresqlHandler_ManagedRoles_InvalidEnsure(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"managedRoles": []any{
+				map[string]any{"name": "myrole", "ensure": "wrong"},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for invalid managedRoles[0].ensure")
+	}
+}
+
+func TestPostgresqlHandler_MonitoringCustomQueries_MissingName(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"customQueries": []any{
+					map[string]any{"key": "queries"},
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing monitoring.customQueries[0].name")
+	}
+}
+
+func TestPostgresqlHandler_MonitoringCustomQueries_MissingKey(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"monitoring": map[string]any{
+				"enabled": true,
+				"customQueries": []any{
+					map[string]any{"name": "pg-stat"},
+				},
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Error("expected error for missing monitoring.customQueries[0].key")
+	}
+}
+
+func TestPostgresqlHandler_ValidProperties(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"version":     "15",
+			"storageSize": "50Gi",
+			"replicas":    float64(3),
+			"imageName":   "ghcr.io/tensorchord/pgvecto-rs:pg16-v0.3.0",
+			"resources": map[string]any{
+				"requests": map[string]any{"cpu": "500m", "memory": "512Mi"},
+				"limits":   map[string]any{"cpu": "2", "memory": "4Gi"},
+			},
+			"postgresql": map[string]any{
+				"parameters": map[string]any{"shared_buffers": "256MB"},
+			},
+			"inheritedMetadata": map[string]any{
+				"labels":      map[string]any{"team": "backend"},
+				"annotations": map[string]any{"backup.velero.io/backup-volumes": "data"},
+			},
+			"pooler": map[string]any{
+				"enabled":    true,
+				"instances":  float64(2),
+				"type":       "ro",
+				"poolMode":   "transaction",
+				"parameters": map[string]any{"max_client_conn": "500"},
+			},
+			"backup": map[string]any{
+				"destinationPath": "s3://my-bucket/backups",
+				"endpointURL":     "https://s3.example.com",
+				"secretName":      "backup-creds",
+				"retentionPolicy": "30d",
+			},
+			"monitoring": map[string]any{
+				"enabled": true,
+				"customQueries": []any{
+					map[string]any{"name": "pg-stat", "key": "queries"},
+				},
+			},
+			"replication": map[string]any{
+				"synchronous": map[string]any{
+					"method":         "any",
+					"number":         float64(1),
+					"dataDurability": "required",
+				},
+			},
+			"affinity": map[string]any{
+				"enablePodAntiAffinity": true,
+				"topologyKey":           "kubernetes.io/hostname",
+				"podAntiAffinityType":   "required",
+				"nodeSelector":          map[string]any{"workload-type": "database"},
+			},
+			"managedRoles": []any{
+				map[string]any{
+					"name":            "app_user",
+					"login":           true,
+					"passwordSecret":  "app-db-creds",
+					"comment":         "App user",
+					"connectionLimit": float64(10),
+					"inRoles":         []any{"pg_read_all_data"},
+				},
+			},
+			"objectStore": map[string]any{
+				"destinationPath": "s3://my-bucket/postgres/",
+				"serverName":      "my-server",
+				"retentionPolicy": "30d",
+			},
+			"databases": []any{
+				map[string]any{
+					"name":                  "mydb",
+					"owner":                 "myapp",
+					"ensure":                "present",
+					"databaseReclaimPolicy": "retain",
+					"extensions": []any{
+						map[string]any{"name": "pg_stat_statements"},
+						map[string]any{"name": "pgvector", "ensure": "absent"},
+					},
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	pc := cfg.(*components.PostgresqlConfig)
+	if pc.Version != "15" {
+		t.Errorf("Version: got %q", pc.Version)
+	}
+	if pc.StorageSize != "50Gi" {
+		t.Errorf("StorageSize: got %q", pc.StorageSize)
+	}
+	if pc.Replicas != 3 {
+		t.Errorf("Replicas: got %d", pc.Replicas)
+	}
+	if pc.ImageName != "ghcr.io/tensorchord/pgvecto-rs:pg16-v0.3.0" {
+		t.Errorf("ImageName: got %q", pc.ImageName)
+	}
+	if pc.Resources.CPURequest != "500m" {
+		t.Errorf("CPURequest: got %q", pc.Resources.CPURequest)
+	}
+	if pc.PostgresqlParameters["shared_buffers"] != "256MB" {
+		t.Errorf("PostgresqlParameters: got %v", pc.PostgresqlParameters)
+	}
+	if pc.InheritedLabels["team"] != "backend" {
+		t.Errorf("InheritedLabels: got %v", pc.InheritedLabels)
+	}
+	if !pc.PoolerEnabled || pc.PoolerType != "ro" {
+		t.Errorf("Pooler: enabled=%v type=%q", pc.PoolerEnabled, pc.PoolerType)
+	}
+	if pc.BackupDestinationPath != "s3://my-bucket/backups" {
+		t.Errorf("BackupDestinationPath: got %q", pc.BackupDestinationPath)
+	}
+	if !pc.MonitoringEnabled || len(pc.MonitoringCustomQueries) != 1 {
+		t.Errorf("Monitoring: enabled=%v queries=%d", pc.MonitoringEnabled, len(pc.MonitoringCustomQueries))
+	}
+	if pc.SynchronousMethod != "any" || pc.SynchronousDataDurability != "required" {
+		t.Errorf("Synchronous: method=%q durability=%q", pc.SynchronousMethod, pc.SynchronousDataDurability)
+	}
+	if !pc.AffinityEnabled || pc.AffinityTopologyKey != "kubernetes.io/hostname" {
+		t.Errorf("Affinity: enabled=%v topologyKey=%q", pc.AffinityEnabled, pc.AffinityTopologyKey)
+	}
+	if len(pc.ManagedRoles) != 1 || pc.ManagedRoles[0].Name != "app_user" {
+		t.Errorf("ManagedRoles: %v", pc.ManagedRoles)
+	}
+	if pc.ObjectStore == nil || pc.ObjectStore.ServerName != "my-server" {
+		t.Errorf("ObjectStore: %v", pc.ObjectStore)
+	}
+	if len(pc.Databases) != 1 || len(pc.Databases[0].Extensions) != 2 {
+		t.Errorf("Databases: %v", pc.Databases)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithResources(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"resources": map[string]any{
+			"requests": map[string]any{"cpu": "500m", "memory": "1Gi"},
+			"limits":   map[string]any{"cpu": "2", "memory": "4Gi"},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster, ok := (*objs[0]).(*cnpgv1.Cluster)
+	if !ok {
+		t.Fatalf("expected *cnpgv1.Cluster")
+	}
+	if cluster.Spec.Resources.Requests == nil {
+		t.Error("expected non-nil resources.requests")
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithBackup(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"backup": map[string]any{
+			"destinationPath": "s3://my-bucket/backups",
+			"retentionPolicy": "30d",
+			"secretName":      "backup-creds",
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.Backup == nil {
+		t.Fatal("expected non-nil Backup")
+	}
+	if cluster.Spec.Backup.RetentionPolicy != "30d" {
+		t.Errorf("Backup.RetentionPolicy: got %q", cluster.Spec.Backup.RetentionPolicy)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithMonitoring(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"monitoring": map[string]any{
+			"enabled": true,
+			"customQueries": []any{
+				map[string]any{"name": "pg-stat", "key": "queries"},
+			},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.Monitoring == nil {
+		t.Fatal("expected non-nil Monitoring")
+	}
+	if len(cluster.Spec.Monitoring.CustomQueriesConfigMap) != 1 {
+		t.Errorf("customQueriesConfigMap: got %d", len(cluster.Spec.Monitoring.CustomQueriesConfigMap))
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithSynchronous(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"replication": map[string]any{
+			"synchronous": map[string]any{
+				"method":         "any",
+				"number":         float64(2),
+				"dataDurability": "required",
+			},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.PostgresConfiguration.Synchronous == nil {
+		t.Fatal("expected non-nil Synchronous")
+	}
+	if cluster.Spec.PostgresConfiguration.Synchronous.Number != 2 {
+		t.Errorf("Synchronous.Number: got %d", cluster.Spec.PostgresConfiguration.Synchronous.Number)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithManagedRoles(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"managedRoles": []any{
+			map[string]any{
+				"name":  "app_user",
+				"login": true,
+			},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.Managed == nil || len(cluster.Spec.Managed.Roles) != 1 {
+		t.Errorf("expected 1 managed role, got %v", cluster.Spec.Managed)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithAffinity(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"affinity": map[string]any{
+			"enablePodAntiAffinity": true,
+			"topologyKey":           "kubernetes.io/hostname",
+			"podAntiAffinityType":   "required",
+			"nodeSelector":          map[string]any{"workload-type": "database"},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.Affinity.TopologyKey != "kubernetes.io/hostname" {
+		t.Errorf("Affinity.TopologyKey: got %q", cluster.Spec.Affinity.TopologyKey)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithBootstrap(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"bootstrap": map[string]any{
+			"recovery": map[string]any{"source": "backup-cluster"},
+		},
+		"externalClusters": []any{
+			map[string]any{"name": "backup-cluster"},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	cluster := (*objs[0]).(*cnpgv1.Cluster)
+	if cluster.Spec.Bootstrap == nil || cluster.Spec.Bootstrap.Recovery == nil {
+		t.Fatal("expected non-nil Bootstrap.Recovery")
+	}
+	if cluster.Spec.Bootstrap.Recovery.Source != "backup-cluster" {
+		t.Errorf("Bootstrap.Recovery.Source: got %q", cluster.Spec.Bootstrap.Recovery.Source)
+	}
+}
+
+func newPostgresqlApp(t *testing.T, props map[string]any) *components.PostgresqlConfig {
+	t.Helper()
+	h := &components.PostgresqlHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "db",
+		Type:       "postgresql",
+		Properties: props,
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	return cfg.(*components.PostgresqlConfig)
+}
+
+func generatePostgresql(t *testing.T, pc *components.PostgresqlConfig) []*client.Object {
+	t.Helper()
+	app := stack.NewApplication("db", "default", pc)
+	objs, err := pc.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	return objs
+}
+
+func TestPostgresqlConfig_Generate_Minimal(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	if _, ok := (*objs[0]).(*cnpgv1.Cluster); !ok {
+		t.Errorf("expected *cnpgv1.Cluster, got %T", *objs[0])
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithPooler(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"pooler": map[string]any{"enabled": true, "instances": float64(2), "type": "rw"},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+	if _, ok := (*objs[0]).(*cnpgv1.Cluster); !ok {
+		t.Errorf("objs[0]: expected *cnpgv1.Cluster, got %T", *objs[0])
+	}
+	if _, ok := (*objs[1]).(*cnpgv1.Pooler); !ok {
+		t.Errorf("objs[1]: expected *cnpgv1.Pooler, got %T", *objs[1])
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithObjectStore(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"objectStore": map[string]any{
+			"destinationPath": "s3://my-bucket/postgres/",
+			"secretName":      "backup-creds",
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+
+	cluster, ok := (*objs[0]).(*cnpgv1.Cluster)
+	if !ok {
+		t.Fatalf("objs[0]: expected *cnpgv1.Cluster, got %T", *objs[0])
+	}
+	if len(cluster.Spec.Plugins) == 0 {
+		t.Fatal("cluster.Spec.Plugins: expected at least 1 entry")
+	}
+	if cluster.Spec.Plugins[0].Name != "barman-cloud.barmancloud.cnpg.io" {
+		t.Errorf("Plugins[0].Name: got %q", cluster.Spec.Plugins[0].Name)
+	}
+	if cluster.Spec.Plugins[0].Parameters["objectStoreName"] != "db" {
+		t.Errorf("Plugins[0].Parameters[objectStoreName]: got %q", cluster.Spec.Plugins[0].Parameters["objectStoreName"])
+	}
+
+	if _, ok := (*objs[1]).(*barmanv1.ObjectStore); !ok {
+		t.Errorf("objs[1]: expected *barmanv1.ObjectStore, got %T", *objs[1])
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithDatabase(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"databases": []any{
+			map[string]any{"name": "mydb", "owner": "myapp"},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+
+	db, ok := (*objs[1]).(*cnpgv1.Database)
+	if !ok {
+		t.Fatalf("objs[1]: expected *cnpgv1.Database, got %T", *objs[1])
+	}
+	if db.Name != "db-mydb" {
+		t.Errorf("Database.Name: got %q, want %q", db.Name, "db-mydb")
+	}
+	if db.Spec.ClusterRef.Name != "db" {
+		t.Errorf("Database.Spec.ClusterRef.Name: got %q, want %q", db.Spec.ClusterRef.Name, "db")
+	}
+	if db.Spec.Name != "mydb" {
+		t.Errorf("Database.Spec.Name: got %q, want %q", db.Spec.Name, "mydb")
+	}
+	if db.Spec.Owner != "myapp" {
+		t.Errorf("Database.Spec.Owner: got %q, want %q", db.Spec.Owner, "myapp")
+	}
+}
+
+func TestPostgresqlConfig_Generate_CombinedOrder(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"pooler": map[string]any{"enabled": true},
+		"objectStore": map[string]any{
+			"destinationPath": "s3://my-bucket/postgres/",
+		},
+		"databases": []any{
+			map[string]any{"name": "mydb", "owner": "myapp"},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 4 {
+		t.Fatalf("expected 4 objects, got %d", len(objs))
+	}
+	if _, ok := (*objs[0]).(*cnpgv1.Cluster); !ok {
+		t.Errorf("objs[0]: expected *cnpgv1.Cluster, got %T", *objs[0])
+	}
+	if _, ok := (*objs[1]).(*cnpgv1.Pooler); !ok {
+		t.Errorf("objs[1]: expected *cnpgv1.Pooler, got %T", *objs[1])
+	}
+	if _, ok := (*objs[2]).(*barmanv1.ObjectStore); !ok {
+		t.Errorf("objs[2]: expected *barmanv1.ObjectStore, got %T", *objs[2])
+	}
+	if _, ok := (*objs[3]).(*cnpgv1.Database); !ok {
+		t.Errorf("objs[3]: expected *cnpgv1.Database, got %T", *objs[3])
+	}
+}
+
+func TestPostgresqlConfig_ApplyPolicy_EnforcesStorageSize(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{"storageSize": "10Gi"})
+	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)
+	p := &stubPolicy{maxStorageSize: "5Gi"}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when storageSize exceeds max")
+	}
+}
+
+func TestPostgresqlConfig_ApplyPolicy_EnforcesReplicas(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{"replicas": float64(5)})
+	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)
+	p := &stubPolicy{maxReplicas: int32ptr(3)}
+	if err := enforceable.ApplyPolicy(p); err == nil {
+		t.Error("expected error when replicas exceed max")
+	}
+}
+
+func TestPostgresqlConfig_ApplyPolicy_DefaultsReplicas(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{})
+	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)
+	p := &stubPolicy{defaultReplicas: int32ptr(2)}
+	if err := enforceable.ApplyPolicy(p); err != nil {
+		t.Fatalf("ApplyPolicy: %v", err)
+	}
+	if pc.Replicas != 2 {
+		t.Errorf("Replicas after defaulting: got %d, want 2", pc.Replicas)
+	}
+}
+
+func TestPostgresqlConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{})
+	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy should be a no-op, got: %v", err)
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithPoolerParameters(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"pooler": map[string]any{
+			"enabled": true,
+			"parameters": map[string]any{
+				"max_client_conn":   "100",
+				"default_pool_size": "20",
+			},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+	pooler, ok := (*objs[1]).(*cnpgv1.Pooler)
+	if !ok {
+		t.Fatalf("objs[1]: expected *cnpgv1.Pooler, got %T", *objs[1])
+	}
+	if pooler.Spec.PgBouncer == nil || len(pooler.Spec.PgBouncer.Parameters) == 0 {
+		t.Error("expected non-empty PgBouncer.Parameters")
+	}
+}
+
+func TestPostgresqlConfig_Generate_WithDatabaseExtensions(t *testing.T) {
+	pc := newPostgresqlApp(t, map[string]any{
+		"databases": []any{
+			map[string]any{
+				"name":  "mydb",
+				"owner": "myapp",
+				"extensions": []any{
+					map[string]any{"name": "postgis", "ensure": "present"},
+					map[string]any{"name": "uuid-ossp", "ensure": "present"},
+				},
+			},
+		},
+	})
+	objs := generatePostgresql(t, pc)
+	if len(objs) != 2 {
+		t.Fatalf("expected 2 objects, got %d", len(objs))
+	}
+	db, ok := (*objs[1]).(*cnpgv1.Database)
+	if !ok {
+		t.Fatalf("objs[1]: expected *cnpgv1.Database, got %T", *objs[1])
+	}
+	if len(db.Spec.Extensions) != 2 {
+		t.Errorf("Extensions: expected 2, got %d", len(db.Spec.Extensions))
+	}
+}

--- a/pkg/oam/builtin/components/postgresql_test.go
+++ b/pkg/oam/builtin/components/postgresql_test.go
@@ -1,6 +1,7 @@
 package components_test
 
 import (
+	"strings"
 	"testing"
 
 	cnpgv1 "github.com/cloudnative-pg/cloudnative-pg/api/v1"
@@ -104,6 +105,42 @@ func TestPostgresqlHandler_BootstrapRecovery(t *testing.T) {
 		Name: "db", Type: "postgresql",
 		Properties: map[string]any{
 			"bootstrap": map[string]any{
+				"recovery": map[string]any{"source": "backup-src"},
+			},
+			"externalClusters": []any{
+				map[string]any{
+					"name": "backup-src",
+					"barmanObjectStore": map[string]any{
+						"destinationPath": "s3://backups/",
+					},
+				},
+			},
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	pc := cfg.(*components.PostgresqlConfig)
+	if pc.BootstrapRecoverySource != "backup-src" {
+		t.Errorf("BootstrapRecoverySource: got %q, want %q", pc.BootstrapRecoverySource, "backup-src")
+	}
+	if len(pc.ExternalClusters) != 1 {
+		t.Fatalf("ExternalClusters: got %d, want 1", len(pc.ExternalClusters))
+	}
+	if pc.ExternalClusters[0].Name != "backup-src" {
+		t.Errorf("ExternalClusters[0].Name: got %q", pc.ExternalClusters[0].Name)
+	}
+	if pc.ExternalClusters[0].BarmanObjectStore == nil {
+		t.Error("ExternalClusters[0].BarmanObjectStore: expected non-nil")
+	}
+}
+
+func TestPostgresqlHandler_BootstrapRecovery_ConnectionParameters(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "db", Type: "postgresql",
+		Properties: map[string]any{
+			"bootstrap": map[string]any{
 				"recovery": map[string]any{"source": "backup-cluster"},
 			},
 			"externalClusters": []any{
@@ -121,13 +158,10 @@ func TestPostgresqlHandler_BootstrapRecovery(t *testing.T) {
 	}
 	pc := cfg.(*components.PostgresqlConfig)
 	if pc.BootstrapRecoverySource != "backup-cluster" {
-		t.Errorf("BootstrapRecoverySource: got %q, want %q", pc.BootstrapRecoverySource, "backup-cluster")
+		t.Errorf("BootstrapRecoverySource: got %q", pc.BootstrapRecoverySource)
 	}
-	if len(pc.ExternalClusters) != 1 {
-		t.Fatalf("ExternalClusters: got %d, want 1", len(pc.ExternalClusters))
-	}
-	if pc.ExternalClusters[0].Name != "backup-cluster" {
-		t.Errorf("ExternalClusters[0].Name: got %q", pc.ExternalClusters[0].Name)
+	if len(pc.ExternalClusters) != 1 || pc.ExternalClusters[0].ConnectionParameters["host"] != "db.example.com" {
+		t.Errorf("ExternalClusters[0].ConnectionParameters: got %v", pc.ExternalClusters[0].ConnectionParameters)
 	}
 }
 
@@ -275,8 +309,8 @@ func TestPostgresqlHandler_MonitoringCustomQueries_MissingName(t *testing.T) {
 			},
 		},
 	}, "default")
-	if err == nil {
-		t.Error("expected error for missing monitoring.customQueries[0].name")
+	if err == nil || !strings.Contains(err.Error(), "both 'name' and 'key' are required") {
+		t.Errorf("expected error containing 'both name and key are required', got: %v", err)
 	}
 }
 
@@ -293,8 +327,8 @@ func TestPostgresqlHandler_MonitoringCustomQueries_MissingKey(t *testing.T) {
 			},
 		},
 	}, "default")
-	if err == nil {
-		t.Error("expected error for missing monitoring.customQueries[0].key")
+	if err == nil || !strings.Contains(err.Error(), "both 'name' and 'key' are required") {
+		t.Errorf("expected error containing 'both name and key are required', got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `PostgresqlHandler` and `PostgresqlConfig` as a faithful port of crane's postgresql component pipeline
- `Generate()` emits Cluster (always) + optional Pooler, ObjectStore, and Database CRs in that order
- `ApplyPolicy` enforces replicas, resources (×4), and storageSize — faithful to crane (no registry enforcement for postgresql)
- Registers `"postgresql"` in the kurel builtin transformer (`build.go`)
- Updates the three postgresql examples to use crane's canonical property names (`replicas`, `storageSize`) instead of the OAM-style `instances`/`storage.size`

Closes #48 (postgresql component handler — helmrelease remains deferred).

## Test plan

- [ ] 31 unit tests in `postgresql_test.go` covering: CanHandle, defaults, invalid provider, pooler validation, bootstrap mutual exclusion, bootstrap recovery (barmanObjectStore + connectionParameters paths), synchronous validation, objectStore/databases/managedRoles/monitoring validation, Generate() for all optional object types and combined order, and ApplyPolicy (enforce replicas, resources, storageSize; nil policy no-op)
- [ ] 12 golden fixtures in `testdata/postgresql-*/` matching crane's full test matrix: basic, backup, full, monitoring, pooler, production, databases, objectstore, managed-roles, imagename, inheritedmetadata, sharedpreload
- [ ] Total `./...` coverage: 81.9% (above 80% CI threshold)
- [ ] `mise run lint` passes (0 issues)
- [ ] `go test ./...` passes