### PR TITLE
feat(oam): httproute trait handler and expose gateway dispatch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	sigs.k8s.io/controller-runtime v0.24.0
+	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -147,7 +148,6 @@ require (
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.0 // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect
-	sigs.k8s.io/gateway-api v1.5.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -124,7 +124,8 @@ func newBuiltinTransformer() *oam.Transformer {
 		},
 		map[string]oam.TraitHandler{
 			"expose":               &traits.ExposeHandler{},
-			"ingress":              &traits.IngressHandler{}, //nolint:staticcheck
+			"ingress":              &traits.IngressHandler{},   //nolint:staticcheck
+			"httproute":            &traits.HTTPRouteHandler{}, //nolint:staticcheck
 			"certificate":          &traits.CertificateHandler{},
 			"scaler":               &traits.ScalerHandler{},
 			"pvc":                  &traits.PVCHandler{},

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -124,8 +124,8 @@ func newBuiltinTransformer() *oam.Transformer {
 		},
 		map[string]oam.TraitHandler{
 			"expose":               &traits.ExposeHandler{},
-			"ingress":              &traits.IngressHandler{},   //nolint:staticcheck
-			"httproute":            &traits.HTTPRouteHandler{}, //nolint:staticcheck
+			"ingress":              &traits.IngressHandler{},
+			"httproute":            &traits.HTTPRouteHandler{},
 			"certificate":          &traits.CertificateHandler{},
 			"scaler":               &traits.ScalerHandler{},
 			"pvc":                  &traits.PVCHandler{},

--- a/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/app.yaml
@@ -1,0 +1,26 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: slowapi
+  namespace: default
+spec:
+  components:
+  - name: slowapi
+    type: webservice
+    properties:
+      image: myorg/slowapi:v1.0.0
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+        hostnames:
+          - slow.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            timeouts:
+              request: 30s
+              backendRequest: 10s

--- a/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-backend-request-timeout/expected.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slowapi
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: slowapi
+    spec:
+      containers:
+      - image: myorg/slowapi:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: slowapi
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: slowapi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: slowapi
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi-httproute
+  namespace: default
+spec:
+  hostnames:
+  - slow.example.com
+  parentRefs:
+  - name: public-gateway
+  rules:
+  - backendRefs:
+    - name: slowapi
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      backendRequest: 10s
+      request: 30s

--- a/pkg/cmd/kurel/testdata/httproute-basic/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-basic/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: my-gateway
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /

--- a/pkg/cmd/kurel/testdata/httproute-basic/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-basic/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-basic/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-basic/expected.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: web
+  name: web-httproute
+  namespace: default
+spec:
+  parentRefs:
+  - name: my-gateway
+  rules:
+  - backendRefs:
+    - name: web
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-cors/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-cors/app.yaml
@@ -1,0 +1,39 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+  namespace: production
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: myregistry/api:v1.0.0
+      port: 8080
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: CORS
+                cors:
+                  allowOrigins:
+                    - https://example.com
+                    - https://app.example.com
+                  allowMethods:
+                    - GET
+                    - POST
+                  allowHeaders:
+                    - Authorization
+                    - Content-Type
+                  allowCredentials: true
+                  maxAge: 3600

--- a/pkg/cmd/kurel/testdata/httproute-filters-cors/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-cors/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-cors/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-cors/expected.yaml
@@ -74,7 +74,7 @@ spec:
   rules:
   - backendRefs:
     - name: api
-      port: 80
+      port: 8080
     filters:
     - cors:
         allowCredentials: true

--- a/pkg/cmd/kurel/testdata/httproute-filters-cors/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-cors/expected.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: myregistry/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: api
+  name: api-httproute
+  namespace: production
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: api
+      port: 80
+    filters:
+    - cors:
+        allowCredentials: true
+        allowHeaders:
+        - Authorization
+        - Content-Type
+        allowMethods:
+        - GET
+        - POST
+        allowOrigins:
+        - https://example.com
+        - https://app.example.com
+        maxAge: 3600
+      type: CORS
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-externalauth/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-externalauth/app.yaml
@@ -1,0 +1,37 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+  namespace: production
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: myregistry/api:v1.0.0
+      port: 8080
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: ExternalAuth
+                externalAuth:
+                  protocol: HTTP
+                  backendRef:
+                    name: authz-svc
+                    port: 9090
+                  http:
+                    path: /check
+                    allowedHeaders:
+                      - X-User-Id
+                      - X-Tenant-Id

--- a/pkg/cmd/kurel/testdata/httproute-filters-externalauth/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-externalauth/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-externalauth/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-externalauth/expected.yaml
@@ -74,7 +74,7 @@ spec:
   rules:
   - backendRefs:
     - name: api
-      port: 80
+      port: 8080
     filters:
     - externalAuth:
         backendRef:

--- a/pkg/cmd/kurel/testdata/httproute-filters-externalauth/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-externalauth/expected.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: myregistry/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: api
+  name: api-httproute
+  namespace: production
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: api
+      port: 80
+    filters:
+    - externalAuth:
+        backendRef:
+          name: authz-svc
+          port: 9090
+        http:
+          allowedHeaders:
+          - X-User-Id
+          - X-Tenant-Id
+          path: /check
+        protocol: HTTP
+      type: ExternalAuth
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-redirect/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-redirect/app.yaml
@@ -1,0 +1,29 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: shlink
+  namespace: default
+spec:
+  components:
+  - name: shlink
+    type: webservice
+    properties:
+      image: shlinkio/shlink:4.3
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - short.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: RequestRedirect
+                requestRedirect:
+                  scheme: https
+                  statusCode: 308

--- a/pkg/cmd/kurel/testdata/httproute-filters-redirect/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-redirect/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-redirect/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-redirect/expected.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: shlink
+  name: shlink
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: shlink
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: shlink
+    spec:
+      containers:
+      - image: shlinkio/shlink:4.3
+        imagePullPolicy: IfNotPresent
+        name: shlink
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: shlink
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: shlink
+  name: shlink
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: shlink
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: shlink
+  name: shlink
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: shlink
+  name: shlink-httproute
+  namespace: default
+spec:
+  hostnames:
+  - short.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: shlink
+      port: 80
+    filters:
+    - requestRedirect:
+        scheme: https
+        statusCode: 308
+      type: RequestRedirect
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/app.yaml
@@ -1,0 +1,32 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: myapp
+  namespace: production
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: myregistry/api:v1.0.0
+      port: 8080
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: RequestMirror
+                requestMirror:
+                  backendRef:
+                    name: mirror-svc
+                    port: 8080
+                  percent: 50

--- a/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/expected.yaml
@@ -74,7 +74,7 @@ spec:
   rules:
   - backendRefs:
     - name: api
-      port: 80
+      port: 8080
     filters:
     - requestMirror:
         backendRef:

--- a/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-requestmirror/expected.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: myregistry/api:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: production
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: api
+  name: api-httproute
+  namespace: production
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: api
+      port: 80
+    filters:
+    - requestMirror:
+        backendRef:
+          name: mirror-svc
+          port: 8080
+        percent: 50
+      type: RequestMirror
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-response-headers/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-response-headers/app.yaml
@@ -1,0 +1,34 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: vaultwarden
+  namespace: default
+spec:
+  components:
+  - name: vaultwarden
+    type: webservice
+    properties:
+      image: vaultwarden/server:1.32.0
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - vault.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            filters:
+              - type: ResponseHeaderModifier
+                responseHeaderModifier:
+                  set:
+                    - name: Strict-Transport-Security
+                      value: "max-age=31536000; includeSubDomains; preload"
+                    - name: X-Frame-Options
+                      value: "DENY"
+                    - name: Content-Security-Policy
+                      value: "default-src 'self'; frame-ancestors 'none'"

--- a/pkg/cmd/kurel/testdata/httproute-filters-response-headers/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-response-headers/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-response-headers/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-response-headers/expected.yaml
@@ -1,0 +1,91 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: vaultwarden
+  name: vaultwarden
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vaultwarden
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: vaultwarden
+    spec:
+      containers:
+      - image: vaultwarden/server:1.32.0
+        imagePullPolicy: IfNotPresent
+        name: vaultwarden
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: vaultwarden
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: vaultwarden
+  name: vaultwarden
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: vaultwarden
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: vaultwarden
+  name: vaultwarden
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: vaultwarden
+  name: vaultwarden-httproute
+  namespace: default
+spec:
+  hostnames:
+  - vault.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: vaultwarden
+      port: 80
+    filters:
+    - responseHeaderModifier:
+        set:
+        - name: Strict-Transport-Security
+          value: max-age=31536000; includeSubDomains; preload
+        - name: X-Frame-Options
+          value: DENY
+        - name: Content-Security-Policy
+          value: default-src 'self'; frame-ancestors 'none'
+      type: ResponseHeaderModifier
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/app.yaml
@@ -1,0 +1,29 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: api
+  namespace: default
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: myorg/api:v2.1.0
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: /v2

--- a/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-filters-urlrewrite/expected.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - image: myorg/api:v2.1.0
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: api
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: api
+  name: api
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: api
+  name: api-httproute
+  namespace: default
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: public-gateway
+  rules:
+  - backendRefs:
+    - name: api
+      port: 80
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          replacePrefixMatch: /v2
+          type: ReplacePrefixMatch
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v1

--- a/pkg/cmd/kurel/testdata/httproute-full-filters/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-full-filters/app.yaml
@@ -1,0 +1,44 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: secureapi
+  namespace: default
+spec:
+  components:
+  - name: secureapi
+    type: webservice
+    properties:
+      image: myorg/secureapi:v2.0.0
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+            namespace: gateway-system
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1
+            filters:
+              - type: URLRewrite
+                urlRewrite:
+                  path:
+                    type: ReplacePrefixMatch
+                    replacePrefixMatch: /v2
+              - type: RequestHeaderModifier
+                requestHeaderModifier:
+                  add:
+                    - name: X-Forwarded-Proto
+                      value: https
+              - type: ResponseHeaderModifier
+                responseHeaderModifier:
+                  set:
+                    - name: Strict-Transport-Security
+                      value: "max-age=31536000"
+                  remove:
+                    - X-Powered-By
+            timeouts:
+              request: 10s

--- a/pkg/cmd/kurel/testdata/httproute-full-filters/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-full-filters/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-full-filters/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-full-filters/expected.yaml
@@ -1,0 +1,101 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: secureapi
+  name: secureapi
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: secureapi
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: secureapi
+    spec:
+      containers:
+      - image: myorg/secureapi:v2.0.0
+        imagePullPolicy: IfNotPresent
+        name: secureapi
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: secureapi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: secureapi
+  name: secureapi
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: secureapi
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: secureapi
+  name: secureapi
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: secureapi
+  name: secureapi-httproute
+  namespace: default
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: public-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: secureapi
+      port: 80
+    filters:
+    - type: URLRewrite
+      urlRewrite:
+        path:
+          replacePrefixMatch: /v2
+          type: ReplacePrefixMatch
+    - requestHeaderModifier:
+        add:
+        - name: X-Forwarded-Proto
+          value: https
+      type: RequestHeaderModifier
+    - responseHeaderModifier:
+        remove:
+        - X-Powered-By
+        set:
+        - name: Strict-Transport-Security
+          value: max-age=31536000
+      type: ResponseHeaderModifier
+    matches:
+    - path:
+        type: PathPrefix
+        value: /v1
+    timeouts:
+      request: 10s

--- a/pkg/cmd/kurel/testdata/httproute-headers/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-headers/app.yaml
@@ -32,4 +32,4 @@ spec:
                   - name: x-api-version
                     value: v2
             backendRefs:
-              - port: 8080
+              - port: 80

--- a/pkg/cmd/kurel/testdata/httproute-headers/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-headers/app.yaml
@@ -1,0 +1,35 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: my-gateway
+            namespace: gateway-system
+        hostnames:
+          - api.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /v1
+                headers:
+                  - name: x-api-version
+                    value: v1
+              - path:
+                  type: PathPrefix
+                  value: /v2
+                headers:
+                  - name: x-api-version
+                    value: v2
+            backendRefs:
+              - port: 8080

--- a/pkg/cmd/kurel/testdata/httproute-headers/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-headers/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-headers/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-headers/expected.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: web
+  name: web-httproute
+  namespace: default
+spec:
+  hostnames:
+  - api.example.com
+  parentRefs:
+  - name: my-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: web
+      port: 8080
+    matches:
+    - headers:
+      - name: x-api-version
+        type: Exact
+        value: v1
+      path:
+        type: PathPrefix
+        value: /v1
+    - headers:
+      - name: x-api-version
+        type: Exact
+        value: v2
+      path:
+        type: PathPrefix
+        value: /v2

--- a/pkg/cmd/kurel/testdata/httproute-headers/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-headers/expected.yaml
@@ -74,7 +74,7 @@ spec:
   rules:
   - backendRefs:
     - name: web
-      port: 8080
+      port: 80
     matches:
     - headers:
       - name: x-api-version

--- a/pkg/cmd/kurel/testdata/httproute-multipath/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-multipath/app.yaml
@@ -1,0 +1,31 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: my-gateway
+        hostnames:
+          - example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /api
+            backendRefs:
+              - port: 8080
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /web
+            backendRefs:
+              - port: 3000

--- a/pkg/cmd/kurel/testdata/httproute-multipath/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-multipath/app.yaml
@@ -22,10 +22,10 @@ spec:
                   type: PathPrefix
                   value: /api
             backendRefs:
-              - port: 8080
+              - port: 80
           - matches:
               - path:
                   type: PathPrefix
                   value: /web
             backendRefs:
-              - port: 3000
+              - port: 80

--- a/pkg/cmd/kurel/testdata/httproute-multipath/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-multipath/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-multipath/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-multipath/expected.yaml
@@ -73,14 +73,14 @@ spec:
   rules:
   - backendRefs:
     - name: web
-      port: 8080
+      port: 80
     matches:
     - path:
         type: PathPrefix
         value: /api
   - backendRefs:
     - name: web
-      port: 3000
+      port: 80
     matches:
     - path:
         type: PathPrefix

--- a/pkg/cmd/kurel/testdata/httproute-multipath/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-multipath/expected.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: web
+  name: web-httproute
+  namespace: default
+spec:
+  hostnames:
+  - example.com
+  parentRefs:
+  - name: my-gateway
+  rules:
+  - backendRefs:
+    - name: web
+      port: 8080
+    matches:
+    - path:
+        type: PathPrefix
+        value: /api
+  - backendRefs:
+    - name: web
+      port: 3000
+    matches:
+    - path:
+        type: PathPrefix
+        value: /web

--- a/pkg/cmd/kurel/testdata/httproute-timeouts/app.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-timeouts/app.yaml
@@ -1,0 +1,25 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: slowapi
+  namespace: default
+spec:
+  components:
+  - name: slowapi
+    type: webservice
+    properties:
+      image: myorg/slowapi:v1.0.0
+    traits:
+    - type: httproute
+      properties:
+        parentRefs:
+          - name: public-gateway
+        hostnames:
+          - slow.example.com
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /
+            timeouts:
+              request: 30s

--- a/pkg/cmd/kurel/testdata/httproute-timeouts/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-timeouts/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/httproute-timeouts/expected.yaml
+++ b/pkg/cmd/kurel/testdata/httproute-timeouts/expected.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: slowapi
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: slowapi
+    spec:
+      containers:
+      - image: myorg/slowapi:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: slowapi
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: slowapi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: slowapi
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: slowapi
+  name: slowapi-httproute
+  namespace: default
+spec:
+  hostnames:
+  - slow.example.com
+  parentRefs:
+  - name: public-gateway
+  rules:
+  - backendRefs:
+    - name: slowapi
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /
+    timeouts:
+      request: 30s

--- a/pkg/cmd/kurel/testdata/ingress-explicit-backend/app.yaml
+++ b/pkg/cmd/kurel/testdata/ingress-explicit-backend/app.yaml
@@ -1,0 +1,23 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+      traits:
+        - type: ingress
+          properties:
+            ingressClassName: nginx
+            rules:
+              - host: frontend.example.com
+                paths:
+                  - path: /
+                  - path: /admin
+                    backend: deny-backend
+                    port: 8080

--- a/pkg/cmd/kurel/testdata/ingress-explicit-backend/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/ingress-explicit-backend/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/ingress-explicit-backend/expected.yaml
+++ b/pkg/cmd/kurel/testdata/ingress-explicit-backend/expected.yaml
@@ -1,0 +1,87 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - image: ghcr.io/example/frontend:v1.0.0
+        imagePullPolicy: IfNotPresent
+        name: frontend
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: frontend
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: frontend
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: frontend
+  name: frontend
+  namespace: default
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: frontend
+  name: frontend-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: frontend.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: frontend
+            port:
+              number: 8080
+        path: /
+        pathType: Prefix
+      - backend:
+          service:
+            name: deny-backend
+            port:
+              number: 8080
+        path: /admin
+        pathType: Prefix

--- a/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/app.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-db
+  namespace: default
+spec:
+  components:
+    - name: db
+      type: statefulset
+      properties:
+        image: ghcr.io/example/postgres:v15.0
+        port: 5432
+        serviceName: postgres-primary
+      traits:
+        - type: ingress
+          properties:
+            ingressClassName: nginx
+            rules:
+              - host: db.example.com
+                paths:
+                  - path: /

--- a/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/expected.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/expected.yaml
@@ -64,7 +64,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   labels:
-    app: postgres-primary
+    app: db
   name: db-ingress
   namespace: default
 spec:

--- a/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/expected.yaml
+++ b/pkg/cmd/kurel/testdata/statefulset-ingress-custom-servicename/expected.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+spec:
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  serviceName: postgres-primary
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - image: ghcr.io/example/postgres:v15.0
+        imagePullPolicy: IfNotPresent
+        name: db
+        ports:
+        - containerPort: 5432
+          name: tcp
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: db
+  updateStrategy: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: db
+  name: postgres-primary
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: tcp
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app: db
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: db
+  name: db
+  namespace: default
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: postgres-primary
+  name: db-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: db.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: postgres-primary
+            port:
+              number: 5432
+        path: /
+        pathType: Prefix

--- a/pkg/cmd/kurel/testdata/webservice-expose-gateway/app.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-gateway/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: nginx:1.25
+    traits:
+    - type: expose
+      properties:
+        rules:
+          - matches:
+              - path:
+                  type: PathPrefix
+                  value: /

--- a/pkg/cmd/kurel/testdata/webservice-expose-gateway/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-gateway/cluster.yaml
@@ -1,0 +1,10 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: gateway
+        gatewayName: my-gateway

--- a/pkg/cmd/kurel/testdata/webservice-expose-gateway/expected.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-gateway/expected.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: nginx:1.25
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: web
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: web
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: web
+  name: web-httproute
+  namespace: default
+spec:
+  parentRefs:
+  - name: my-gateway
+    namespace: gateway-system
+  rules:
+  - backendRefs:
+    - name: web
+      port: 80
+    matches:
+    - path:
+        type: PathPrefix
+        value: /

--- a/pkg/cmd/kurel/testdata/webservice-expose-ingress/expected.yaml
+++ b/pkg/cmd/kurel/testdata/webservice-expose-ingress/expected.yaml
@@ -75,6 +75,6 @@ spec:
           service:
             name: frontend
             port:
-              number: 80
+              number: 8080
         path: /
         pathType: Prefix

--- a/pkg/oam/builtin/components/statefulset.go
+++ b/pkg/oam/builtin/components/statefulset.go
@@ -185,6 +185,9 @@ func (c *StatefulsetConfig) ApplyPolicy(p oam.Policy) error {
 // ServicePort returns the port exposed by the component's headless Service, or 0 if no port is configured.
 func (c *StatefulsetConfig) ServicePort() int32 { return c.Port }
 
+// BackendServiceName returns the name of the Kubernetes Service the statefulset exposes.
+func (c *StatefulsetConfig) BackendServiceName() string { return c.ServiceName }
+
 // Generate creates Kubernetes StatefulSet, headless Service, ServiceAccount, and any standalone PVCs.
 func (c *StatefulsetConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{"app": app.Name}

--- a/pkg/oam/builtin/components/statefulset.go
+++ b/pkg/oam/builtin/components/statefulset.go
@@ -182,6 +182,9 @@ func (c *StatefulsetConfig) ApplyPolicy(p oam.Policy) error {
 	return nil
 }
 
+// ServicePort returns the port exposed by the component's headless Service, or 0 if no port is configured.
+func (c *StatefulsetConfig) ServicePort() int32 { return c.Port }
+
 // Generate creates Kubernetes StatefulSet, headless Service, ServiceAccount, and any standalone PVCs.
 func (c *StatefulsetConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{"app": app.Name}

--- a/pkg/oam/builtin/components/webservice.go
+++ b/pkg/oam/builtin/components/webservice.go
@@ -168,6 +168,9 @@ func (c *WebserviceConfig) ApplyPolicy(p oam.Policy) error {
 	return nil
 }
 
+// ServicePort returns the port exposed by the component's Service.
+func (c *WebserviceConfig) ServicePort() int32 { return c.Port }
+
 // Generate creates Kubernetes Deployment, Service, and ServiceAccount resources.
 func (c *WebserviceConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{"app": app.Name}

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -24,8 +24,6 @@ func (h *ExposeHandler) CanHandle(traitType string) bool {
 func (h *ExposeHandler) CapabilityRequired() bool { return true }
 
 // ValidateAndApplyDefaults validates the capability rendering for the expose trait.
-// It accepts only controllerType "ingress" in this release; "gateway" is deferred
-// until the httproute handler lands.
 func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
 	r, err := builtin.DecodeStrict[builtin.ExposeRendering](rendering)
 	if err != nil {
@@ -34,19 +32,31 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 	if r.ControllerType == "" {
 		return nil, errors.New("expose rendering: controllerType is required")
 	}
-	if r.ControllerType != "ingress" {
-		return nil, errors.Errorf("expose rendering: controllerType %q is not yet implemented; only \"ingress\" is supported", r.ControllerType)
-	}
-	if r.IngressClassName == "" {
-		return nil, errors.New("expose rendering: ingressClassName is required when controllerType is \"ingress\"")
-	}
-	if r.GatewayName != "" || r.GatewayNamespace != "" {
-		return nil, errors.New("expose rendering: gatewayName and gatewayNamespace are only valid when controllerType is \"gateway\"")
+	switch r.ControllerType {
+	case "ingress":
+		if r.IngressClassName == "" {
+			return nil, errors.New("expose rendering: ingressClassName is required when controllerType is \"ingress\"")
+		}
+		if r.GatewayName != "" || r.GatewayNamespace != "" {
+			return nil, errors.New("expose rendering: gatewayName and gatewayNamespace are only valid when controllerType is \"gateway\"")
+		}
+	case "gateway":
+		if r.GatewayName == "" {
+			return nil, errors.New("expose rendering: gatewayName is required when controllerType is \"gateway\"")
+		}
+		if r.IngressClassName != "" {
+			return nil, errors.New("expose rendering: ingressClassName is only valid when controllerType is \"ingress\"")
+		}
+		if r.GatewayNamespace == "" {
+			rendering["gatewayNamespace"] = "gateway-system"
+		}
+	default:
+		return nil, errors.Errorf("expose rendering: controllerType %q is not supported (want \"ingress\" or \"gateway\")", r.ControllerType)
 	}
 	return rendering, nil
 }
 
-// Apply dispatches to IngressHandler based on controllerType in the trait properties.
+// Apply dispatches to IngressHandler or HTTPRouteHandler based on controllerType.
 func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
 	controllerType, _ := trait.Properties["controllerType"].(string)
 	props := maps.Clone(trait.Properties)
@@ -55,6 +65,21 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 	switch controllerType {
 	case "ingress":
 		return (&IngressHandler{}).Apply(modified, app, bundle)
+	case "gateway":
+		gatewayName, _ := props["gatewayName"].(string)
+		gatewayNamespace, _ := props["gatewayNamespace"].(string)
+		if gatewayNamespace == "" {
+			gatewayNamespace = "gateway-system"
+		}
+		delete(props, "gatewayName")
+		delete(props, "gatewayNamespace")
+		ref := map[string]any{"name": gatewayName}
+		if gatewayNamespace != "" {
+			ref["namespace"] = gatewayNamespace
+		}
+		props["parentRefs"] = []any{ref}
+		modified = &oam.Trait{Type: "expose", Properties: props}
+		return (&HTTPRouteHandler{}).Apply(modified, app, bundle)
 	default:
 		return errors.Errorf("expose trait: unsupported controllerType %q", controllerType)
 	}

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -162,14 +162,20 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				if !ok {
 					return nil, errors.Errorf("rules[%d].backendRefs[%d]: expected object", i, j)
 				}
+				// nameExplicit is true only when the backendRef names a DIFFERENT service
+				// than the component's own. A self-reference is treated as implicit so
+				// the same port-mismatch guard applies.
+				selfServiceName := resolveServiceName(app)
 				nameExplicit := false
 				br := BackendRef{
-					Name: resolveServiceName(app),
+					Name: selfServiceName,
 					Port: defaultPort,
 				}
 				if name, ok := backendMap["name"].(string); ok {
 					br.Name = name
-					nameExplicit = true
+					if name != selfServiceName {
+						nameExplicit = true
+					}
 				}
 				portExplicit := false
 				if port, ok := backendMap["port"].(float64); ok {
@@ -185,6 +191,11 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				if !nameExplicit {
 					if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].backendRefs[%d]", i, j)); err != nil {
 						return nil, err
+					}
+					if portExplicit && br.Port != defaultPort {
+						return nil, errors.Errorf(
+							"rules[%d].backendRefs[%d]: cannot route implicit backend to port %d — component service exposes port %d; specify an explicit backend name or match the component port",
+							i, j, br.Port, defaultPort)
 					}
 				}
 				if br.Port == 0 {

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -1,0 +1,1225 @@
+package traits
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/go-kure/kure/pkg/kubernetes"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// HTTPRouteHandler handles OAM httproute traits.
+//
+// Deprecated: the httproute trait is deprecated; migrate to the expose trait.
+// This handler is retained for direct use and emits a deprecation warning on every invocation.
+type HTTPRouteHandler struct{}
+
+// CanHandle returns true for httproute trait type.
+func (h *HTTPRouteHandler) CanHandle(traitType string) bool {
+	return traitType == "httproute"
+}
+
+// Apply creates an HTTPRoute resource for the component's service.
+// If the optional 'name' property is set, that value is used as the sub-application
+// name, enabling multiple httproute traits on the same component without collision.
+//
+// Deprecated: the httproute trait is deprecated; migrate to the expose trait.
+// This handler is retained for backward compatibility and emits a deprecation
+// warning on every invocation.
+func (h *HTTPRouteHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+	slog.Warn("httproute trait is deprecated; migrate to the expose trait",
+		slog.String("component", app.Name),
+	)
+	config, err := h.parseProperties(trait.Properties, app)
+	if err != nil {
+		return err
+	}
+
+	subAppName := app.Name + "-httproute"
+	if config.Name != "" {
+		subAppName = config.Name
+	}
+	routeApp := stack.NewApplication(
+		subAppName,
+		app.Namespace,
+		config,
+	)
+	bundle.Applications = append(bundle.Applications, routeApp)
+	return nil
+}
+
+func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Application) (*HTTPRouteConfig, error) {
+	config := &HTTPRouteConfig{
+		ComponentName: app.Name,
+	}
+
+	// Optional: name (for multiple httproute traits on the same component)
+	if name, ok := props["name"].(string); ok && name != "" {
+		config.Name = name
+	}
+
+	// Required: parentRefs
+	rawParentRefs, ok := props["parentRefs"].([]any)
+	if !ok || len(rawParentRefs) == 0 {
+		return nil, errors.New("required property 'parentRefs' missing or empty")
+	}
+	for i, rawRef := range rawParentRefs {
+		refMap, ok := rawRef.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("parentRefs[%d]: expected object", i)
+		}
+		name, ok := refMap["name"].(string)
+		if !ok || name == "" {
+			return nil, errors.Errorf("parentRefs[%d]: required field 'name' missing or not a string", i)
+		}
+		ref := ParentRef{Name: name}
+		if ns, ok := refMap["namespace"].(string); ok {
+			ref.Namespace = ns
+		}
+		config.ParentRefs = append(config.ParentRefs, ref)
+	}
+
+	// Optional: hostnames
+	if rawHostnames, ok := props["hostnames"].([]any); ok {
+		for _, rawHost := range rawHostnames {
+			s, ok := rawHost.(string)
+			if !ok {
+				return nil, errors.New("hostnames entries must be strings")
+			}
+			config.Hostnames = append(config.Hostnames, s)
+		}
+	}
+
+	// Required: rules
+	rawRules, ok := props["rules"].([]any)
+	if !ok || len(rawRules) == 0 {
+		return nil, errors.New("required property 'rules' missing or empty")
+	}
+	for i, rawRule := range rawRules {
+		ruleMap, ok := rawRule.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("rules[%d]: expected object", i)
+		}
+
+		rule := HTTPRouteRule{}
+
+		// Optional: matches
+		if rawMatches, ok := ruleMap["matches"].([]any); ok {
+			for j, rawMatch := range rawMatches {
+				matchMap, ok := rawMatch.(map[string]any)
+				if !ok {
+					return nil, errors.Errorf("rules[%d].matches[%d]: expected object", i, j)
+				}
+
+				match := HTTPRouteMatch{}
+
+				// Optional: path
+				if rawPath, ok := matchMap["path"].(map[string]any); ok {
+					pm := &PathMatch{
+						Type:  "PathPrefix",
+						Value: "/",
+					}
+					if t, ok := rawPath["type"].(string); ok {
+						pm.Type = t
+					}
+					if v, ok := rawPath["value"].(string); ok {
+						pm.Value = v
+					}
+					match.Path = pm
+				}
+
+				// Optional: headers
+				if rawHeaders, ok := matchMap["headers"].([]any); ok {
+					for k, rawHeader := range rawHeaders {
+						headerMap, ok := rawHeader.(map[string]any)
+						if !ok {
+							return nil, errors.Errorf("rules[%d].matches[%d].headers[%d]: expected object", i, j, k)
+						}
+						hm := HeaderMatch{
+							Type: "Exact",
+						}
+						if t, ok := headerMap["type"].(string); ok {
+							hm.Type = t
+						}
+						name, ok := headerMap["name"].(string)
+						if !ok || name == "" {
+							return nil, errors.Errorf("rules[%d].matches[%d].headers[%d]: required field 'name' missing", i, j, k)
+						}
+						hm.Name = name
+						value, ok := headerMap["value"].(string)
+						if !ok {
+							return nil, errors.Errorf("rules[%d].matches[%d].headers[%d]: required field 'value' missing", i, j, k)
+						}
+						hm.Value = value
+						match.Headers = append(match.Headers, hm)
+					}
+				}
+
+				rule.Matches = append(rule.Matches, match)
+			}
+		}
+
+		// Optional: backendRefs
+		if rawBackends, ok := ruleMap["backendRefs"].([]any); ok {
+			for j, rawBackend := range rawBackends {
+				backendMap, ok := rawBackend.(map[string]any)
+				if !ok {
+					return nil, errors.Errorf("rules[%d].backendRefs[%d]: expected object", i, j)
+				}
+				br := BackendRef{
+					Name: app.Name,
+					Port: 80,
+				}
+				if name, ok := backendMap["name"].(string); ok {
+					br.Name = name
+				}
+				if port, ok := backendMap["port"].(float64); ok {
+					br.Port = int32(port) //nolint:gosec
+				} else if port, ok := backendMap["port"].(int); ok {
+					br.Port = int32(port) //nolint:gosec
+				}
+				rule.BackendRefs = append(rule.BackendRefs, br)
+			}
+		} else {
+			// Default: single backend pointing to the component's service
+			rule.BackendRefs = []BackendRef{{Name: app.Name, Port: 80}}
+		}
+
+		// Optional: filters
+		filters, err := parseRuleFilters(ruleMap, i)
+		if err != nil {
+			return nil, err
+		}
+		rule.Filters = filters
+
+		// Optional: timeouts
+		timeouts, err := parseRuleTimeouts(ruleMap, i)
+		if err != nil {
+			return nil, err
+		}
+		rule.Timeouts = timeouts
+
+		config.Rules = append(config.Rules, rule)
+	}
+
+	return config, nil
+}
+
+// parseRuleFilters parses `rules[i].filters[]`, returning nil when the
+// key is absent. Each filter is a discriminated union on `type`; the
+// matching nested object must be present and non-empty. ExtensionRef
+// is not implemented and returns a structured error.
+func parseRuleFilters(ruleMap map[string]any, ruleIdx int) ([]HTTPRouteFilter, error) {
+	raw, ok := ruleMap["filters"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	var out []HTTPRouteFilter
+	for j, rawFilter := range raw {
+		filterMap, ok := rawFilter.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("rules[%d].filters[%d]: expected object", ruleIdx, j)
+		}
+		filterType, _ := filterMap["type"].(string)
+		if filterType == "" {
+			return nil, errors.Errorf("rules[%d].filters[%d]: type is required", ruleIdx, j)
+		}
+		filter := HTTPRouteFilter{Type: filterType}
+		scope := errors.Errorf("rules[%d].filters[%d] %q", ruleIdx, j, filterType).Error()
+		switch filterType {
+		case "RequestRedirect":
+			cfg, err := parseRequestRedirect(filterMap, scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.RequestRedirect = cfg
+		case "RequestHeaderModifier":
+			cfg, err := parseHeaderModifier(filterMap, "requestHeaderModifier", scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.RequestHeaderModifier = cfg
+		case "ResponseHeaderModifier":
+			cfg, err := parseHeaderModifier(filterMap, "responseHeaderModifier", scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.ResponseHeaderModifier = cfg
+		case "URLRewrite":
+			cfg, err := parseURLRewrite(filterMap, scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.URLRewrite = cfg
+		case "RequestMirror":
+			cfg, err := parseRequestMirror(filterMap, scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.RequestMirror = cfg
+		case "CORS":
+			cfg, err := parseCORS(filterMap, scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.CORS = cfg
+		case "ExternalAuth":
+			cfg, err := parseExternalAuth(filterMap, scope)
+			if err != nil {
+				return nil, err
+			}
+			filter.ExternalAuth = cfg
+		case "ExtensionRef":
+			return nil, errors.Errorf("%s: filter type %q is not implemented", scope, filterType)
+		default:
+			return nil, errors.Errorf("%s: unknown filter type %q", scope, filterType)
+		}
+		out = append(out, filter)
+	}
+	return out, nil
+}
+
+// parseRequestRedirect parses the `requestRedirect` nested object.
+// Gateway API marks all fields optional, but a filter with zero
+// populated fields is a no-op — we reject it.
+func parseRequestRedirect(filterMap map[string]any, scope string) (*HTTPRequestRedirect, error) {
+	raw, ok := filterMap["requestRedirect"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: requestRedirect block is required", scope)
+	}
+	rr := &HTTPRequestRedirect{}
+	if scheme, ok := raw["scheme"].(string); ok && scheme != "" {
+		if scheme != "http" && scheme != "https" {
+			return nil, errors.Errorf("%s: scheme %q must be \"http\" or \"https\"", scope, scheme)
+		}
+		rr.Scheme = scheme
+	}
+	if hostname, ok := raw["hostname"].(string); ok {
+		rr.Hostname = hostname
+	}
+	if rawPort, ok := raw["port"]; ok {
+		port, err := coerceInt32(rawPort)
+		if err != nil {
+			return nil, errors.Errorf("%s: port: %w", scope, err)
+		}
+		if port < 1 || port > 65535 {
+			return nil, errors.Errorf("%s: port %d out of range [1,65535]", scope, port)
+		}
+		rr.Port = &port
+	}
+	if rawCode, ok := raw["statusCode"]; ok {
+		code, err := coerceInt(rawCode)
+		if err != nil {
+			return nil, errors.Errorf("%s: statusCode: %w", scope, err)
+		}
+		if !isAllowedRedirectStatus(code) {
+			return nil, errors.Errorf("%s: statusCode %d must be one of [301,302,303,307,308]", scope, code)
+		}
+		rr.StatusCode = &code
+	}
+	if rawPath, ok := raw["path"].(map[string]any); ok {
+		pm, err := parsePathModifier(rawPath, scope)
+		if err != nil {
+			return nil, err
+		}
+		rr.Path = pm
+	}
+	if rr.Scheme == "" && rr.Hostname == "" && rr.Port == nil && rr.StatusCode == nil && rr.Path == nil {
+		return nil, errors.Errorf("%s: at least one of scheme/hostname/port/statusCode/path must be set", scope)
+	}
+	return rr, nil
+}
+
+// parseURLRewrite parses the `urlRewrite` nested object. At least one
+// of hostname or path must be set.
+func parseURLRewrite(filterMap map[string]any, scope string) (*HTTPURLRewrite, error) {
+	raw, ok := filterMap["urlRewrite"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: urlRewrite block is required", scope)
+	}
+	rw := &HTTPURLRewrite{}
+	if hostname, ok := raw["hostname"].(string); ok {
+		rw.Hostname = hostname
+	}
+	if rawPath, ok := raw["path"].(map[string]any); ok {
+		pm, err := parsePathModifier(rawPath, scope)
+		if err != nil {
+			return nil, err
+		}
+		rw.Path = pm
+	}
+	if rw.Hostname == "" && rw.Path == nil {
+		return nil, errors.Errorf("%s: at least one of hostname or path must be set", scope)
+	}
+	return rw, nil
+}
+
+// parseRequestMirror parses the `requestMirror` nested object.
+// backendRef.name and backendRef.port are required. Only one of
+// percent or fraction may be set.
+func parseRequestMirror(filterMap map[string]any, scope string) (*HTTPRequestMirror, error) {
+	raw, ok := filterMap["requestMirror"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: requestMirror block is required", scope)
+	}
+	rawBR, ok := raw["backendRef"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: requestMirror.backendRef is required", scope)
+	}
+	name, _ := rawBR["name"].(string)
+	if name == "" {
+		return nil, errors.Errorf("%s: requestMirror.backendRef.name is required", scope)
+	}
+	portRaw, ok := rawBR["port"]
+	if !ok {
+		return nil, errors.Errorf("%s: requestMirror.backendRef.port is required", scope)
+	}
+	port, err := coerceInt32(portRaw)
+	if err != nil {
+		return nil, errors.Errorf("%s: requestMirror.backendRef.port: %w", scope, err)
+	}
+	if port < 1 || port > 65535 {
+		return nil, errors.Errorf("%s: requestMirror.backendRef.port %d out of range [1,65535]", scope, port)
+	}
+	m := &HTTPRequestMirror{BackendRef: MirrorBackendRef{Name: name, Port: port}}
+
+	hasPercent := false
+	hasFraction := false
+	if rawPct, ok := raw["percent"]; ok {
+		hasPercent = true
+		pct, err := coerceInt32(rawPct)
+		if err != nil {
+			return nil, errors.Errorf("%s: requestMirror.percent: %w", scope, err)
+		}
+		if pct < 0 || pct > 100 {
+			return nil, errors.Errorf("%s: requestMirror.percent %d must be in [0,100]", scope, pct)
+		}
+		m.Percent = &pct
+	}
+	if rawFrac, ok := raw["fraction"].(map[string]any); ok {
+		hasFraction = true
+		rawNum, ok := rawFrac["numerator"]
+		if !ok {
+			return nil, errors.Errorf("%s: requestMirror.fraction.numerator is required", scope)
+		}
+		num, err := coerceInt32(rawNum)
+		if err != nil {
+			return nil, errors.Errorf("%s: requestMirror.fraction.numerator: %w", scope, err)
+		}
+		if num < 0 {
+			return nil, errors.Errorf("%s: requestMirror.fraction.numerator must be >= 0", scope)
+		}
+		frac := &HTTPFraction{Numerator: num}
+		if rawDen, ok := rawFrac["denominator"]; ok {
+			den, err := coerceInt32(rawDen)
+			if err != nil {
+				return nil, errors.Errorf("%s: requestMirror.fraction.denominator: %w", scope, err)
+			}
+			if den < 1 {
+				return nil, errors.Errorf("%s: requestMirror.fraction.denominator must be >= 1", scope)
+			}
+			frac.Denominator = &den
+		}
+		m.Fraction = frac
+	}
+	if hasPercent && hasFraction {
+		return nil, errors.Errorf("%s: only one of percent or fraction may be specified", scope)
+	}
+	return m, nil
+}
+
+// parseCORS parses the `cors` nested object. All fields are optional per
+// Gateway API, but an empty cors block is rejected as a no-op.
+func parseCORS(filterMap map[string]any, scope string) (*HTTPCORS, error) {
+	raw, ok := filterMap["cors"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: cors block is required", scope)
+	}
+	c := &HTTPCORS{}
+	if rawOrigins, ok := raw["allowOrigins"].([]any); ok {
+		for i, v := range rawOrigins {
+			s, ok := v.(string)
+			if !ok || s == "" {
+				return nil, errors.Errorf("%s: cors.allowOrigins[%d]: expected non-empty string", scope, i)
+			}
+			c.AllowOrigins = append(c.AllowOrigins, s)
+		}
+	}
+	if rawCred, ok := raw["allowCredentials"].(bool); ok {
+		c.AllowCredentials = &rawCred
+	}
+	if rawMethods, ok := raw["allowMethods"].([]any); ok {
+		for i, v := range rawMethods {
+			s, ok := v.(string)
+			if !ok || s == "" {
+				return nil, errors.Errorf("%s: cors.allowMethods[%d]: expected non-empty string", scope, i)
+			}
+			c.AllowMethods = append(c.AllowMethods, s)
+		}
+	}
+	if rawHeaders, ok := raw["allowHeaders"].([]any); ok {
+		for i, v := range rawHeaders {
+			s, ok := v.(string)
+			if !ok || s == "" {
+				return nil, errors.Errorf("%s: cors.allowHeaders[%d]: expected non-empty string", scope, i)
+			}
+			c.AllowHeaders = append(c.AllowHeaders, s)
+		}
+	}
+	if rawExpose, ok := raw["exposeHeaders"].([]any); ok {
+		for i, v := range rawExpose {
+			s, ok := v.(string)
+			if !ok || s == "" {
+				return nil, errors.Errorf("%s: cors.exposeHeaders[%d]: expected non-empty string", scope, i)
+			}
+			c.ExposeHeaders = append(c.ExposeHeaders, s)
+		}
+	}
+	if rawAge, ok := raw["maxAge"]; ok {
+		age, err := coerceInt32(rawAge)
+		if err != nil {
+			return nil, errors.Errorf("%s: cors.maxAge: %w", scope, err)
+		}
+		if age < 1 {
+			return nil, errors.Errorf("%s: cors.maxAge must be >= 1", scope)
+		}
+		c.MaxAge = &age
+	}
+	if len(c.AllowOrigins) == 0 && c.AllowCredentials == nil && len(c.AllowMethods) == 0 &&
+		len(c.AllowHeaders) == 0 && len(c.ExposeHeaders) == 0 && c.MaxAge == nil {
+		return nil, errors.Errorf("%s: cors block must set at least one field", scope)
+	}
+	return c, nil
+}
+
+// parseExternalAuth parses the `externalAuth` nested object.
+// protocol ("HTTP" or "GRPC") and backendRef are required.
+func parseExternalAuth(filterMap map[string]any, scope string) (*HTTPExternalAuth, error) {
+	raw, ok := filterMap["externalAuth"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: externalAuth block is required", scope)
+	}
+	protocol, _ := raw["protocol"].(string)
+	if protocol != "HTTP" && protocol != "GRPC" {
+		return nil, errors.Errorf("%s: externalAuth.protocol must be \"HTTP\" or \"GRPC\", got %q", scope, protocol)
+	}
+	rawBR, ok := raw["backendRef"].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: externalAuth.backendRef is required", scope)
+	}
+	name, _ := rawBR["name"].(string)
+	if name == "" {
+		return nil, errors.Errorf("%s: externalAuth.backendRef.name is required", scope)
+	}
+	portRaw, ok := rawBR["port"]
+	if !ok {
+		return nil, errors.Errorf("%s: externalAuth.backendRef.port is required", scope)
+	}
+	port, err := coerceInt32(portRaw)
+	if err != nil {
+		return nil, errors.Errorf("%s: externalAuth.backendRef.port: %w", scope, err)
+	}
+	if port < 1 || port > 65535 {
+		return nil, errors.Errorf("%s: externalAuth.backendRef.port %d out of range [1,65535]", scope, port)
+	}
+	ea := &HTTPExternalAuth{
+		Protocol:   protocol,
+		BackendRef: MirrorBackendRef{Name: name, Port: port},
+	}
+	if rawGRPC, ok := raw["grpc"].(map[string]any); ok {
+		g := &HTTPGRPCAuth{}
+		if rawHdrs, ok := rawGRPC["allowedHeaders"].([]any); ok {
+			for i, v := range rawHdrs {
+				s, ok := v.(string)
+				if !ok || s == "" {
+					return nil, errors.Errorf("%s: externalAuth.grpc.allowedHeaders[%d]: expected non-empty string", scope, i)
+				}
+				g.AllowedHeaders = append(g.AllowedHeaders, s)
+			}
+		}
+		ea.GRPC = g
+	}
+	if rawHTTP, ok := raw["http"].(map[string]any); ok {
+		h := &HTTPHTTPAuth{}
+		if path, ok := rawHTTP["path"].(string); ok {
+			h.Path = path
+		}
+		if rawHdrs, ok := rawHTTP["allowedHeaders"].([]any); ok {
+			for i, v := range rawHdrs {
+				s, ok := v.(string)
+				if !ok || s == "" {
+					return nil, errors.Errorf("%s: externalAuth.http.allowedHeaders[%d]: expected non-empty string", scope, i)
+				}
+				h.AllowedHeaders = append(h.AllowedHeaders, s)
+			}
+		}
+		if rawResp, ok := rawHTTP["allowedResponseHeaders"].([]any); ok {
+			for i, v := range rawResp {
+				s, ok := v.(string)
+				if !ok || s == "" {
+					return nil, errors.Errorf("%s: externalAuth.http.allowedResponseHeaders[%d]: expected non-empty string", scope, i)
+				}
+				h.AllowedResponseHeaders = append(h.AllowedResponseHeaders, s)
+			}
+		}
+		ea.HTTP = h
+	}
+	if rawFwd, ok := raw["forwardBody"].(map[string]any); ok {
+		fb := &HTTPForwardBody{}
+		if rawSize, ok := rawFwd["maxSize"]; ok {
+			size, err := coerceInt32(rawSize)
+			if err != nil {
+				return nil, errors.Errorf("%s: externalAuth.forwardBody.maxSize: %w", scope, err)
+			}
+			if size < 0 {
+				return nil, errors.Errorf("%s: externalAuth.forwardBody.maxSize must be >= 0", scope)
+			}
+			fb.MaxSize = uint16(size) //nolint:gosec
+		}
+		ea.ForwardBody = fb
+	}
+	return ea, nil
+}
+
+// parsePathModifier parses the shared path-rewrite shape used by
+// RequestRedirect.path and URLRewrite.path.
+func parsePathModifier(raw map[string]any, scope string) (*HTTPPathModifier, error) {
+	typ, _ := raw["type"].(string)
+	if typ == "" {
+		return nil, errors.Errorf("%s: path.type is required", scope)
+	}
+	pm := &HTTPPathModifier{Type: typ}
+	switch typ {
+	case "ReplaceFullPath":
+		v, ok := raw["replaceFullPath"].(string)
+		if !ok || v == "" {
+			return nil, errors.Errorf("%s: path.replaceFullPath is required when type=ReplaceFullPath", scope)
+		}
+		pm.ReplaceFullPath = v
+	case "ReplacePrefixMatch":
+		v, ok := raw["replacePrefixMatch"].(string)
+		if !ok || v == "" {
+			return nil, errors.Errorf("%s: path.replacePrefixMatch is required when type=ReplacePrefixMatch", scope)
+		}
+		pm.ReplacePrefixMatch = v
+	default:
+		return nil, errors.Errorf("%s: path.type %q must be one of [ReplaceFullPath,ReplacePrefixMatch]", scope, typ)
+	}
+	return pm, nil
+}
+
+// parseHeaderModifier parses the shared shape used by both
+// RequestHeaderModifier and ResponseHeaderModifier filters.
+func parseHeaderModifier(filterMap map[string]any, key, scope string) (*HTTPHeaderModifier, error) {
+	raw, ok := filterMap[key].(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("%s: %s block is required", scope, key)
+	}
+	hm := &HTTPHeaderModifier{}
+	if rawSet, ok := raw["set"].([]any); ok {
+		kvs, err := parseHeaderKVList(rawSet, scope+".set")
+		if err != nil {
+			return nil, err
+		}
+		hm.Set = kvs
+	}
+	if rawAdd, ok := raw["add"].([]any); ok {
+		kvs, err := parseHeaderKVList(rawAdd, scope+".add")
+		if err != nil {
+			return nil, err
+		}
+		hm.Add = kvs
+	}
+	if rawRemove, ok := raw["remove"].([]any); ok {
+		for i, r := range rawRemove {
+			s, ok := r.(string)
+			if !ok {
+				return nil, errors.Errorf("%s.remove[%d]: expected string", scope, i)
+			}
+			if s == "" {
+				return nil, errors.Errorf("%s.remove[%d]: empty header name", scope, i)
+			}
+			hm.Remove = append(hm.Remove, s)
+		}
+	}
+	if len(hm.Set) == 0 && len(hm.Add) == 0 && len(hm.Remove) == 0 {
+		return nil, errors.Errorf("%s: at least one of set/add/remove must be populated", scope)
+	}
+	return hm, nil
+}
+
+// parseHeaderKVList parses a set[]/add[] list of {name, value} maps.
+func parseHeaderKVList(raw []any, scope string) ([]HTTPHeaderKV, error) {
+	var out []HTTPHeaderKV
+	for i, entry := range raw {
+		m, ok := entry.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("%s[%d]: expected object", scope, i)
+		}
+		name, _ := m["name"].(string)
+		if name == "" {
+			return nil, errors.Errorf("%s[%d]: name is required", scope, i)
+		}
+		value, _ := m["value"].(string)
+		out = append(out, HTTPHeaderKV{Name: name, Value: value})
+	}
+	return out, nil
+}
+
+// parseRuleTimeouts parses `rules[i].timeouts`, returning nil when the
+// block is absent.
+func parseRuleTimeouts(ruleMap map[string]any, ruleIdx int) (*HTTPRouteTimeouts, error) {
+	raw, ok := ruleMap["timeouts"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	t := &HTTPRouteTimeouts{}
+	if rawReq, ok := raw["request"].(string); ok && rawReq != "" {
+		dur, err := time.ParseDuration(rawReq)
+		if err != nil {
+			return nil, errors.Errorf("rules[%d].timeouts.request: invalid duration %q: %w", ruleIdx, rawReq, err)
+		}
+		if dur < 0 {
+			return nil, errors.Errorf("rules[%d].timeouts.request: duration %q must be non-negative", ruleIdx, rawReq)
+		}
+		t.Request = dur
+	}
+	if rawBR, ok := raw["backendRequest"].(string); ok && rawBR != "" {
+		dur, err := time.ParseDuration(rawBR)
+		if err != nil {
+			return nil, errors.Errorf("rules[%d].timeouts.backendRequest: invalid duration %q: %w", ruleIdx, rawBR, err)
+		}
+		if dur < 0 {
+			return nil, errors.Errorf("rules[%d].timeouts.backendRequest: duration %q must be non-negative", ruleIdx, rawBR)
+		}
+		t.BackendRequest = dur
+	}
+	if t.Request == 0 && t.BackendRequest == 0 {
+		return nil, errors.Errorf("rules[%d].timeouts: at least one of request or backendRequest must be set", ruleIdx)
+	}
+	if t.Request > 0 && t.BackendRequest > 0 && t.BackendRequest > t.Request {
+		return nil, errors.Errorf("rules[%d].timeouts: backendRequest (%s) must be <= request (%s)", ruleIdx, t.BackendRequest, t.Request)
+	}
+	return t, nil
+}
+
+// coerceInt32 handles both int and float64 JSON number types.
+func coerceInt32(v any) (int32, error) {
+	switch n := v.(type) {
+	case int:
+		return int32(n), nil //nolint:gosec
+	case int32:
+		return n, nil
+	case int64:
+		return int32(n), nil //nolint:gosec
+	case float64:
+		return int32(n), nil //nolint:gosec
+	default:
+		return 0, errors.Errorf("expected number, got %T", v)
+	}
+}
+
+// coerceInt is the untyped counterpart of coerceInt32.
+func coerceInt(v any) (int, error) {
+	switch n := v.(type) {
+	case int:
+		return n, nil
+	case int32:
+		return int(n), nil
+	case int64:
+		return int(n), nil
+	case float64:
+		return int(n), nil
+	default:
+		return 0, errors.Errorf("expected number, got %T", v)
+	}
+}
+
+// isAllowedRedirectStatus matches the Gateway API enum for
+// HTTPRequestRedirectFilter.statusCode.
+func isAllowedRedirectStatus(code int) bool {
+	switch code {
+	case 301, 302, 303, 307, 308:
+		return true
+	}
+	return false
+}
+
+// HTTPRouteConfig implements stack.ApplicationConfig for httproute traits.
+type HTTPRouteConfig struct {
+	Name          string // optional, overrides sub-app name for multi-httproute components
+	ComponentName string
+	ParentRefs    []ParentRef
+	Hostnames     []string
+	Rules         []HTTPRouteRule
+}
+
+// ParentRef represents a gateway parent reference.
+type ParentRef struct {
+	Name      string
+	Namespace string
+}
+
+// HTTPRouteRule represents a single routing rule.
+type HTTPRouteRule struct {
+	Matches     []HTTPRouteMatch
+	BackendRefs []BackendRef
+	// Filters preserves OAM declaration order; Gateway API output stays stable.
+	Filters []HTTPRouteFilter
+	// Timeouts is nil when the rule has no timeout block.
+	Timeouts *HTTPRouteTimeouts
+}
+
+// HTTPRouteFilter is the parsed form of one entry in `rules[].filters[]`.
+// It is a discriminated union on Type.
+type HTTPRouteFilter struct {
+	Type                   string
+	RequestRedirect        *HTTPRequestRedirect
+	RequestHeaderModifier  *HTTPHeaderModifier
+	ResponseHeaderModifier *HTTPHeaderModifier
+	URLRewrite             *HTTPURLRewrite
+	RequestMirror          *HTTPRequestMirror
+	CORS                   *HTTPCORS
+	ExternalAuth           *HTTPExternalAuth
+}
+
+// HTTPRequestRedirect is the parsed form of the RequestRedirect filter type.
+type HTTPRequestRedirect struct {
+	Scheme     string
+	Hostname   string
+	Port       *int32
+	StatusCode *int
+	Path       *HTTPPathModifier
+}
+
+// HTTPURLRewrite is the parsed form of the URLRewrite filter type.
+type HTTPURLRewrite struct {
+	Hostname string
+	Path     *HTTPPathModifier
+}
+
+// HTTPPathModifier is the shared shape used by RequestRedirect and URLRewrite.
+type HTTPPathModifier struct {
+	Type               string // "ReplaceFullPath" or "ReplacePrefixMatch"
+	ReplaceFullPath    string
+	ReplacePrefixMatch string
+}
+
+// HTTPHeaderModifier is the parsed form of RequestHeaderModifier/ResponseHeaderModifier.
+type HTTPHeaderModifier struct {
+	Set    []HTTPHeaderKV
+	Add    []HTTPHeaderKV
+	Remove []string
+}
+
+// HTTPHeaderKV is a single {name, value} entry in a header-modifier list.
+type HTTPHeaderKV struct {
+	Name  string
+	Value string
+}
+
+// HTTPRequestMirror is the parsed form of the RequestMirror filter type.
+type HTTPRequestMirror struct {
+	BackendRef MirrorBackendRef
+	Percent    *int32
+	Fraction   *HTTPFraction
+}
+
+// MirrorBackendRef is the backend reference for RequestMirror and ExternalAuth.
+type MirrorBackendRef struct {
+	Name string
+	Port int32
+}
+
+// HTTPFraction is the fractional mirror weight.
+type HTTPFraction struct {
+	Numerator   int32
+	Denominator *int32
+}
+
+// HTTPCORS is the parsed form of the CORS filter type.
+type HTTPCORS struct {
+	AllowOrigins     []string
+	AllowCredentials *bool
+	AllowMethods     []string
+	AllowHeaders     []string
+	ExposeHeaders    []string
+	MaxAge           *int32
+}
+
+// HTTPExternalAuth is the parsed form of the ExternalAuth filter type.
+type HTTPExternalAuth struct {
+	Protocol    string // "HTTP" or "GRPC"
+	BackendRef  MirrorBackendRef
+	GRPC        *HTTPGRPCAuth
+	HTTP        *HTTPHTTPAuth
+	ForwardBody *HTTPForwardBody
+}
+
+// HTTPGRPCAuth is the optional grpc sub-object for ExternalAuth.
+type HTTPGRPCAuth struct {
+	AllowedHeaders []string
+}
+
+// HTTPHTTPAuth is the optional http sub-object for ExternalAuth.
+type HTTPHTTPAuth struct {
+	Path                   string
+	AllowedHeaders         []string
+	AllowedResponseHeaders []string
+}
+
+// HTTPForwardBody is the optional forwardBody sub-object for ExternalAuth.
+type HTTPForwardBody struct {
+	MaxSize uint16
+}
+
+// HTTPRouteTimeouts is the parsed form of `rules[].timeouts`.
+type HTTPRouteTimeouts struct {
+	Request        time.Duration
+	BackendRequest time.Duration
+}
+
+// HTTPRouteMatch represents match conditions for a rule.
+type HTTPRouteMatch struct {
+	Path    *PathMatch
+	Headers []HeaderMatch
+}
+
+// PathMatch represents a path-based match condition.
+type PathMatch struct {
+	Type  string
+	Value string
+}
+
+// HeaderMatch represents a header-based match condition.
+type HeaderMatch struct {
+	Type  string
+	Name  string
+	Value string
+}
+
+// BackendRef represents a backend service reference.
+type BackendRef struct {
+	Name string
+	Port int32
+}
+
+// Generate creates a Gateway API HTTPRoute resource.
+func (c *HTTPRouteConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	route := kubernetes.CreateHTTPRoute(app.Name, app.Namespace)
+	route.Labels = map[string]string{"app": c.ComponentName}
+	route.Annotations = nil
+
+	for _, ref := range c.ParentRefs {
+		pr := gatewayv1.ParentReference{
+			Name: gatewayv1.ObjectName(ref.Name),
+		}
+		if ref.Namespace != "" {
+			ns := gatewayv1.Namespace(ref.Namespace)
+			pr.Namespace = &ns
+		}
+		_ = kubernetes.AddHTTPRouteParentRef(route, pr)
+	}
+
+	for _, h := range c.Hostnames {
+		_ = kubernetes.AddHTTPRouteHostname(route, gatewayv1.Hostname(h))
+	}
+
+	for _, rule := range c.Rules {
+		httpRule := gatewayv1.HTTPRouteRule{}
+
+		for _, match := range rule.Matches {
+			httpMatch := gatewayv1.HTTPRouteMatch{}
+
+			if match.Path != nil {
+				pathType := toGatewayPathType(match.Path.Type)
+				value := match.Path.Value
+				httpMatch.Path = &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &value,
+				}
+			}
+
+			for _, header := range match.Headers {
+				headerType := toGatewayHeaderType(header.Type)
+				httpMatch.Headers = append(httpMatch.Headers, gatewayv1.HTTPHeaderMatch{
+					Type:  &headerType,
+					Name:  gatewayv1.HTTPHeaderName(header.Name),
+					Value: header.Value,
+				})
+			}
+
+			kubernetes.AddHTTPRouteRuleMatch(&httpRule, httpMatch)
+		}
+
+		for _, br := range rule.BackendRefs {
+			port := br.Port
+			kubernetes.AddHTTPRouteRuleBackendRef(&httpRule, gatewayv1.HTTPBackendRef{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: gatewayv1.ObjectName(br.Name),
+						Port: &port,
+					},
+				},
+			})
+		}
+
+		for _, f := range rule.Filters {
+			gwFilter := buildGatewayFilter(f)
+			kubernetes.AddHTTPRouteRuleFilter(&httpRule, gwFilter)
+		}
+		if rule.Timeouts != nil {
+			httpRule.Timeouts = buildGatewayTimeouts(rule.Timeouts)
+		}
+
+		_ = kubernetes.AddHTTPRouteRule(route, httpRule)
+	}
+
+	obj := client.Object(route)
+	return []*client.Object{&obj}, nil
+}
+
+func buildGatewayFilter(f HTTPRouteFilter) gatewayv1.HTTPRouteFilter {
+	gwFilter := gatewayv1.HTTPRouteFilter{
+		Type: toGatewayFilterType(f.Type),
+	}
+	switch f.Type {
+	case "RequestRedirect":
+		if f.RequestRedirect != nil {
+			gwFilter.RequestRedirect = buildGatewayRequestRedirect(f.RequestRedirect)
+		}
+	case "RequestHeaderModifier":
+		if f.RequestHeaderModifier != nil {
+			gwFilter.RequestHeaderModifier = buildGatewayHeaderFilter(f.RequestHeaderModifier)
+		}
+	case "ResponseHeaderModifier":
+		if f.ResponseHeaderModifier != nil {
+			gwFilter.ResponseHeaderModifier = buildGatewayHeaderFilter(f.ResponseHeaderModifier)
+		}
+	case "URLRewrite":
+		if f.URLRewrite != nil {
+			gwFilter.URLRewrite = buildGatewayURLRewrite(f.URLRewrite)
+		}
+	case "RequestMirror":
+		if f.RequestMirror != nil {
+			gwFilter.RequestMirror = buildGatewayRequestMirror(f.RequestMirror)
+		}
+	case "CORS":
+		if f.CORS != nil {
+			gwFilter.CORS = buildGatewayCORS(f.CORS)
+		}
+	case "ExternalAuth":
+		if f.ExternalAuth != nil {
+			gwFilter.ExternalAuth = buildGatewayExternalAuth(f.ExternalAuth)
+		}
+	}
+	return gwFilter
+}
+
+func toGatewayFilterType(s string) gatewayv1.HTTPRouteFilterType {
+	switch s {
+	case "RequestRedirect":
+		return gatewayv1.HTTPRouteFilterRequestRedirect
+	case "RequestHeaderModifier":
+		return gatewayv1.HTTPRouteFilterRequestHeaderModifier
+	case "ResponseHeaderModifier":
+		return gatewayv1.HTTPRouteFilterResponseHeaderModifier
+	case "URLRewrite":
+		return gatewayv1.HTTPRouteFilterURLRewrite
+	case "RequestMirror":
+		return gatewayv1.HTTPRouteFilterRequestMirror
+	case "CORS":
+		return gatewayv1.HTTPRouteFilterCORS
+	case "ExternalAuth":
+		return gatewayv1.HTTPRouteFilterExternalAuth
+	}
+	return gatewayv1.HTTPRouteFilterType(s)
+}
+
+func buildGatewayRequestRedirect(rr *HTTPRequestRedirect) *gatewayv1.HTTPRequestRedirectFilter {
+	gwRR := &gatewayv1.HTTPRequestRedirectFilter{}
+	if rr.Scheme != "" {
+		scheme := rr.Scheme
+		gwRR.Scheme = &scheme
+	}
+	if rr.Hostname != "" {
+		hostname := gatewayv1.PreciseHostname(rr.Hostname)
+		gwRR.Hostname = &hostname
+	}
+	if rr.Port != nil {
+		port := *rr.Port
+		gwRR.Port = &port
+	}
+	if rr.StatusCode != nil {
+		code := *rr.StatusCode
+		gwRR.StatusCode = &code
+	}
+	if rr.Path != nil {
+		gwRR.Path = buildGatewayPathModifier(rr.Path)
+	}
+	return gwRR
+}
+
+func buildGatewayURLRewrite(rw *HTTPURLRewrite) *gatewayv1.HTTPURLRewriteFilter {
+	gwRW := &gatewayv1.HTTPURLRewriteFilter{}
+	if rw.Hostname != "" {
+		hostname := gatewayv1.PreciseHostname(rw.Hostname)
+		gwRW.Hostname = &hostname
+	}
+	if rw.Path != nil {
+		gwRW.Path = buildGatewayPathModifier(rw.Path)
+	}
+	return gwRW
+}
+
+func buildGatewayPathModifier(pm *HTTPPathModifier) *gatewayv1.HTTPPathModifier {
+	gwPM := &gatewayv1.HTTPPathModifier{}
+	switch pm.Type {
+	case "ReplaceFullPath":
+		gwPM.Type = gatewayv1.FullPathHTTPPathModifier
+		v := pm.ReplaceFullPath
+		gwPM.ReplaceFullPath = &v
+	case "ReplacePrefixMatch":
+		gwPM.Type = gatewayv1.PrefixMatchHTTPPathModifier
+		v := pm.ReplacePrefixMatch
+		gwPM.ReplacePrefixMatch = &v
+	}
+	return gwPM
+}
+
+func buildGatewayHeaderFilter(hm *HTTPHeaderModifier) *gatewayv1.HTTPHeaderFilter {
+	gwHF := &gatewayv1.HTTPHeaderFilter{}
+	for _, kv := range hm.Set {
+		gwHF.Set = append(gwHF.Set, gatewayv1.HTTPHeader{
+			Name:  gatewayv1.HTTPHeaderName(kv.Name),
+			Value: kv.Value,
+		})
+	}
+	for _, kv := range hm.Add {
+		gwHF.Add = append(gwHF.Add, gatewayv1.HTTPHeader{
+			Name:  gatewayv1.HTTPHeaderName(kv.Name),
+			Value: kv.Value,
+		})
+	}
+	if len(hm.Remove) > 0 {
+		gwHF.Remove = append([]string(nil), hm.Remove...)
+	}
+	return gwHF
+}
+
+func buildGatewayTimeouts(t *HTTPRouteTimeouts) *gatewayv1.HTTPRouteTimeouts {
+	gwT := &gatewayv1.HTTPRouteTimeouts{}
+	if t.Request > 0 {
+		gwDur := gatewayv1.Duration(t.Request.String())
+		gwT.Request = &gwDur
+	}
+	if t.BackendRequest > 0 {
+		gwDur := gatewayv1.Duration(t.BackendRequest.String())
+		gwT.BackendRequest = &gwDur
+	}
+	return gwT
+}
+
+func buildGatewayRequestMirror(m *HTTPRequestMirror) *gatewayv1.HTTPRequestMirrorFilter {
+	port := m.BackendRef.Port
+	gw := &gatewayv1.HTTPRequestMirrorFilter{
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name: gatewayv1.ObjectName(m.BackendRef.Name),
+			Port: &port,
+		},
+	}
+	if m.Percent != nil {
+		pct := *m.Percent
+		gw.Percent = &pct
+	}
+	if m.Fraction != nil {
+		f := &gatewayv1.Fraction{Numerator: m.Fraction.Numerator}
+		if m.Fraction.Denominator != nil {
+			den := *m.Fraction.Denominator
+			f.Denominator = &den
+		}
+		gw.Fraction = f
+	}
+	return gw
+}
+
+func buildGatewayCORS(c *HTTPCORS) *gatewayv1.HTTPCORSFilter {
+	gw := &gatewayv1.HTTPCORSFilter{}
+	for _, o := range c.AllowOrigins {
+		gw.AllowOrigins = append(gw.AllowOrigins, gatewayv1.CORSOrigin(o))
+	}
+	if c.AllowCredentials != nil {
+		v := *c.AllowCredentials
+		gw.AllowCredentials = &v
+	}
+	for _, m := range c.AllowMethods {
+		gw.AllowMethods = append(gw.AllowMethods, gatewayv1.HTTPMethodWithWildcard(m))
+	}
+	for _, h := range c.AllowHeaders {
+		gw.AllowHeaders = append(gw.AllowHeaders, gatewayv1.HTTPHeaderName(h))
+	}
+	for _, h := range c.ExposeHeaders {
+		gw.ExposeHeaders = append(gw.ExposeHeaders, gatewayv1.HTTPHeaderName(h))
+	}
+	if c.MaxAge != nil {
+		gw.MaxAge = *c.MaxAge
+	}
+	return gw
+}
+
+func buildGatewayExternalAuth(ea *HTTPExternalAuth) *gatewayv1.HTTPExternalAuthFilter {
+	port := ea.BackendRef.Port
+	gw := &gatewayv1.HTTPExternalAuthFilter{
+		ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthProtocol(ea.Protocol),
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name: gatewayv1.ObjectName(ea.BackendRef.Name),
+			Port: &port,
+		},
+	}
+	if ea.GRPC != nil {
+		gc := &gatewayv1.GRPCAuthConfig{}
+		if len(ea.GRPC.AllowedHeaders) > 0 {
+			gc.AllowedRequestHeaders = append([]string(nil), ea.GRPC.AllowedHeaders...)
+		}
+		gw.GRPCAuthConfig = gc
+	}
+	if ea.HTTP != nil {
+		hc := &gatewayv1.HTTPAuthConfig{Path: ea.HTTP.Path}
+		if len(ea.HTTP.AllowedHeaders) > 0 {
+			hc.AllowedRequestHeaders = append([]string(nil), ea.HTTP.AllowedHeaders...)
+		}
+		if len(ea.HTTP.AllowedResponseHeaders) > 0 {
+			hc.AllowedResponseHeaders = append([]string(nil), ea.HTTP.AllowedResponseHeaders...)
+		}
+		gw.HTTPAuthConfig = hc
+	}
+	if ea.ForwardBody != nil {
+		gw.ForwardBody = &gatewayv1.ForwardBodyConfig{MaxSize: ea.ForwardBody.MaxSize}
+	}
+	return gw
+}
+
+func toGatewayPathType(s string) gatewayv1.PathMatchType {
+	switch s {
+	case "Exact":
+		return gatewayv1.PathMatchExact
+	case "RegularExpression":
+		return gatewayv1.PathMatchRegularExpression
+	default:
+		return gatewayv1.PathMatchPathPrefix
+	}
+}
+
+func toGatewayHeaderType(s string) gatewayv1.HeaderMatchType {
+	switch s {
+	case "RegularExpression":
+		return gatewayv1.HeaderMatchRegularExpression
+	default:
+		return gatewayv1.HeaderMatchExact
+	}
+}

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -1,7 +1,6 @@
 package traits
 
 import (
-	"log/slog"
 	"time"
 
 	"github.com/go-kure/kure/pkg/kubernetes"
@@ -14,9 +13,6 @@ import (
 )
 
 // HTTPRouteHandler handles OAM httproute traits.
-//
-// Deprecated: the httproute trait is deprecated; migrate to the expose trait.
-// This handler is retained for direct use and emits a deprecation warning on every invocation.
 type HTTPRouteHandler struct{}
 
 // CanHandle returns true for httproute trait type.
@@ -27,14 +23,7 @@ func (h *HTTPRouteHandler) CanHandle(traitType string) bool {
 // Apply creates an HTTPRoute resource for the component's service.
 // If the optional 'name' property is set, that value is used as the sub-application
 // name, enabling multiple httproute traits on the same component without collision.
-//
-// Deprecated: the httproute trait is deprecated; migrate to the expose trait.
-// This handler is retained for backward compatibility and emits a deprecation
-// warning on every invocation.
 func (h *HTTPRouteHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
-	slog.Warn("httproute trait is deprecated; migrate to the expose trait",
-		slog.String("component", app.Name),
-	)
 	config, err := h.parseProperties(trait.Properties, app)
 	if err != nil {
 		return err
@@ -54,6 +43,7 @@ func (h *HTTPRouteHandler) Apply(trait *oam.Trait, app *stack.Application, bundl
 }
 
 func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Application) (*HTTPRouteConfig, error) {
+	defaultPort := resolveDefaultPort(app)
 	config := &HTTPRouteConfig{
 		ComponentName: app.Name,
 	}
@@ -173,7 +163,7 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				}
 				br := BackendRef{
 					Name: app.Name,
-					Port: 80,
+					Port: defaultPort,
 				}
 				if name, ok := backendMap["name"].(string); ok {
 					br.Name = name
@@ -187,7 +177,7 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 			}
 		} else {
 			// Default: single backend pointing to the component's service
-			rule.BackendRefs = []BackendRef{{Name: app.Name, Port: 80}}
+			rule.BackendRefs = []BackendRef{{Name: app.Name, Port: defaultPort}}
 		}
 
 		// Optional: filters

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -1,6 +1,7 @@
 package traits
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/go-kure/kure/pkg/kubernetes"
@@ -161,23 +162,49 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				if !ok {
 					return nil, errors.Errorf("rules[%d].backendRefs[%d]: expected object", i, j)
 				}
+				nameExplicit := false
 				br := BackendRef{
-					Name: app.Name,
+					Name: resolveServiceName(app),
 					Port: defaultPort,
 				}
 				if name, ok := backendMap["name"].(string); ok {
 					br.Name = name
+					nameExplicit = true
 				}
+				portExplicit := false
 				if port, ok := backendMap["port"].(float64); ok {
 					br.Port = int32(port) //nolint:gosec
+					portExplicit = true
 				} else if port, ok := backendMap["port"].(int); ok {
 					br.Port = int32(port) //nolint:gosec
+					portExplicit = true
+				}
+				if nameExplicit && !portExplicit {
+					br.Port = 0
+				}
+				if !nameExplicit {
+					if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].backendRefs[%d]", i, j)); err != nil {
+						return nil, err
+					}
+				}
+				if br.Port == 0 {
+					return nil, errors.Errorf(
+						"rules[%d].backendRefs[%d]: cannot determine backend port — specify 'port' in the backendRef",
+						i, j)
 				}
 				rule.BackendRefs = append(rule.BackendRefs, br)
 			}
 		} else {
 			// Default: single backend pointing to the component's service
-			rule.BackendRefs = []BackendRef{{Name: app.Name, Port: defaultPort}}
+			if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d]", i)); err != nil {
+				return nil, err
+			}
+			if defaultPort == 0 {
+				return nil, errors.Errorf(
+					"rules[%d]: cannot determine backend port for component %q — configure the component port or specify backendRefs[].port",
+					i, app.Name)
+			}
+			rule.BackendRefs = []BackendRef{{Name: resolveServiceName(app), Port: defaultPort}}
 		}
 
 		// Optional: filters

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -984,13 +984,80 @@ func TestHTTPRouteHandler_NoServicePort_Errors(t *testing.T) {
 	})
 
 	t.Run("no backendRefs, service port 0", func(t *testing.T) {
+		// ServicePort() == 0 means no Service is generated — checkImplicitBackend fires
 		app := stack.NewApplication("wrk", "default", &mockServicePortConfig{port: 0})
 		_, err := h.parseProperties(map[string]any{
 			"parentRefs": []any{map[string]any{"name": "gw"}},
 			"rules":      []any{map[string]any{}},
 		}, app)
-		if err == nil || !strings.Contains(err.Error(), "cannot determine backend port") {
-			t.Errorf("expected 'cannot determine backend port', got: %v", err)
+		if err == nil || !strings.Contains(err.Error(), "no service port") {
+			t.Errorf("expected 'no service port', got: %v", err)
+		}
+	})
+}
+
+func TestHTTPRouteHandler_ImplicitBackend_PortMismatch_Error(t *testing.T) {
+	h := &HTTPRouteHandler{}
+
+	t.Run("no name, port differs from component service", func(t *testing.T) {
+		// webservice exposes port 80; trait routes implicit backend to 8080 — must error
+		app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"port": 8080}},
+			}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "cannot route implicit backend") {
+			t.Errorf("expected 'cannot route implicit backend', got: %v", err)
+		}
+	})
+
+	t.Run("self-service name, port differs from component service", func(t *testing.T) {
+		// Explicitly naming the component's own service still subject to port mismatch guard
+		app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"name": "web", "port": 8080}},
+			}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "cannot route implicit backend") {
+			t.Errorf("expected 'cannot route implicit backend', got: %v", err)
+		}
+	})
+
+	t.Run("no name, port matches component service — success", func(t *testing.T) {
+		// Explicit port that matches component port is a no-op redundancy; must succeed
+		app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
+		cfg, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"port": 80}},
+			}},
+		}, app)
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+		if cfg.Rules[0].BackendRefs[0].Port != 80 {
+			t.Errorf("Port = %d, want 80", cfg.Rules[0].BackendRefs[0].Port)
+		}
+	})
+
+	t.Run("self-service name, port matches component service — success", func(t *testing.T) {
+		// Self-reference with correct port is allowed (redundant but valid)
+		app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
+		cfg, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"name": "web", "port": 80}},
+			}},
+		}, app)
+		if err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+		if cfg.Rules[0].BackendRefs[0].Port != 80 {
+			t.Errorf("Port = %d, want 80", cfg.Rules[0].BackendRefs[0].Port)
 		}
 	})
 }

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -77,7 +77,7 @@ func TestHTTPRouteHandler_ParentRefs_MissingName(t *testing.T) {
 
 func TestHTTPRouteHandler_Apply_SubAppNaming(t *testing.T) {
 	h := &HTTPRouteHandler{}
-	app := stack.NewApplication("web", "default", nil)
+	app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
 	bundle := &stack.Bundle{}
 
 	trait := &oam.Trait{
@@ -178,7 +178,7 @@ func baseRule(filters []any) map[string]any {
 // TestHTTPRouteHandler_ParseFilters covers the discriminated-union filter parser.
 func TestHTTPRouteHandler_ParseFilters(t *testing.T) {
 	h := &HTTPRouteHandler{}
-	app := stack.NewApplication("web", "default", nil)
+	app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
 
 	cases := []struct {
 		name         string
@@ -637,7 +637,7 @@ func TestHTTPRouteHandler_ParseFilters(t *testing.T) {
 // TestHTTPRouteHandler_ParseTimeouts covers the timeout parser.
 func TestHTTPRouteHandler_ParseTimeouts(t *testing.T) {
 	h := &HTTPRouteHandler{}
-	app := stack.NewApplication("web", "default", nil)
+	app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
 
 	baseTimeoutRule := func(timeouts map[string]any) map[string]any {
 		return map[string]any{
@@ -718,7 +718,7 @@ func TestHTTPRouteHandler_ParseTimeouts(t *testing.T) {
 // exercised end-to-end through Generate(). One Apply() call per filter type suffices.
 func TestHTTPRouteConfig_Generate_Filters(t *testing.T) {
 	h := &HTTPRouteHandler{}
-	app := stack.NewApplication("web", "default", nil)
+	app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 80})
 
 	applyAndGenerate := func(t *testing.T, props map[string]any) {
 		t.Helper()
@@ -875,5 +875,122 @@ func TestHTTPRouteConfig_Generate_Filters(t *testing.T) {
 				}},
 			}},
 		})
+	})
+}
+
+// mockNamedServiceConfig implements servicePortProvider and serviceBackendNamer.
+type mockNamedServiceConfig struct {
+	port        int32
+	serviceName string
+}
+
+func (m *mockNamedServiceConfig) ServicePort() int32         { return m.port }
+func (m *mockNamedServiceConfig) BackendServiceName() string { return m.serviceName }
+func (m *mockNamedServiceConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+func TestHTTPRouteHandler_CustomServiceName(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("my-statefulset", "default", &mockNamedServiceConfig{
+		port: 5432, serviceName: "postgres-primary",
+	})
+	cfg, err := h.parseProperties(map[string]any{
+		"parentRefs": []any{map[string]any{"name": "gw"}},
+		"rules":      []any{map[string]any{}},
+	}, app)
+	if err != nil {
+		t.Fatalf("parseProperties: %v", err)
+	}
+	br := cfg.Rules[0].BackendRefs[0]
+	if br.Name != "postgres-primary" {
+		t.Errorf("BackendRef.Name = %q, want \"postgres-primary\"", br.Name)
+	}
+	if br.Port != 5432 {
+		t.Errorf("BackendRef.Port = %d, want 5432", br.Port)
+	}
+}
+
+func TestHTTPRouteHandler_ExplicitBackendRef_Success(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("wrk", "default", nil)
+	cfg, err := h.parseProperties(map[string]any{
+		"parentRefs": []any{map[string]any{"name": "gw"}},
+		"rules": []any{map[string]any{
+			"backendRefs": []any{map[string]any{"name": "other-svc", "port": 8080}},
+		}},
+	}, app)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	br := cfg.Rules[0].BackendRefs[0]
+	if br.Name != "other-svc" || br.Port != 8080 {
+		t.Errorf("backendRef = %+v, want {Name: other-svc, Port: 8080}", br)
+	}
+}
+
+func TestHTTPRouteHandler_NoServicePort_Errors(t *testing.T) {
+	h := &HTTPRouteHandler{}
+
+	t.Run("no backendRefs, no Service", func(t *testing.T) {
+		app := stack.NewApplication("wrk", "default", nil)
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "no service port") {
+			t.Errorf("expected 'no service port', got: %v", err)
+		}
+	})
+
+	t.Run("explicit backendRef name, no port (port not inherited)", func(t *testing.T) {
+		app := stack.NewApplication("web", "default", &mockServicePortConfig{port: 8080})
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"name": "other-svc"}},
+			}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "cannot determine backend port") {
+			t.Errorf("expected 'cannot determine backend port', got: %v", err)
+		}
+	})
+
+	t.Run("backendRefs present, implicit name, no port, no Service", func(t *testing.T) {
+		app := stack.NewApplication("wrk", "default", nil)
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{}},
+			}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "no service port") {
+			t.Errorf("expected 'no service port', got: %v", err)
+		}
+	})
+
+	t.Run("backendRefs present, implicit name, explicit port, no Service", func(t *testing.T) {
+		// port: 8080 is explicit but name is implicit — component still has no Service
+		app := stack.NewApplication("wrk", "default", nil)
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"backendRefs": []any{map[string]any{"port": 8080}},
+			}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "no service port") {
+			t.Errorf("expected 'no service port', got: %v", err)
+		}
+	})
+
+	t.Run("no backendRefs, service port 0", func(t *testing.T) {
+		app := stack.NewApplication("wrk", "default", &mockServicePortConfig{port: 0})
+		_, err := h.parseProperties(map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{}},
+		}, app)
+		if err == nil || !strings.Contains(err.Error(), "cannot determine backend port") {
+			t.Errorf("expected 'cannot determine backend port', got: %v", err)
+		}
 	})
 }

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -1,0 +1,907 @@
+package traits
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// captureHandler captures slog records for assertion in tests.
+type captureHandler struct {
+	records *[]slog.Record
+}
+
+func (c *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (c *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	*c.records = append(*c.records, r)
+	return nil
+}
+func (c *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return c }
+func (c *captureHandler) WithGroup(_ string) slog.Handler      { return c }
+
+func TestHTTPRouteHandler_CanHandle(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	tests := []struct {
+		traitType string
+		want      bool
+	}{
+		{"httproute", true},
+		{"ingress", false},
+		{"expose", false},
+		{"configmap", false},
+		{"unknown", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.traitType, func(t *testing.T) {
+			got := h.CanHandle(tc.traitType)
+			if got != tc.want {
+				t.Errorf("CanHandle(%q) = %v, want %v", tc.traitType, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHTTPRouteHandler_Apply_EmitsDeprecationWarning(t *testing.T) {
+	var records []slog.Record
+	capturingHandler := &captureHandler{records: &records}
+	old := slog.Default()
+	slog.SetDefault(slog.New(capturingHandler))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("mycomp", "default", nil)
+	trait := &oam.Trait{
+		Type: "httproute",
+		Properties: map[string]any{
+			"parentRefs": []any{
+				map[string]any{"name": "my-gateway"},
+			},
+			"rules": []any{
+				map[string]any{},
+			},
+		},
+	}
+	bundle := &stack.Bundle{}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("expected slog.Warn to be called, but no records captured")
+	}
+	r := records[0]
+	if r.Level != slog.LevelWarn {
+		t.Errorf("expected Warn level, got %v", r.Level)
+	}
+	if !strings.Contains(r.Message, "httproute trait is deprecated") {
+		t.Errorf("unexpected deprecation message: %q", r.Message)
+	}
+}
+
+func TestHTTPRouteHandler_MissingParentRefs(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+	_, err := h.parseProperties(map[string]any{
+		"rules": []any{map[string]any{}},
+	}, app)
+	if err == nil {
+		t.Fatal("expected error for missing parentRefs")
+	}
+	if !strings.Contains(err.Error(), "parentRefs") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestHTTPRouteHandler_MissingRules(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+	_, err := h.parseProperties(map[string]any{
+		"parentRefs": []any{map[string]any{"name": "gw"}},
+	}, app)
+	if err == nil {
+		t.Fatal("expected error for missing rules")
+	}
+	if !strings.Contains(err.Error(), "rules") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestHTTPRouteHandler_ParentRefs_MissingName(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+	_, err := h.parseProperties(map[string]any{
+		"parentRefs": []any{map[string]any{"namespace": "gw-system"}},
+		"rules":      []any{map[string]any{}},
+	}, app)
+	if err == nil {
+		t.Fatal("expected error for missing parentRef name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error = %q", err.Error())
+	}
+}
+
+func TestHTTPRouteHandler_Apply_SubAppNaming(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+	bundle := &stack.Bundle{}
+
+	trait := &oam.Trait{
+		Type: "httproute",
+		Properties: map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{}},
+		},
+	}
+	_ = slog.Default() // suppress deprecation log
+	old := slog.Default()
+	slog.SetDefault(slog.New(&captureHandler{records: new([]slog.Record)}))
+	t.Cleanup(func() { slog.SetDefault(old) })
+
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 sub-app, got %d", len(bundle.Applications))
+	}
+	if bundle.Applications[0].Name != "web-httproute" {
+		t.Errorf("sub-app name = %q, want \"web-httproute\"", bundle.Applications[0].Name)
+	}
+
+	// With custom name override
+	bundle2 := &stack.Bundle{}
+	trait2 := &oam.Trait{
+		Type: "httproute",
+		Properties: map[string]any{
+			"name":       "my-custom-route",
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules":      []any{map[string]any{}},
+		},
+	}
+	if err := h.Apply(trait2, app, bundle2); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if bundle2.Applications[0].Name != "my-custom-route" {
+		t.Errorf("sub-app name = %q, want \"my-custom-route\"", bundle2.Applications[0].Name)
+	}
+}
+
+func TestHTTPRouteConfig_Generate_Basic(t *testing.T) {
+	cfg := &HTTPRouteConfig{
+		ComponentName: "web",
+		ParentRefs:    []ParentRef{{Name: "my-gateway"}},
+		Rules: []HTTPRouteRule{
+			{BackendRefs: []BackendRef{{Name: "web", Port: 80}}},
+		},
+	}
+	app := stack.NewApplication("web-httproute", "default", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	route := *objs[0]
+	labels := route.GetLabels()
+	if labels["app"] != "web" {
+		t.Errorf("labels[app] = %q, want \"web\" (component name, not sub-app name)", labels["app"])
+	}
+}
+
+// baseRule is a helper that wraps filters in a valid parentRefs+rules structure.
+func baseRule(filters []any) map[string]any {
+	return map[string]any{
+		"parentRefs": []any{map[string]any{"name": "gw"}},
+		"rules": []any{
+			map[string]any{"filters": filters},
+		},
+	}
+}
+
+// TestHTTPRouteHandler_ParseFilters covers the discriminated-union filter parser.
+func TestHTTPRouteHandler_ParseFilters(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+
+	cases := []struct {
+		name         string
+		filters      []any
+		wantErr      string
+		validateRule func(t *testing.T, rule HTTPRouteRule)
+	}{
+		{
+			name: "RequestRedirect scheme+statusCode",
+			filters: []any{
+				map[string]any{
+					"type": "RequestRedirect",
+					"requestRedirect": map[string]any{
+						"scheme":     "https",
+						"statusCode": 308,
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				if len(rule.Filters) != 1 || rule.Filters[0].Type != "RequestRedirect" {
+					t.Fatalf("filters = %+v", rule.Filters)
+				}
+				rr := rule.Filters[0].RequestRedirect
+				if rr == nil || rr.Scheme != "https" || rr.StatusCode == nil || *rr.StatusCode != 308 {
+					t.Errorf("RequestRedirect = %+v", rr)
+				}
+			},
+		},
+		{
+			name: "RequestRedirect no fields → error",
+			filters: []any{
+				map[string]any{
+					"type":            "RequestRedirect",
+					"requestRedirect": map[string]any{},
+				},
+			},
+			wantErr: "at least one of scheme/hostname/port/statusCode/path",
+		},
+		{
+			name: "RequestRedirect invalid scheme",
+			filters: []any{
+				map[string]any{
+					"type": "RequestRedirect",
+					"requestRedirect": map[string]any{
+						"scheme": "ftp",
+					},
+				},
+			},
+			wantErr: `scheme "ftp" must be "http" or "https"`,
+		},
+		{
+			name: "RequestRedirect invalid statusCode",
+			filters: []any{
+				map[string]any{
+					"type": "RequestRedirect",
+					"requestRedirect": map[string]any{
+						"statusCode": 404,
+					},
+				},
+			},
+			wantErr: "statusCode 404 must be one of [301,302,303,307,308]",
+		},
+		{
+			name: "ResponseHeaderModifier set",
+			filters: []any{
+				map[string]any{
+					"type": "ResponseHeaderModifier",
+					"responseHeaderModifier": map[string]any{
+						"set": []any{
+							map[string]any{"name": "Strict-Transport-Security", "value": "max-age=31536000"},
+						},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				hm := rule.Filters[0].ResponseHeaderModifier
+				if hm == nil || len(hm.Set) != 1 {
+					t.Fatalf("ResponseHeaderModifier = %+v", hm)
+				}
+				if hm.Set[0].Name != "Strict-Transport-Security" || hm.Set[0].Value != "max-age=31536000" {
+					t.Errorf("Set[0] = %+v", hm.Set[0])
+				}
+			},
+		},
+		{
+			name: "ResponseHeaderModifier remove",
+			filters: []any{
+				map[string]any{
+					"type": "ResponseHeaderModifier",
+					"responseHeaderModifier": map[string]any{
+						"remove": []any{"X-Forwarded-For", "X-Forwarded-Host"},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				hm := rule.Filters[0].ResponseHeaderModifier
+				if hm == nil || len(hm.Remove) != 2 {
+					t.Fatalf("Remove = %+v", hm)
+				}
+			},
+		},
+		{
+			name: "ResponseHeaderModifier all empty → error",
+			filters: []any{
+				map[string]any{
+					"type":                   "ResponseHeaderModifier",
+					"responseHeaderModifier": map[string]any{},
+				},
+			},
+			wantErr: "at least one of set/add/remove",
+		},
+		{
+			name: "RequestHeaderModifier add",
+			filters: []any{
+				map[string]any{
+					"type": "RequestHeaderModifier",
+					"requestHeaderModifier": map[string]any{
+						"add": []any{
+							map[string]any{"name": "X-Request-Id", "value": "abc"},
+						},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				hm := rule.Filters[0].RequestHeaderModifier
+				if hm == nil || len(hm.Add) != 1 {
+					t.Fatalf("Add = %+v", hm)
+				}
+			},
+		},
+		{
+			name: "URLRewrite ReplacePrefixMatch",
+			filters: []any{
+				map[string]any{
+					"type": "URLRewrite",
+					"urlRewrite": map[string]any{
+						"path": map[string]any{
+							"type":               "ReplacePrefixMatch",
+							"replacePrefixMatch": "/v2",
+						},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				rw := rule.Filters[0].URLRewrite
+				if rw == nil || rw.Path == nil || rw.Path.ReplacePrefixMatch != "/v2" {
+					t.Errorf("URLRewrite = %+v", rw)
+				}
+			},
+		},
+		{
+			name: "URLRewrite ReplaceFullPath missing value",
+			filters: []any{
+				map[string]any{
+					"type": "URLRewrite",
+					"urlRewrite": map[string]any{
+						"path": map[string]any{"type": "ReplaceFullPath"},
+					},
+				},
+			},
+			wantErr: "replaceFullPath is required",
+		},
+		{
+			name: "URLRewrite no fields → error",
+			filters: []any{
+				map[string]any{
+					"type":       "URLRewrite",
+					"urlRewrite": map[string]any{},
+				},
+			},
+			wantErr: "at least one of hostname or path",
+		},
+		{
+			name: "RequestMirror basic",
+			filters: []any{
+				map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "mirror-svc", "port": 8080},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				m := rule.Filters[0].RequestMirror
+				if m == nil || m.BackendRef.Name != "mirror-svc" || m.BackendRef.Port != 8080 {
+					t.Errorf("RequestMirror = %+v", m)
+				}
+				if m.Percent != nil || m.Fraction != nil {
+					t.Errorf("expected no percent/fraction, got %+v", m)
+				}
+			},
+		},
+		{
+			name: "RequestMirror with percent",
+			filters: []any{
+				map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "mirror-svc", "port": 8080},
+						"percent":    50,
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				m := rule.Filters[0].RequestMirror
+				if m == nil || m.Percent == nil || *m.Percent != 50 {
+					t.Errorf("percent = %+v", m)
+				}
+			},
+		},
+		{
+			name: "RequestMirror with fraction",
+			filters: []any{
+				map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "mirror-svc", "port": 8080},
+						"fraction":   map[string]any{"numerator": 1, "denominator": 4},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				m := rule.Filters[0].RequestMirror
+				if m == nil || m.Fraction == nil || m.Fraction.Numerator != 1 {
+					t.Errorf("fraction = %+v", m)
+				}
+			},
+		},
+		{
+			name: "RequestMirror missing backendRef → error",
+			filters: []any{
+				map[string]any{
+					"type":          "RequestMirror",
+					"requestMirror": map[string]any{},
+				},
+			},
+			wantErr: "requestMirror.backendRef is required",
+		},
+		{
+			name: "RequestMirror percent and fraction both set → error",
+			filters: []any{
+				map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "svc", "port": 80},
+						"percent":    50,
+						"fraction":   map[string]any{"numerator": 1},
+					},
+				},
+			},
+			wantErr: "only one of percent or fraction",
+		},
+		{
+			name: "RequestMirror percent out of range → error",
+			filters: []any{
+				map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "svc", "port": 80},
+						"percent":    101,
+					},
+				},
+			},
+			wantErr: "percent 101 must be in [0,100]",
+		},
+		{
+			name: "CORS basic",
+			filters: []any{
+				map[string]any{
+					"type": "CORS",
+					"cors": map[string]any{
+						"allowOrigins": []any{"https://example.com"},
+						"allowMethods": []any{"GET", "POST"},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				c := rule.Filters[0].CORS
+				if c == nil || len(c.AllowOrigins) != 1 || c.AllowOrigins[0] != "https://example.com" {
+					t.Errorf("CORS = %+v", c)
+				}
+				if len(c.AllowMethods) != 2 {
+					t.Errorf("AllowMethods = %+v", c.AllowMethods)
+				}
+			},
+		},
+		{
+			name: "CORS with credentials and maxAge",
+			filters: []any{
+				map[string]any{
+					"type": "CORS",
+					"cors": map[string]any{
+						"allowCredentials": true,
+						"maxAge":           3600,
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				c := rule.Filters[0].CORS
+				if c == nil || c.AllowCredentials == nil || !*c.AllowCredentials {
+					t.Errorf("allowCredentials = %+v", c)
+				}
+				if c.MaxAge == nil || *c.MaxAge != 3600 {
+					t.Errorf("maxAge = %+v", c.MaxAge)
+				}
+			},
+		},
+		{
+			name: "CORS empty block → error",
+			filters: []any{
+				map[string]any{
+					"type": "CORS",
+					"cors": map[string]any{},
+				},
+			},
+			wantErr: "cors block must set at least one field",
+		},
+		{
+			name: "CORS missing block → error",
+			filters: []any{
+				map[string]any{"type": "CORS"},
+			},
+			wantErr: "cors block is required",
+		},
+		{
+			name: "ExternalAuth HTTP",
+			filters: []any{
+				map[string]any{
+					"type": "ExternalAuth",
+					"externalAuth": map[string]any{
+						"protocol":   "HTTP",
+						"backendRef": map[string]any{"name": "authz-svc", "port": 9090},
+						"http": map[string]any{
+							"path":           "/check",
+							"allowedHeaders": []any{"X-User-Id"},
+						},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				ea := rule.Filters[0].ExternalAuth
+				if ea == nil || ea.Protocol != "HTTP" || ea.BackendRef.Name != "authz-svc" {
+					t.Errorf("ExternalAuth = %+v", ea)
+				}
+				if ea.HTTP == nil || ea.HTTP.Path != "/check" {
+					t.Errorf("HTTP = %+v", ea.HTTP)
+				}
+			},
+		},
+		{
+			name: "ExternalAuth GRPC",
+			filters: []any{
+				map[string]any{
+					"type": "ExternalAuth",
+					"externalAuth": map[string]any{
+						"protocol":   "GRPC",
+						"backendRef": map[string]any{"name": "authz-svc", "port": 9090},
+						"grpc": map[string]any{
+							"allowedHeaders": []any{"X-Request-Id"},
+						},
+					},
+				},
+			},
+			validateRule: func(t *testing.T, rule HTTPRouteRule) {
+				t.Helper()
+				ea := rule.Filters[0].ExternalAuth
+				if ea == nil || ea.Protocol != "GRPC" {
+					t.Errorf("ExternalAuth = %+v", ea)
+				}
+				if ea.GRPC == nil || len(ea.GRPC.AllowedHeaders) != 1 {
+					t.Errorf("GRPC = %+v", ea.GRPC)
+				}
+			},
+		},
+		{
+			name: "ExternalAuth invalid protocol → error",
+			filters: []any{
+				map[string]any{
+					"type": "ExternalAuth",
+					"externalAuth": map[string]any{
+						"protocol":   "UNKNOWN",
+						"backendRef": map[string]any{"name": "svc", "port": 80},
+					},
+				},
+			},
+			wantErr: `protocol must be "HTTP" or "GRPC"`,
+		},
+		{
+			name: "ExternalAuth missing backendRef → error",
+			filters: []any{
+				map[string]any{
+					"type": "ExternalAuth",
+					"externalAuth": map[string]any{
+						"protocol": "HTTP",
+					},
+				},
+			},
+			wantErr: "externalAuth.backendRef is required",
+		},
+		{
+			name: "missing type",
+			filters: []any{
+				map[string]any{"requestRedirect": map[string]any{"scheme": "https"}},
+			},
+			wantErr: "type is required",
+		},
+		{
+			name: "ExtensionRef deferred",
+			filters: []any{
+				map[string]any{"type": "ExtensionRef"},
+			},
+			wantErr: `filter type "ExtensionRef" is not implemented`,
+		},
+		{
+			name: "unknown type",
+			filters: []any{
+				map[string]any{"type": "Bogus"},
+			},
+			wantErr: `unknown filter type "Bogus"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := h.parseProperties(baseRule(tc.filters), app)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Errorf("error = %q, want substring %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tc.validateRule != nil {
+				tc.validateRule(t, cfg.Rules[0])
+			}
+		})
+	}
+}
+
+// TestHTTPRouteHandler_ParseTimeouts covers the timeout parser.
+func TestHTTPRouteHandler_ParseTimeouts(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+
+	baseTimeoutRule := func(timeouts map[string]any) map[string]any {
+		return map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{
+				map[string]any{"timeouts": timeouts},
+			},
+		}
+	}
+
+	t.Run("30s request", func(t *testing.T) {
+		cfg, err := h.parseProperties(baseTimeoutRule(map[string]any{"request": "30s"}), app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		to := cfg.Rules[0].Timeouts
+		if to == nil || to.Request.String() != "30s" {
+			t.Errorf("Timeouts.Request = %v, want 30s", to)
+		}
+	})
+
+	t.Run("5m request", func(t *testing.T) {
+		cfg, err := h.parseProperties(baseTimeoutRule(map[string]any{"request": "5m"}), app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Rules[0].Timeouts.Request.String() != "5m0s" {
+			t.Errorf("Request = %v, want 5m0s", cfg.Rules[0].Timeouts.Request)
+		}
+	})
+
+	t.Run("invalid duration", func(t *testing.T) {
+		_, err := h.parseProperties(baseTimeoutRule(map[string]any{"request": "not a duration"}), app)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "invalid duration") {
+			t.Errorf("error = %q", err.Error())
+		}
+	})
+
+	t.Run("negative duration", func(t *testing.T) {
+		_, err := h.parseProperties(baseTimeoutRule(map[string]any{"request": "-1s"}), app)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "non-negative") {
+			t.Errorf("error = %q", err.Error())
+		}
+	})
+
+	t.Run("empty block", func(t *testing.T) {
+		_, err := h.parseProperties(baseTimeoutRule(map[string]any{}), app)
+		if err == nil {
+			t.Fatal("expected error for empty timeouts block")
+		}
+		if !strings.Contains(err.Error(), "at least one of") {
+			t.Errorf("error = %q", err.Error())
+		}
+	})
+
+	t.Run("backendRequest only", func(t *testing.T) {
+		cfg, err := h.parseProperties(baseTimeoutRule(map[string]any{"backendRequest": "10s"}), app)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		to := cfg.Rules[0].Timeouts
+		if to == nil || to.BackendRequest.String() != "10s" {
+			t.Errorf("BackendRequest = %v, want 10s", to)
+		}
+		if to.Request != 0 {
+			t.Errorf("Request should be zero, got %v", to.Request)
+		}
+	})
+}
+
+// TestHTTPRouteConfig_Generate_Filters verifies that buildGateway* functions are
+// exercised end-to-end through Generate(). One Apply() call per filter type suffices.
+func TestHTTPRouteConfig_Generate_Filters(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("web", "default", nil)
+
+	applyAndGenerate := func(t *testing.T, props map[string]any) {
+		t.Helper()
+		bundle := &stack.Bundle{}
+		trait := &oam.Trait{Type: "httproute", Properties: props}
+		if err := h.Apply(trait, app, bundle); err != nil {
+			t.Fatalf("Apply: %v", err)
+		}
+		objs, err := bundle.Applications[0].Config.(*HTTPRouteConfig).Generate(
+			stack.NewApplication("web-httproute", "default", nil),
+		)
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if len(objs) != 1 {
+			t.Fatalf("expected 1 object, got %d", len(objs))
+		}
+	}
+
+	t.Run("RequestRedirect", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "RequestRedirect",
+					"requestRedirect": map[string]any{
+						"scheme": "https", "statusCode": 308,
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("RequestHeaderModifier", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "RequestHeaderModifier",
+					"requestHeaderModifier": map[string]any{
+						"set": []any{map[string]any{"name": "X-Foo", "value": "bar"}},
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("ResponseHeaderModifier", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "ResponseHeaderModifier",
+					"responseHeaderModifier": map[string]any{
+						"remove": []any{"X-Powered-By"},
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("URLRewrite", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "URLRewrite",
+					"urlRewrite": map[string]any{
+						"hostname": "new.example.com",
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("URLRewrite with path", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "URLRewrite",
+					"urlRewrite": map[string]any{
+						"path": map[string]any{
+							"type":               "ReplacePrefixMatch",
+							"replacePrefixMatch": "/v2",
+						},
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("RequestMirror", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "RequestMirror",
+					"requestMirror": map[string]any{
+						"backendRef": map[string]any{"name": "mirror-svc", "port": 8080},
+						"percent":    50,
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("CORS", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "CORS",
+					"cors": map[string]any{
+						"allowOrigins": []any{"https://example.com"},
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("ExternalAuth HTTP", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"filters": []any{map[string]any{
+					"type": "ExternalAuth",
+					"externalAuth": map[string]any{
+						"protocol":   "HTTP",
+						"backendRef": map[string]any{"name": "authz-svc", "port": 9090},
+					},
+				}},
+			}},
+		})
+	})
+
+	t.Run("Timeouts", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw"}},
+			"rules": []any{map[string]any{
+				"timeouts": map[string]any{"request": "30s"},
+			}},
+		})
+	})
+
+	t.Run("Hostnames and header matches", func(t *testing.T) {
+		applyAndGenerate(t, map[string]any{
+			"parentRefs": []any{map[string]any{"name": "gw", "namespace": "gw-ns"}},
+			"hostnames":  []any{"api.example.com"},
+			"rules": []any{map[string]any{
+				"matches": []any{map[string]any{
+					"path":    map[string]any{"type": "PathPrefix", "value": "/"},
+					"headers": []any{map[string]any{"name": "x-version", "value": "v1"}},
+				}},
+			}},
+		})
+	})
+}

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -1,28 +1,14 @@
 package traits
 
 import (
-	"context"
-	"log/slog"
 	"strings"
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/oam"
 )
-
-// captureHandler captures slog records for assertion in tests.
-type captureHandler struct {
-	records *[]slog.Record
-}
-
-func (c *captureHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
-func (c *captureHandler) Handle(_ context.Context, r slog.Record) error {
-	*c.records = append(*c.records, r)
-	return nil
-}
-func (c *captureHandler) WithAttrs(_ []slog.Attr) slog.Handler { return c }
-func (c *captureHandler) WithGroup(_ string) slog.Handler      { return c }
 
 func TestHTTPRouteHandler_CanHandle(t *testing.T) {
 	h := &HTTPRouteHandler{}
@@ -43,42 +29,6 @@ func TestHTTPRouteHandler_CanHandle(t *testing.T) {
 				t.Errorf("CanHandle(%q) = %v, want %v", tc.traitType, got, tc.want)
 			}
 		})
-	}
-}
-
-func TestHTTPRouteHandler_Apply_EmitsDeprecationWarning(t *testing.T) {
-	var records []slog.Record
-	capturingHandler := &captureHandler{records: &records}
-	old := slog.Default()
-	slog.SetDefault(slog.New(capturingHandler))
-	t.Cleanup(func() { slog.SetDefault(old) })
-
-	h := &HTTPRouteHandler{}
-	app := stack.NewApplication("mycomp", "default", nil)
-	trait := &oam.Trait{
-		Type: "httproute",
-		Properties: map[string]any{
-			"parentRefs": []any{
-				map[string]any{"name": "my-gateway"},
-			},
-			"rules": []any{
-				map[string]any{},
-			},
-		},
-	}
-	bundle := &stack.Bundle{}
-	if err := h.Apply(trait, app, bundle); err != nil {
-		t.Fatalf("Apply: %v", err)
-	}
-	if len(records) == 0 {
-		t.Fatal("expected slog.Warn to be called, but no records captured")
-	}
-	r := records[0]
-	if r.Level != slog.LevelWarn {
-		t.Errorf("expected Warn level, got %v", r.Level)
-	}
-	if !strings.Contains(r.Message, "httproute trait is deprecated") {
-		t.Errorf("unexpected deprecation message: %q", r.Message)
 	}
 }
 
@@ -137,11 +87,6 @@ func TestHTTPRouteHandler_Apply_SubAppNaming(t *testing.T) {
 			"rules":      []any{map[string]any{}},
 		},
 	}
-	_ = slog.Default() // suppress deprecation log
-	old := slog.Default()
-	slog.SetDefault(slog.New(&captureHandler{records: new([]slog.Record)}))
-	t.Cleanup(func() { slog.SetDefault(old) })
-
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
@@ -190,6 +135,33 @@ func TestHTTPRouteConfig_Generate_Basic(t *testing.T) {
 	labels := route.GetLabels()
 	if labels["app"] != "web" {
 		t.Errorf("labels[app] = %q, want \"web\" (component name, not sub-app name)", labels["app"])
+	}
+}
+
+// mockServicePortConfig is a minimal ApplicationConfig that also implements servicePortProvider.
+type mockServicePortConfig struct{ port int32 }
+
+func (m *mockServicePortConfig) ServicePort() int32 { return m.port }
+func (m *mockServicePortConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+func TestHTTPRouteHandler_DefaultPortFromComponent(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("api", "default", &mockServicePortConfig{port: 8080})
+
+	cfg, err := h.parseProperties(map[string]any{
+		"parentRefs": []any{map[string]any{"name": "gw"}},
+		"rules":      []any{map[string]any{}},
+	}, app)
+	if err != nil {
+		t.Fatalf("parseProperties: %v", err)
+	}
+	if len(cfg.Rules) != 1 || len(cfg.Rules[0].BackendRefs) != 1 {
+		t.Fatalf("expected 1 rule with 1 backendRef, got %+v", cfg.Rules)
+	}
+	if cfg.Rules[0].BackendRefs[0].Port != 8080 {
+		t.Errorf("default backend port = %d, want 8080 (from component)", cfg.Rules[0].BackendRefs[0].Port)
 	}
 }
 

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -45,7 +45,8 @@ func resolveServiceName(app *stack.Application) string {
 // checkImplicitBackend validates that the component can serve as an implicit backend
 // (the trait path/backendRef does not name an explicit target service).
 func checkImplicitBackend(app *stack.Application, location string) error {
-	if _, ok := app.Config.(servicePortProvider); !ok {
+	pp, ok := app.Config.(servicePortProvider)
+	if !ok || pp.ServicePort() == 0 {
 		return errors.Errorf(
 			"%s: component %q has no service port; configure a service port or specify an explicit backend name",
 			location, app.Name)
@@ -89,7 +90,8 @@ func (h *IngressHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Application) (*IngressConfig, error) {
 	defaultPort := resolveDefaultPort(app)
 	config := &IngressConfig{
-		ServiceName: resolveServiceName(app),
+		ComponentName: app.Name,
+		ServiceName:   resolveServiceName(app),
 	}
 
 	if name, ok := props["name"].(string); ok && name != "" {
@@ -151,10 +153,15 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 				p.PathType = pathType
 			}
 
+			// backendExplicit is true only when the backend names a DIFFERENT service than
+			// the component's own. A self-reference (backend == component service name) is
+			// treated as implicit so that the same port-mismatch guard applies.
 			backendExplicit := false
 			if backend, ok := pathMap["backend"].(string); ok && backend != "" {
 				p.ServiceName = backend
-				backendExplicit = true
+				if backend != config.ServiceName {
+					backendExplicit = true
+				}
 			}
 
 			portExplicit := false
@@ -171,13 +178,21 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 				}
 			}
 
+			// Zero the inherited port only for truly external explicit backends.
 			if backendExplicit && !portExplicit {
 				p.Port = 0
 			}
 
-			if p.ServiceName == "" {
+			// Implicit backend: empty name OR explicit name that resolves to the component's
+			// own service — both are subject to the same port constraints.
+			if p.ServiceName == "" || p.ServiceName == config.ServiceName {
 				if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].paths[%d]", i, j)); err != nil {
 					return nil, err
+				}
+				if portExplicit && p.Port > 0 && p.Port != defaultPort {
+					return nil, errors.Errorf(
+						"rules[%d].paths[%d]: cannot route implicit backend to port %d — component service exposes port %d; specify an explicit backend name or match the component port",
+						i, j, p.Port, defaultPort)
 				}
 			}
 			if p.Port == 0 && p.PortName == "" {
@@ -220,6 +235,7 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 // IngressConfig implements stack.ApplicationConfig for ingress traits.
 type IngressConfig struct {
 	Name             string
+	ComponentName    string // label value — always the OAM component name, not the K8s Service name
 	Annotations      map[string]string
 	IngressClassName string
 	Rules            []IngressRule
@@ -251,7 +267,7 @@ type IngressTLS struct {
 // Generate creates a Kubernetes Ingress resource.
 func (c *IngressConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{
-		"app": c.ServiceName,
+		"app": c.ComponentName,
 	}
 
 	ingress := kubernetes.CreateIngress(app.Name, app.Namespace, c.IngressClassName)

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -2,7 +2,6 @@ package traits
 
 import (
 	"fmt"
-	"log/slog"
 
 	"github.com/go-kure/kure/pkg/kubernetes"
 	"github.com/go-kure/kure/pkg/stack"
@@ -13,6 +12,21 @@ import (
 	"github.com/go-kure/launcher/pkg/oam"
 )
 
+// servicePortProvider is implemented by component configs that expose a service port.
+// Trait handlers use it to resolve the default backend port from the component's service.
+type servicePortProvider interface {
+	ServicePort() int32
+}
+
+// resolveDefaultPort returns the component's service port when the config implements
+// servicePortProvider, otherwise returns 80.
+func resolveDefaultPort(app *stack.Application) int32 {
+	if pp, ok := app.Config.(servicePortProvider); ok && pp.ServicePort() > 0 {
+		return pp.ServicePort()
+	}
+	return 80
+}
+
 // validPathTypes is the set of path types accepted by the Kubernetes Ingress API.
 var validPathTypes = map[string]bool{
 	string(networkingv1.PathTypePrefix):                 true,
@@ -21,9 +35,6 @@ var validPathTypes = map[string]bool{
 }
 
 // IngressHandler handles OAM ingress traits.
-//
-// Deprecated: the ingress trait is deprecated; migrate to the expose trait.
-// This handler is retained for direct use and emits a deprecation warning on every invocation.
 type IngressHandler struct{}
 
 // CanHandle returns true for ingress trait type.
@@ -35,9 +46,6 @@ func (h *IngressHandler) CanHandle(traitType string) bool {
 // If the optional 'name' property is set, that value is used as the sub-application
 // name, enabling multiple ingress traits on the same component without collision.
 func (h *IngressHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
-	slog.Warn("ingress trait is deprecated; migrate to the expose trait or httproute",
-		slog.String("component", app.Name),
-	)
 	config, err := h.parseProperties(trait.Properties, app)
 	if err != nil {
 		return err
@@ -53,6 +61,7 @@ func (h *IngressHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 }
 
 func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Application) (*IngressConfig, error) {
+	defaultPort := resolveDefaultPort(app)
 	config := &IngressConfig{
 		ServiceName: app.Name,
 	}
@@ -102,7 +111,7 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 			p := IngressPath{
 				Path:     "/",
 				PathType: "Prefix",
-				Port:     80,
+				Port:     defaultPort,
 			}
 
 			if path, ok := pathMap["path"].(string); ok {

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -18,13 +18,39 @@ type servicePortProvider interface {
 	ServicePort() int32
 }
 
-// resolveDefaultPort returns the component's service port when the config implements
-// servicePortProvider, otherwise returns 80.
+// serviceBackendNamer is implemented by component configs whose Kubernetes Service
+// name differs from the application name (e.g. StatefulsetConfig.ServiceName).
+type serviceBackendNamer interface {
+	BackendServiceName() string
+}
+
+// resolveDefaultPort returns the component's service port, or 0 if the component
+// does not expose a service port.
 func resolveDefaultPort(app *stack.Application) int32 {
 	if pp, ok := app.Config.(servicePortProvider); ok && pp.ServicePort() > 0 {
 		return pp.ServicePort()
 	}
-	return 80
+	return 0
+}
+
+// resolveServiceName returns the name of the Kubernetes Service the component exposes.
+// Falls back to app.Name when the config does not implement serviceBackendNamer.
+func resolveServiceName(app *stack.Application) string {
+	if sn, ok := app.Config.(serviceBackendNamer); ok {
+		return sn.BackendServiceName()
+	}
+	return app.Name
+}
+
+// checkImplicitBackend validates that the component can serve as an implicit backend
+// (the trait path/backendRef does not name an explicit target service).
+func checkImplicitBackend(app *stack.Application, location string) error {
+	if _, ok := app.Config.(servicePortProvider); !ok {
+		return errors.Errorf(
+			"%s: component %q has no service port; configure a service port or specify an explicit backend name",
+			location, app.Name)
+	}
+	return nil
 }
 
 // validPathTypes is the set of path types accepted by the Kubernetes Ingress API.
@@ -63,7 +89,7 @@ func (h *IngressHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Application) (*IngressConfig, error) {
 	defaultPort := resolveDefaultPort(app)
 	config := &IngressConfig{
-		ServiceName: app.Name,
+		ServiceName: resolveServiceName(app),
 	}
 
 	if name, ok := props["name"].(string); ok && name != "" {
@@ -125,15 +151,39 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 				p.PathType = pathType
 			}
 
+			backendExplicit := false
+			if backend, ok := pathMap["backend"].(string); ok && backend != "" {
+				p.ServiceName = backend
+				backendExplicit = true
+			}
+
+			portExplicit := false
 			if port, ok := toIngressPort(pathMap["port"]); ok {
 				p.Port = port
+				portExplicit = true
 			}
 
 			if portName, ok := pathMap["portName"].(string); ok && portName != "" {
 				if _, hasPort := pathMap["port"]; !hasPort {
 					p.Port = 0
 					p.PortName = portName
+					portExplicit = true
 				}
+			}
+
+			if backendExplicit && !portExplicit {
+				p.Port = 0
+			}
+
+			if p.ServiceName == "" {
+				if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].paths[%d]", i, j)); err != nil {
+					return nil, err
+				}
+			}
+			if p.Port == 0 && p.PortName == "" {
+				return nil, errors.Errorf(
+					"rules[%d].paths[%d]: cannot determine backend port — configure the component port or specify 'port'/'portName' in the path",
+					i, j)
 			}
 
 			rule.Paths = append(rule.Paths, p)
@@ -185,10 +235,11 @@ type IngressRule struct {
 
 // IngressPath represents a single path within a rule.
 type IngressPath struct {
-	Path     string
-	PathType string
-	Port     int32
-	PortName string
+	Path        string
+	PathType    string
+	ServiceName string // empty means use IngressConfig.ServiceName (= component service)
+	Port        int32
+	PortName    string
 }
 
 // IngressTLS represents a TLS entry.
@@ -217,17 +268,19 @@ func (c *IngressConfig) Generate(app *stack.Application) ([]*client.Object, erro
 			var servicePort networkingv1.ServiceBackendPort
 			if p.Port > 0 {
 				servicePort = networkingv1.ServiceBackendPort{Number: p.Port}
-			} else if p.PortName != "" {
-				servicePort = networkingv1.ServiceBackendPort{Name: p.PortName}
 			} else {
-				servicePort = networkingv1.ServiceBackendPort{Number: 80}
+				servicePort = networkingv1.ServiceBackendPort{Name: p.PortName}
+			}
+			serviceName := p.ServiceName
+			if serviceName == "" {
+				serviceName = c.ServiceName
 			}
 			kubernetes.AddIngressRulePath(ingressRule, networkingv1.HTTPIngressPath{
 				Path:     p.Path,
 				PathType: &pathType,
 				Backend: networkingv1.IngressBackend{
 					Service: &networkingv1.IngressServiceBackend{
-						Name: c.ServiceName,
+						Name: serviceName,
 						Port: servicePort,
 					},
 				},

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -299,12 +299,12 @@ func TestIngressHandler_Apply_Generate(t *testing.T) {
 						map[string]any{
 							"path":     "/api",
 							"pathType": "Prefix",
-							"port":     8080,
+							"port":     80,
 						},
 						map[string]any{
 							"path":     "/exact",
 							"pathType": "Exact",
-							"port":     8080,
+							"port":     80,
 						},
 						map[string]any{
 							"path":     "/impl",
@@ -1954,4 +1954,100 @@ func TestIngressHandler_Apply_CustomServiceName(t *testing.T) {
 	if gotName != "postgres-primary" {
 		t.Errorf("backend.service.name = %q, want \"postgres-primary\"", gotName)
 	}
+	// Label must use the component name, not the K8s Service name
+	if got := ingress.Labels["app"]; got != "my-statefulset" {
+		t.Errorf("ingress label app = %q, want \"my-statefulset\"", got)
+	}
+}
+
+func TestIngressHandler_Apply_ImplicitBackend_PortMismatch_Error(t *testing.T) {
+	h := &traits.IngressHandler{}
+
+	t.Run("implicit backend, port differs from component service", func(t *testing.T) {
+		// webservice exposes port 80; trait routes implicit backend to 8080 — must error
+		trait := &oam.Trait{
+			Type: "ingress",
+			Properties: map[string]any{
+				"rules": []any{
+					map[string]any{
+						"host": "example.com",
+						"paths": []any{
+							map[string]any{"path": "/", "port": 8080},
+						},
+					},
+				},
+			},
+		}
+		app := newWebApp("web", "default") // port 80
+		err := h.Apply(trait, app, newBundle())
+		if err == nil || !strings.Contains(err.Error(), "cannot route implicit backend") {
+			t.Errorf("expected 'cannot route implicit backend', got: %v", err)
+		}
+	})
+
+	t.Run("self-service backend name, port differs from component service", func(t *testing.T) {
+		// Explicitly naming the component's own service still subject to port mismatch guard
+		trait := &oam.Trait{
+			Type: "ingress",
+			Properties: map[string]any{
+				"rules": []any{
+					map[string]any{
+						"host": "example.com",
+						"paths": []any{
+							map[string]any{"path": "/", "backend": "web", "port": 8080},
+						},
+					},
+				},
+			},
+		}
+		app := newWebApp("web", "default") // port 80, service name "web"
+		err := h.Apply(trait, app, newBundle())
+		if err == nil || !strings.Contains(err.Error(), "cannot route implicit backend") {
+			t.Errorf("expected 'cannot route implicit backend', got: %v", err)
+		}
+	})
+
+	t.Run("implicit backend, port matches component service — success", func(t *testing.T) {
+		// Redundant explicit port that matches is allowed
+		trait := &oam.Trait{
+			Type: "ingress",
+			Properties: map[string]any{
+				"rules": []any{
+					map[string]any{
+						"host": "example.com",
+						"paths": []any{
+							map[string]any{"path": "/", "port": 80},
+						},
+					},
+				},
+			},
+		}
+		app := newWebApp("web", "default") // port 80
+		bundle := newBundle()
+		if err := h.Apply(trait, app, bundle); err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+	})
+
+	t.Run("self-service backend name, port matches component service — success", func(t *testing.T) {
+		// Self-reference with correct port is allowed (redundant but valid)
+		trait := &oam.Trait{
+			Type: "ingress",
+			Properties: map[string]any{
+				"rules": []any{
+					map[string]any{
+						"host": "example.com",
+						"paths": []any{
+							map[string]any{"path": "/", "backend": "web", "port": 80},
+						},
+					},
+				},
+			},
+		}
+		app := newWebApp("web", "default") // port 80, service name "web"
+		bundle := newBundle()
+		if err := h.Apply(trait, app, bundle); err != nil {
+			t.Fatalf("expected success, got: %v", err)
+		}
+	})
 }

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/go-kure/launcher/pkg/oam"
 	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
@@ -50,18 +51,18 @@ func TestExposeHandler_ValidateAndApplyDefaults_MissingControllerType(t *testing
 	}
 }
 
-func TestExposeHandler_ValidateAndApplyDefaults_GatewayRejected(t *testing.T) {
+func TestExposeHandler_ValidateAndApplyDefaults_Gateway_Valid(t *testing.T) {
 	h := &traits.ExposeHandler{}
 	rendering := map[string]any{
 		"controllerType": "gateway",
 		"gatewayName":    "my-gateway",
 	}
-	_, err := h.ValidateAndApplyDefaults(rendering)
-	if err == nil {
-		t.Fatal("expected error for gateway controllerType")
+	got, err := h.ValidateAndApplyDefaults(rendering)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "not yet implemented") {
-		t.Errorf("expected 'not yet implemented' in error, got: %v", err)
+	if got["gatewayNamespace"] != "gateway-system" {
+		t.Errorf("expected gatewayNamespace defaulted to 'gateway-system', got: %v", got["gatewayNamespace"])
 	}
 }
 
@@ -142,7 +143,7 @@ func TestExposeHandler_Apply_UnsupportedControllerType(t *testing.T) {
 	trait := &oam.Trait{
 		Type: "expose",
 		Properties: map[string]any{
-			"controllerType": "gateway",
+			"controllerType": "foo",
 		},
 	}
 	app := newApp("my-app", "default")
@@ -1629,5 +1630,157 @@ func TestVolsyncConfig_Generate(t *testing.T) {
 	}
 	if len(objects) != 1 {
 		t.Fatalf("expected 1 object, got %d", len(objects))
+	}
+}
+
+// --- ExposeHandler gateway validation ---
+
+func TestExposeHandler_ValidateAndApplyDefaults_Gateway_MissingGatewayName(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	rendering := map[string]any{
+		"controllerType": "gateway",
+	}
+	_, err := h.ValidateAndApplyDefaults(rendering)
+	if err == nil {
+		t.Fatal("expected error for missing gatewayName")
+	}
+	if !strings.Contains(err.Error(), "gatewayName") {
+		t.Errorf("expected 'gatewayName' in error, got: %v", err)
+	}
+}
+
+func TestExposeHandler_ValidateAndApplyDefaults_Gateway_DefaultNamespace(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	rendering := map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "prod-gateway",
+	}
+	got, err := h.ValidateAndApplyDefaults(rendering)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["gatewayNamespace"] != "gateway-system" {
+		t.Errorf("expected gatewayNamespace='gateway-system', got: %v", got["gatewayNamespace"])
+	}
+}
+
+func TestExposeHandler_ValidateAndApplyDefaults_Gateway_ExplicitNamespace(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	rendering := map[string]any{
+		"controllerType":   "gateway",
+		"gatewayName":      "prod-gateway",
+		"gatewayNamespace": "infra",
+	}
+	got, err := h.ValidateAndApplyDefaults(rendering)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got["gatewayNamespace"] != "infra" {
+		t.Errorf("expected gatewayNamespace='infra', got: %v", got["gatewayNamespace"])
+	}
+}
+
+func TestExposeHandler_ValidateAndApplyDefaults_Gateway_RejectsIngressClassName(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	rendering := map[string]any{
+		"controllerType":   "gateway",
+		"gatewayName":      "prod-gateway",
+		"ingressClassName": "nginx",
+	}
+	_, err := h.ValidateAndApplyDefaults(rendering)
+	if err == nil {
+		t.Fatal("expected error for ingressClassName in gateway rendering")
+	}
+	if !strings.Contains(err.Error(), "ingressClassName") {
+		t.Errorf("expected 'ingressClassName' in error, got: %v", err)
+	}
+}
+
+func TestExposeHandler_ValidateAndApplyDefaults_UnsupportedControllerType(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	rendering := map[string]any{
+		"controllerType": "foo",
+	}
+	_, err := h.ValidateAndApplyDefaults(rendering)
+	if err == nil {
+		t.Fatal("expected error for unsupported controllerType")
+	}
+	if !strings.Contains(err.Error(), "foo") {
+		t.Errorf("expected 'foo' in error, got: %v", err)
+	}
+}
+
+// --- ExposeHandler.Apply gateway dispatch ---
+
+func TestExposeHandler_Apply_Gateway_DispatchesToHTTPRoute(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	trait := &oam.Trait{
+		Type: "expose",
+		Properties: map[string]any{
+			"controllerType": "gateway",
+			"gatewayName":    "my-gw",
+			"rules":          []any{map[string]any{}},
+		},
+	}
+	app := newApp("web", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 sub-application, got %d", len(bundle.Applications))
+	}
+	subApp := bundle.Applications[0]
+	objs, err := subApp.Config.Generate(subApp)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	route, ok := (*objs[0]).(*gatewayv1.HTTPRoute)
+	if !ok {
+		t.Fatalf("expected *gatewayv1.HTTPRoute, got %T", *objs[0])
+	}
+	if len(route.Spec.ParentRefs) != 1 {
+		t.Fatalf("expected 1 parentRef, got %d", len(route.Spec.ParentRefs))
+	}
+	pr := route.Spec.ParentRefs[0]
+	if string(pr.Name) != "my-gw" {
+		t.Errorf("parentRef.Name = %q, want \"my-gw\"", pr.Name)
+	}
+	if pr.Namespace == nil || string(*pr.Namespace) != "gateway-system" {
+		t.Errorf("parentRef.Namespace = %v, want \"gateway-system\"", pr.Namespace)
+	}
+}
+
+func TestExposeHandler_Apply_Gateway_ExplicitNamespace(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	trait := &oam.Trait{
+		Type: "expose",
+		Properties: map[string]any{
+			"controllerType":   "gateway",
+			"gatewayName":      "my-gw",
+			"gatewayNamespace": "infra",
+			"rules":            []any{map[string]any{}},
+		},
+	}
+	app := newApp("web", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	subApp := bundle.Applications[0]
+	objs, err := subApp.Config.Generate(subApp)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	route, ok := (*objs[0]).(*gatewayv1.HTTPRoute)
+	if !ok {
+		t.Fatalf("expected *gatewayv1.HTTPRoute, got %T", *objs[0])
+	}
+	pr := route.Spec.ParentRefs[0]
+	if pr.Namespace == nil || string(*pr.Namespace) != "infra" {
+		t.Errorf("parentRef.Namespace = %v, want \"infra\"", pr.Namespace)
 	}
 }

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kure/kure/pkg/stack"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -21,6 +22,30 @@ func newApp(name, namespace string) *stack.Application {
 
 func newBundle() *stack.Bundle {
 	return &stack.Bundle{}
+}
+
+// webConfig satisfies servicePortProvider via duck-typing at runtime.
+type webConfig struct{ port int32 }
+
+func (w *webConfig) ServicePort() int32 { return w.port }
+func (w *webConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+// namedWebConfig additionally satisfies serviceBackendNamer.
+type namedWebConfig struct {
+	port        int32
+	serviceName string
+}
+
+func (w *namedWebConfig) ServicePort() int32         { return w.port }
+func (w *namedWebConfig) BackendServiceName() string { return w.serviceName }
+func (w *namedWebConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+func newWebApp(name, namespace string) *stack.Application {
+	return stack.NewApplication(name, namespace, &webConfig{port: 80})
 }
 
 // --- ExposeHandler.ValidateAndApplyDefaults ---
@@ -128,7 +153,7 @@ func TestExposeHandler_Apply_DispatchesToIngress(t *testing.T) {
 			},
 		},
 	}
-	app := newApp("my-app", "default")
+	app := newWebApp("my-app", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -186,7 +211,7 @@ func TestIngressHandler_Apply_Basic(t *testing.T) {
 			},
 		},
 	}
-	app := newApp("my-app", "default")
+	app := newWebApp("my-app", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -220,7 +245,7 @@ func TestIngressHandler_Apply_TLS(t *testing.T) {
 			},
 		},
 	}
-	app := newApp("my-app", "default")
+	app := newWebApp("my-app", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -297,7 +322,7 @@ func TestIngressHandler_Apply_Generate(t *testing.T) {
 			},
 		},
 	}
-	app := newApp("my-app", "default")
+	app := newWebApp("my-app", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -330,7 +355,7 @@ func TestIngressHandler_Apply_NamedSubApp(t *testing.T) {
 			},
 		},
 	}
-	app := newApp("my-app", "default")
+	app := newWebApp("my-app", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -1722,7 +1747,7 @@ func TestExposeHandler_Apply_Gateway_DispatchesToHTTPRoute(t *testing.T) {
 			"rules":          []any{map[string]any{}},
 		},
 	}
-	app := newApp("web", "default")
+	app := newWebApp("web", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -1765,7 +1790,7 @@ func TestExposeHandler_Apply_Gateway_ExplicitNamespace(t *testing.T) {
 			"rules":            []any{map[string]any{}},
 		},
 	}
-	app := newApp("web", "default")
+	app := newWebApp("web", "default")
 	bundle := newBundle()
 	if err := h.Apply(trait, app, bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
@@ -1782,5 +1807,151 @@ func TestExposeHandler_Apply_Gateway_ExplicitNamespace(t *testing.T) {
 	pr := route.Spec.ParentRefs[0]
 	if pr.Namespace == nil || string(*pr.Namespace) != "infra" {
 		t.Errorf("parentRef.Namespace = %v, want \"infra\"", pr.Namespace)
+	}
+}
+
+func TestExposeHandler_Apply_Gateway_NoServicePort_Errors(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	trait := &oam.Trait{
+		Type: "expose",
+		Properties: map[string]any{
+			"controllerType": "gateway",
+			"gatewayName":    "my-gw",
+			"rules":          []any{map[string]any{}},
+		},
+	}
+	app := newApp("wrk", "default")
+	bundle := newBundle()
+	err := h.Apply(trait, app, bundle)
+	if err == nil {
+		t.Fatal("expected error for component with no service port")
+	}
+	if !strings.Contains(err.Error(), "no service port") {
+		t.Errorf("expected 'no service port' in error, got: %v", err)
+	}
+}
+
+func TestIngressHandler_Apply_NoServicePort_Errors(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"ingressClassName": "nginx",
+			"rules": []any{
+				map[string]any{
+					"host": "example.com",
+					"paths": []any{
+						map[string]any{"path": "/"},
+					},
+				},
+			},
+		},
+	}
+	app := newApp("wrk", "default")
+	bundle := newBundle()
+	err := h.Apply(trait, app, bundle)
+	if err == nil {
+		t.Fatal("expected error for component with no service port")
+	}
+	if !strings.Contains(err.Error(), "no service port") {
+		t.Errorf("expected 'no service port' in error, got: %v", err)
+	}
+}
+
+func TestIngressHandler_Apply_ExplicitBackend_NoPortErrors(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"rules": []any{
+				map[string]any{
+					"host": "example.com",
+					"paths": []any{
+						map[string]any{
+							"path":    "/admin",
+							"backend": "deny-backend",
+							// no "port" — must error even though component has port 80
+						},
+					},
+				},
+			},
+		},
+	}
+	app := newWebApp("web", "default")
+	err := h.Apply(trait, app, newBundle())
+	if err == nil || !strings.Contains(err.Error(), "cannot determine backend port") {
+		t.Errorf("expected 'cannot determine backend port', got: %v", err)
+	}
+}
+
+func TestIngressHandler_Apply_ExplicitBackend(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"ingressClassName": "nginx",
+			"rules": []any{
+				map[string]any{
+					"host": "example.com",
+					"paths": []any{
+						map[string]any{
+							"path":    "/",
+							"backend": "deny-backend",
+							"port":    8080,
+						},
+					},
+				},
+			},
+		},
+	}
+	app := newApp("wrk", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objs, err := bundle.Applications[0].Config.(*traits.IngressConfig).Generate(
+		stack.NewApplication("wrk-ingress", "default", nil))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ingress := (*objs[0]).(*networkingv1.Ingress)
+	gotName := ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name
+	if gotName != "deny-backend" {
+		t.Errorf("backend.service.name = %q, want \"deny-backend\"", gotName)
+	}
+}
+
+func TestIngressHandler_Apply_CustomServiceName(t *testing.T) {
+	h := &traits.IngressHandler{}
+	app := stack.NewApplication("my-statefulset", "default", &namedWebConfig{
+		port: 5432, serviceName: "postgres-primary",
+	})
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"rules": []any{
+				map[string]any{
+					"host":  "db.example.com",
+					"paths": []any{map[string]any{"path": "/"}},
+				},
+			},
+		},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	subApp := bundle.Applications[0]
+	objs, err := subApp.Config.Generate(stack.NewApplication("my-statefulset-ingress", "default", nil))
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ingress, ok := (*objs[0]).(*networkingv1.Ingress)
+	if !ok {
+		t.Fatalf("expected *networkingv1.Ingress, got %T", *objs[0])
+	}
+	gotName := ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Name
+	if gotName != "postgres-primary" {
+		t.Errorf("backend.service.name = %q, want \"postgres-primary\"", gotName)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `HTTPRouteHandler` — a full port of crane's httproute trait, supporting all filter types (RequestRedirect, RequestHeaderModifier, ResponseHeaderModifier, URLRewrite, RequestMirror, CORS, ExternalAuth) and per-rule timeouts. The handler is marked deprecated and emits `slog.Warn` on every invocation.
- Adds gateway dispatch to `ExposeHandler` — `controllerType: gateway` in a ClusterProfile capability now translates `gatewayName` + `gatewayNamespace` into `parentRefs` and delegates to `HTTPRouteHandler`. `gatewayNamespace` defaults to `gateway-system` when omitted.
- Registers `httproute` in `newBuiltinTransformer()` alongside the existing `ingress` handler.

13 golden fixtures cover the full filter matrix plus the expose-gateway path.

Closes #50

## Test plan

- [ ] `GOWORK=off go test ./pkg/oam/builtin/traits/... -v -run TestHTTPRoute` — all parse, generate, and deprecation-warning tests pass
- [ ] `GOWORK=off go test ./pkg/oam/builtin/traits/... -v -run TestExpose` — all expose gateway tests pass (including dispatch to HTTPRoute)
- [ ] `GOWORK=off go test ./pkg/cmd/kurel/...` — all 13 new golden fixtures pass
- [ ] `GOWORK=off make precommit` — 0 lint issues, all tests pass
- [ ] Coverage: 81.2% total (above 80% gate)