### PR TITLE
feat(oam): daemonset port field, Service generation, servicePortProvider (#86)

### DIFF
--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -114,7 +114,7 @@ Migrated from crane. Each type maps to a `ComponentHandler` implementation in
 | `cronjob` | Scheduled task: CronJob |
 | `postgresql` | PostgreSQL instance (CNPG) |
 | `helmrelease` | FluxCD HelmRelease for third-party charts |
-| `daemonset` | DaemonSet for node-level agents |
+| `daemonset` | DaemonSet for node-level agents. Optional `port: <N>` generates a ClusterIP Service exposing port N; required when the daemonset acts as an implicit backend for ingress, httproute, or expose traits. |
 | `statefulset` | StatefulSet for ordered, persistent workloads |
 
 ### 4.3 Supported trait types (Phase 1)

--- a/pkg/cmd/kurel/testdata/daemonset-httproute/app.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-httproute/app.yaml
@@ -1,0 +1,19 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+    - name: agent
+      type: daemonset
+      properties:
+        image: ghcr.io/example/agent:v1.0
+        port: 9090
+      traits:
+        - type: httproute
+          properties:
+            parentRefs:
+              - name: my-gateway
+            rules:
+              - {}

--- a/pkg/cmd/kurel/testdata/daemonset-httproute/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-httproute/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/daemonset-httproute/expected.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-httproute/expected.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+      - image: ghcr.io/example/agent:v1.0
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 9090
+          name: tcp
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: agent
+  updateStrategy: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+spec:
+  ports:
+  - name: tcp
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: agent
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  labels:
+    app: agent
+  name: agent-httproute
+  namespace: default
+spec:
+  parentRefs:
+  - name: my-gateway
+  rules:
+  - backendRefs:
+    - name: agent
+      port: 9090

--- a/pkg/cmd/kurel/testdata/daemonset-ingress/app.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-ingress/app.yaml
@@ -1,0 +1,20 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+  namespace: default
+spec:
+  components:
+    - name: agent
+      type: daemonset
+      properties:
+        image: ghcr.io/example/agent:v1.0
+        port: 9090
+      traits:
+        - type: ingress
+          properties:
+            ingressClassName: nginx
+            rules:
+              - host: agent.example.com
+                paths:
+                  - path: /metrics

--- a/pkg/cmd/kurel/testdata/daemonset-ingress/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-ingress/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/daemonset-ingress/expected.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-ingress/expected.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      app: agent
+  template:
+    metadata:
+      labels:
+        app: agent
+    spec:
+      containers:
+      - image: ghcr.io/example/agent:v1.0
+        imagePullPolicy: IfNotPresent
+        name: agent
+        ports:
+        - containerPort: 9090
+          name: tcp
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: agent
+  updateStrategy: {}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+spec:
+  ports:
+  - name: tcp
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: agent
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: agent
+  name: agent
+  namespace: default
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    app: agent
+  name: agent-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: agent.example.com
+    http:
+      paths:
+      - backend:
+          service:
+            name: agent
+            port:
+              number: 9090
+        path: /metrics
+        pathType: Prefix

--- a/pkg/oam/builtin/components/daemonset.go
+++ b/pkg/oam/builtin/components/daemonset.go
@@ -5,6 +5,7 @@ import (
 	"github.com/go-kure/kure/pkg/stack"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/errors"
@@ -73,6 +74,10 @@ func (h *DaemonsetHandler) ToApplicationConfig(component *oam.Component, namespa
 	}
 	config.InitContainers = initContainers
 
+	if port, ok := toInt32(props["port"]); ok {
+		config.Port = port
+	}
+
 	return config, nil
 }
 
@@ -81,6 +86,7 @@ type DaemonsetConfig struct {
 	Name              string
 	Namespace         string
 	Image             string
+	Port              int32 // when > 0, generates a ClusterIP Service exposing this port
 	Env               []EnvVar
 	Resources         ResourceRequirements
 	Command           []string
@@ -93,6 +99,10 @@ type DaemonsetConfig struct {
 	PVCs              []PVCConfig
 	explicitResources explicitResourceFlags
 }
+
+// ServicePort implements servicePortProvider, making DaemonsetConfig usable as an
+// implicit backend for ingress, httproute, and expose traits.
+func (c *DaemonsetConfig) ServicePort() int32 { return c.Port }
 
 // ApplyPolicy applies defaults then enforces limits from the policy.
 // DaemonSets don't have replicas, so only resource and registry limits apply.
@@ -138,19 +148,28 @@ func (c *DaemonsetConfig) ApplyPolicy(p oam.Policy) error {
 	return nil
 }
 
-// Generate creates a Kubernetes DaemonSet and ServiceAccount.
+// Generate creates a Kubernetes DaemonSet, optional Service, and ServiceAccount.
+// A Service is generated when Port > 0.
 func (c *DaemonsetConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{"app": app.Name}
 	ds, err := c.createDaemonSet(app)
 	if err != nil {
 		return nil, err
 	}
-	sa := createServiceAccount(app.Name, app.Namespace, labels)
 
 	dsObj := client.Object(ds)
-	saObj := client.Object(sa)
+	objects := []*client.Object{&dsObj}
 
-	objects := []*client.Object{&dsObj, &saObj}
+	if c.Port > 0 {
+		svc := c.createService(app)
+		svcObj := client.Object(svc)
+		objects = append(objects, &svcObj)
+	}
+
+	sa := createServiceAccount(app.Name, app.Namespace, labels)
+	saObj := client.Object(sa)
+	objects = append(objects, &saObj)
+
 	for _, pvc := range c.PVCs {
 		p, err := BuildPVC(pvc, app.Namespace, labels)
 		if err != nil {
@@ -160,6 +179,22 @@ func (c *DaemonsetConfig) Generate(app *stack.Application) ([]*client.Object, er
 		objects = append(objects, &pObj)
 	}
 	return objects, nil
+}
+
+func (c *DaemonsetConfig) createService(app *stack.Application) *corev1.Service {
+	labels := map[string]string{"app": app.Name}
+	svc := kubernetes.CreateService(app.Name, app.Namespace)
+	svc.Labels = labels
+	svc.Annotations = nil
+	_ = kubernetes.SetServiceType(svc, corev1.ServiceTypeClusterIP)
+	_ = kubernetes.SetServiceSelector(svc, map[string]string{"app": app.Name})
+	_ = kubernetes.AddServicePort(svc, corev1.ServicePort{
+		Name:       "tcp",
+		Port:       c.Port,
+		TargetPort: intstr.FromInt32(c.Port),
+		Protocol:   corev1.ProtocolTCP,
+	})
+	return svc
 }
 
 func (c *DaemonsetConfig) createDaemonSet(app *stack.Application) (*appsv1.DaemonSet, error) {
@@ -175,6 +210,13 @@ func (c *DaemonsetConfig) createDaemonSet(app *stack.Application) (*appsv1.Daemo
 		_ = kubernetes.AddContainerEnv(container, env)
 	}
 	applyProbes(container, c.Probes)
+	if c.Port > 0 {
+		_ = kubernetes.AddContainerPort(container, corev1.ContainerPort{
+			Name:          "tcp",
+			ContainerPort: c.Port,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
 	for _, m := range c.VolumeMounts {
 		_ = kubernetes.AddContainerVolumeMount(container, m)
 	}

--- a/pkg/oam/builtin/components/daemonset_test.go
+++ b/pkg/oam/builtin/components/daemonset_test.go
@@ -223,3 +223,115 @@ func TestDaemonsetHandler_WithTolerations(t *testing.T) {
 	}
 	t.Error("DaemonSet not found")
 }
+
+func TestDaemonsetConfig_WithPort(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+			"port":  9090,
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	dc, ok := cfg.(*components.DaemonsetConfig)
+	if !ok {
+		t.Fatalf("expected *DaemonsetConfig, got %T", cfg)
+	}
+	if dc.Port != 9090 {
+		t.Errorf("Port = %d, want 9090", dc.Port)
+	}
+	if dc.ServicePort() != 9090 {
+		t.Errorf("ServicePort() = %d, want 9090", dc.ServicePort())
+	}
+
+	app := stack.NewApplication("agent", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var foundDS, foundSvc, foundSA bool
+	for _, obj := range objects {
+		switch o := (*obj).(type) {
+		case *appsv1.DaemonSet:
+			foundDS = true
+			// Verify container port
+			if len(o.Spec.Template.Spec.Containers) == 0 {
+				t.Fatal("no containers in DaemonSet")
+			}
+			ports := o.Spec.Template.Spec.Containers[0].Ports
+			if len(ports) == 0 || ports[0].ContainerPort != 9090 {
+				t.Errorf("container port = %v, want [{tcp 9090}]", ports)
+			}
+		case *corev1.Service:
+			foundSvc = true
+			if len(o.Spec.Ports) == 0 || o.Spec.Ports[0].Port != 9090 {
+				t.Errorf("service port = %v, want 9090", o.Spec.Ports)
+			}
+			if o.Spec.Type != corev1.ServiceTypeClusterIP {
+				t.Errorf("service type = %q, want ClusterIP", o.Spec.Type)
+			}
+			if o.Name != "agent" {
+				t.Errorf("service name = %q, want \"agent\"", o.Name)
+			}
+		case *corev1.ServiceAccount:
+			foundSA = true
+		}
+	}
+	if !foundDS {
+		t.Error("expected DaemonSet")
+	}
+	if !foundSvc {
+		t.Error("expected Service when port > 0")
+	}
+	if !foundSA {
+		t.Error("expected ServiceAccount")
+	}
+	// Verify object order: DaemonSet → Service → ServiceAccount
+	if len(objects) < 3 {
+		t.Fatalf("expected at least 3 objects, got %d", len(objects))
+	}
+	if _, ok := (*objects[0]).(*appsv1.DaemonSet); !ok {
+		t.Errorf("objects[0] = %T, want *DaemonSet", *objects[0])
+	}
+	if _, ok := (*objects[1]).(*corev1.Service); !ok {
+		t.Errorf("objects[1] = %T, want *Service", *objects[1])
+	}
+	if _, ok := (*objects[2]).(*corev1.ServiceAccount); !ok {
+		t.Errorf("objects[2] = %T, want *ServiceAccount", *objects[2])
+	}
+}
+
+func TestDaemonsetConfig_WithoutPort(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "agent",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "ghcr.io/org/agent:v1.0.0",
+		},
+	}, "default")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("agent", "default", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, obj := range objects {
+		if _, ok := (*obj).(*corev1.Service); ok {
+			t.Error("expected no Service when port is not set")
+		}
+	}
+	if len(objects) != 2 {
+		t.Errorf("expected 2 objects (DaemonSet + ServiceAccount), got %d", len(objects))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `port: <N>` property to the `daemonset` component type
- When set, `Generate()` emits a `ClusterIP` Service alongside the DaemonSet, making the component usable as an implicit backend for `ingress`, `httproute`, and `expose` traits
- Implements `servicePortProvider` (`ServicePort() int32`) so `checkImplicitBackend` accepts daemonsets with a port configured
- Golden fixtures added for both `daemonset-ingress` and `daemonset-httproute` paths
- Docs updated: daemonset row in `docs/oam/design-kurel-package.md`

Closes #86.

## Test plan

- [ ] `GOWORK=off go test ./pkg/oam/builtin/components/... -run TestDaemonset -v` — unit tests pass
- [ ] `GOWORK=off go test ./pkg/cmd/kurel/... -run 'TestFixtures/daemonset' -v` — golden fixtures pass
- [ ] `GOWORK=off make precommit` — all checks green