### PR TITLE
feat(oam): rename helmrelease→helmchart, add gitopsEngine, implement helmchart handler

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -106,7 +106,7 @@ OAM YAML input (app.yaml + cluster.yaml)
          ▼
 ┌───────────────────┐
 │  Handler Registry  │  ComponentHandler + TraitHandler per OAM type
-│  + Transformer    │  TransformContext carries Policy + ClusterProfile
+│  + Transformer    │  TransformContext carries ClusterID, Namespace, Policy, Capabilities
 └────────┬──────────┘
          │ ApplicationConfig per component
          ▼
@@ -293,7 +293,7 @@ This monolithic layout is owned by launcher and generated as part of `kurel buil
 - Fixture parity and regression coverage (#54)
 
 **Phase 2: Built-in handlers** (#32)
-- Component handlers: webservice, worker, postgresql, cronjob, helmrelease, daemonset, statefulset (#48)
+- Component handlers: webservice, worker, postgresql, cronjob, helmchart, daemonset, statefulset (#48)
 - Trait handlers — workload set: expose, certificate, external-secret, pvc, scaler (#49)
 - Trait handlers — network/infra set: ingress, httproute, configmap, networkpolicy, cilium-networkpolicy, volsync (#50)
 

--- a/docs/oam/design-cluster-profile.md
+++ b/docs/oam/design-cluster-profile.md
@@ -29,6 +29,7 @@ kind: ClusterProfile
 metadata:
   name: <string>       # cluster identifier, e.g. "prod-eu-west"
 spec:
+  gitopsEngine: fluxcd # optional; default "fluxcd". Selects native-delivery CR type for helmchart.
   capabilities:
     <trait-type>:      # e.g. "expose", "certificate", "external-secret"
       rendering:       # values injected into trait properties at build time
@@ -40,6 +41,7 @@ spec:
 | Field | Type | Description |
 |---|---|---|
 | `metadata.name` | string | Identifies the cluster; referenced in build tooling |
+| `spec.gitopsEngine` | string | GitOps engine for helmchart native delivery. Accepted: `"fluxcd"` (default, optional). |
 | `spec.capabilities` | map | Keys are trait types; values are capability bindings |
 | `capabilities.<type>.rendering` | map | Platform values merged into trait properties before handler invocation |
 
@@ -72,6 +74,11 @@ not appear in a launcher `cluster.yaml`:
 - `spec.gitops` — FluxCD/ArgoCD wiring; delivery-layer concern
 - `spec.componentCatalog` / `spec.catalog` — Harbor catalog references
 - `spec.componentVariants` — crane layer-3 variant selection
+
+Note: `spec.gitopsEngine` (a single string field) is launcher-specific and IS present in
+launcher ClusterProfiles. It selects which native GitOps delivery CRs are emitted for
+helmchart components. Do not confuse it with crane's `spec.gitops` (the full delivery
+block, which stays in crane only).
 
 ---
 
@@ -261,6 +268,10 @@ follows:
 | `spec.catalog` | — | Stays in crane |
 | `spec.componentCatalog` | — | Stays in crane |
 | `spec.componentVariants` | — | Stays in crane |
+
+`spec.gitopsEngine` is a launcher-only addition with no direct crane counterpart. It
+replaces the engine-selection concern embedded in crane's `spec.gitops.engine` with a
+top-level string. The full `spec.gitops` delivery wiring stays in crane only.
 
 Operators migrating a crane `ClusterProfile` to a launcher `cluster.yaml` must:
 1. Change `apiVersion` to `launcher.gokure.dev/v1alpha1`

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -113,7 +113,7 @@ Migrated from crane. Each type maps to a `ComponentHandler` implementation in
 | `worker` | Long-running background worker: Deployment (no Service) |
 | `cronjob` | Scheduled task: CronJob |
 | `postgresql` | PostgreSQL instance (CNPG) |
-| `helmrelease` | FluxCD HelmRelease for third-party charts |
+| `helmchart` | FluxCD HelmRelease for third-party charts. Supports inline source creation (`source.url`) and reference to existing source CRs (`source.name`). Multiple components sharing the same source key share a single source CR (first component wins). For HelmRepository the key is the URL; for OCIRepository the key is URL+version, so two OCI components with the same URL but different versions each get their own source CR. |
 | `daemonset` | DaemonSet for node-level agents. Optional `port: <N>` generates a ClusterIP Service exposing port N; required when the daemonset acts as an implicit backend for ingress, httproute, or expose traits. |
 | `statefulset` | StatefulSet for ordered, persistent workloads |
 

--- a/examples/11-helmchart.yaml
+++ b/examples/11-helmchart.yaml
@@ -5,12 +5,12 @@ metadata:
 spec:
   components:
   - name: redis
-    type: helmrelease
+    type: helmchart
     properties:
-      chart:
-        name: redis
-        repository: https://charts.bitnami.com/bitnami
-        version: "18.6.1"
+      chart: redis
+      version: "18.6.1"
+      source:
+        url: https://charts.bitnami.com/bitnami
       values:
         auth:
           enabled: false

--- a/examples/14-full-stack.yaml
+++ b/examples/14-full-stack.yaml
@@ -1,5 +1,5 @@
 # Full-stack example — exercises every Phase 1 component type and every Phase 1 trait type.
-# Component types: webservice, worker, cronjob, postgresql, helmrelease, daemonset, statefulset
+# Component types: webservice, worker, cronjob, postgresql, helmchart, daemonset, statefulset
 # Trait types: expose (public + scoped internal), ingress, httproute, certificate,
 #              external-secret, configmap, scaler
 # Use with cluster-profiles/gateway-certmanager-aws.yaml to exercise scoped capabilities.
@@ -123,14 +123,14 @@ spec:
           cpu: "500m"
           memory: "1Gi"
 
-  # --- helmrelease ---
+  # --- helmchart ---
   - name: redis
-    type: helmrelease
+    type: helmchart
     properties:
-      chart:
-        name: redis
-        repository: https://charts.bitnami.com/bitnami
-        version: "18.6.1"
+      chart: redis
+      version: "18.6.1"
+      source:
+        url: https://charts.bitnami.com/bitnami
       values:
         auth:
           enabled: false

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/cloudnative-pg/plugin-barman-cloud v0.12.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342
+	github.com/fluxcd/helm-controller/api v1.5.4
+	github.com/fluxcd/source-controller/api v1.8.3
 	github.com/go-kure/kure v0.2.0-alpha.3
 	github.com/google/go-containerregistry v0.21.5
 	github.com/spf13/cobra v1.10.2
@@ -40,14 +42,12 @@ require (
 	github.com/controlplaneio-fluxcd/flux-operator v0.40.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
-	github.com/fluxcd/helm-controller/api v1.5.4 // indirect
 	github.com/fluxcd/image-automation-controller/api v1.1.2 // indirect
 	github.com/fluxcd/kustomize-controller/api v1.8.4 // indirect
 	github.com/fluxcd/notification-controller/api v1.8.4 // indirect
 	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.15.1 // indirect
 	github.com/fluxcd/pkg/apis/meta v1.25.1 // indirect
-	github.com/fluxcd/source-controller/api v1.8.3 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-errors/errors v1.5.1 // indirect

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -121,6 +121,7 @@ func newBuiltinTransformer() *oam.Transformer {
 			"daemonset":   &components.DaemonsetHandler{},
 			"statefulset": &components.StatefulsetHandler{},
 			"postgresql":  &components.PostgresqlHandler{},
+			"helmchart":   &components.HelmchartHandler{},
 		},
 		map[string]oam.TraitHandler{
 			"expose":               &traits.ExposeHandler{},

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -166,7 +166,7 @@ metadata:
 spec:
   components:
     - name: backend
-      type: helmrelease
+      type: unknownxyz
       properties:
         image: ghcr.io/example/backend:v1.0.0
 `
@@ -182,7 +182,7 @@ spec:
 	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
 	err := cmd.Execute()
 	if err == nil {
-		t.Fatal("expected error for unsupported component type 'helmrelease'")
+		t.Fatal("expected error for unsupported component type 'unknownxyz'")
 	}
 }
 

--- a/pkg/cmd/kurel/testdata/helmchart-oci/app.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-oci/app.yaml
@@ -1,0 +1,14 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: cert-manager
+  namespace: default
+spec:
+  components:
+    - name: cert-manager
+      type: helmchart
+      properties:
+        version: v1.17.2
+        source:
+          kind: OCIRepository
+          url: oci://ghcr.io/cert-manager/charts/cert-manager

--- a/pkg/cmd/kurel/testdata/helmchart-oci/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-oci/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/helmchart-oci/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-oci/expected.yaml
@@ -1,0 +1,21 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: cert-manager
+  namespace: default
+spec:
+  interval: 10m0s
+  ref:
+    tag: v1.17.2
+  url: oci://ghcr.io/cert-manager/charts/cert-manager
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: default
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: cert-manager
+  interval: 10m0s

--- a/pkg/cmd/kurel/testdata/helmchart-repository/app.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-repository/app.yaml
@@ -1,0 +1,15 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: monitoring
+  namespace: default
+spec:
+  components:
+    - name: metrics
+      type: helmchart
+      properties:
+        chart: kube-prometheus-stack
+        version: "69.3.2"
+        source:
+          url: https://prometheus-community.github.io/helm-charts
+        targetNamespace: monitoring

--- a/pkg/cmd/kurel/testdata/helmchart-repository/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-repository/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/helmchart-repository/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-repository/expected.yaml
@@ -1,0 +1,24 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics
+  namespace: default
+spec:
+  interval: 10m0s
+  url: https://prometheus-community.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      sourceRef:
+        kind: HelmRepository
+        name: metrics
+      version: 69.3.2
+  interval: 10m0s
+  targetNamespace: monitoring

--- a/pkg/cmd/kurel/testdata/helmchart-sourceref/app.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-sourceref/app.yaml
@@ -1,0 +1,16 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: monitoring
+  namespace: default
+spec:
+  components:
+    - name: prometheus
+      type: helmchart
+      properties:
+        chart: kube-prometheus-stack
+        version: "69.3.2"
+        source:
+          kind: HelmRepository
+          name: prometheus-community
+          namespace: flux-system

--- a/pkg/cmd/kurel/testdata/helmchart-sourceref/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-sourceref/cluster.yaml
@@ -1,0 +1,6 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:
+  capabilities: {}

--- a/pkg/cmd/kurel/testdata/helmchart-sourceref/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-sourceref/expected.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: prometheus
+  namespace: default
+spec:
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus-community
+        namespace: flux-system
+      version: 69.3.2
+  interval: 10m0s

--- a/pkg/oam/builtin/components/helmchart.go
+++ b/pkg/oam/builtin/components/helmchart.go
@@ -1,0 +1,340 @@
+package components
+
+import (
+	"strings"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	"github.com/go-kure/kure/pkg/kubernetes/fluxcd"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// HelmchartHandler handles OAM helmchart components.
+type HelmchartHandler struct{}
+
+// CanHandle returns true for helmchart component type.
+func (h *HelmchartHandler) CanHandle(componentType string) bool {
+	return componentType == "helmchart"
+}
+
+// ToApplicationConfig converts an OAM helmchart component to a HelmchartConfig.
+func (h *HelmchartHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	cfg := &HelmchartConfig{
+		Name:      component.Name,
+		Namespace: namespace,
+	}
+
+	props := component.Properties
+
+	cfg.Chart, _ = props["chart"].(string)
+	cfg.Version, _ = props["version"].(string)
+	cfg.Delivery, _ = props["delivery"].(string)
+	cfg.Interval, _ = props["interval"].(string)
+	cfg.ReleaseName, _ = props["releaseName"].(string)
+	cfg.TargetNamespace, _ = props["targetNamespace"].(string)
+
+	if dd, ok := props["driftDetection"].(map[string]any); ok {
+		mode, _ := dd["mode"].(string)
+		switch mode {
+		case "enabled", "warn", "disabled":
+			cfg.DriftMode = mode
+		case "":
+			// not configured
+		default:
+			return nil, errors.Errorf("helmchart: driftDetection.mode %q is invalid; must be enabled, warn, or disabled", mode)
+		}
+	}
+	if install, ok := props["install"].(map[string]any); ok {
+		crds, _ := install["crds"].(string)
+		switch crds {
+		case "Skip", "Create", "CreateReplace":
+			cfg.InstallCRDs = crds
+		case "":
+			// not configured
+		default:
+			return nil, errors.Errorf("helmchart: install.crds %q is invalid; must be Skip, Create, or CreateReplace", crds)
+		}
+	}
+	if upgrade, ok := props["upgrade"].(map[string]any); ok {
+		crds, _ := upgrade["crds"].(string)
+		switch crds {
+		case "Skip", "Create", "CreateReplace":
+			cfg.UpgradeCRDs = crds
+		case "":
+			// not configured
+		default:
+			return nil, errors.Errorf("helmchart: upgrade.crds %q is invalid; must be Skip, Create, or CreateReplace", crds)
+		}
+	}
+	if vals, ok := props["values"].(map[string]any); ok {
+		cfg.Values = vals
+	}
+	if vfList, ok := props["valuesFrom"].([]any); ok {
+		for i, vf := range vfList {
+			m, ok := vf.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("valuesFrom[%d]: expected object, got %T", i, vf)
+			}
+			vfc := fluxcd.ValuesFromConfig{}
+			vfc.Kind, _ = m["kind"].(string)
+			switch vfc.Kind {
+			case "ConfigMap", "Secret":
+				// ok
+			default:
+				return nil, errors.Errorf("valuesFrom[%d]: kind %q is invalid; must be ConfigMap or Secret", i, vfc.Kind)
+			}
+			vfc.Name, _ = m["name"].(string)
+			if vfc.Name == "" {
+				return nil, errors.Errorf("valuesFrom[%d]: name is required", i)
+			}
+			vfc.ValuesKey, _ = m["valuesKey"].(string)
+			vfc.TargetPath, _ = m["targetPath"].(string)
+			cfg.ValuesFrom = append(cfg.ValuesFrom, vfc)
+		}
+	}
+
+	// Validate delivery
+	switch cfg.Delivery {
+	case "", "native":
+		// ok
+	case "template":
+		return nil, errors.New("helmchart: delivery: template is not yet implemented; see issue #83")
+	default:
+		return nil, errors.Errorf("helmchart: unsupported delivery %q; supported values: native", cfg.Delivery)
+	}
+
+	// Parse source block
+	src, ok := props["source"].(map[string]any)
+	if !ok {
+		return nil, errors.New("helmchart: source is required")
+	}
+	srcURL, _ := src["url"].(string)
+	srcName, _ := src["name"].(string)
+	srcKind, _ := src["kind"].(string)
+	srcNamespace, _ := src["namespace"].(string)
+
+	if srcURL != "" && srcName != "" {
+		return nil, errors.New("helmchart: source.url and source.name are mutually exclusive")
+	}
+	if srcURL == "" && srcName == "" {
+		return nil, errors.New("helmchart: source requires either source.url (inline) or source.name (reference)")
+	}
+
+	if srcURL != "" {
+		// Form A: inline source — launcher creates the source CR
+		cfg.SourceURL = srcURL
+
+		if srcKind == "" {
+			if strings.HasPrefix(srcURL, "oci://") {
+				cfg.SourceKind = "OCIRepository"
+			} else {
+				cfg.SourceKind = "HelmRepository"
+			}
+		} else {
+			cfg.SourceKind = srcKind
+		}
+
+		switch cfg.SourceKind {
+		case "HelmRepository":
+			if strings.HasPrefix(srcURL, "oci://") {
+				return nil, errors.Errorf("helmchart: source.kind HelmRepository is incompatible with oci:// URL")
+			}
+			if !strings.HasPrefix(srcURL, "https://") && !strings.HasPrefix(srcURL, "http://") {
+				return nil, errors.Errorf("helmchart: HelmRepository source.url must start with https:// or http://")
+			}
+			if cfg.Chart == "" {
+				return nil, errors.New("helmchart: source.kind HelmRepository requires chart to be specified")
+			}
+		case "OCIRepository":
+			if !strings.HasPrefix(srcURL, "oci://") {
+				return nil, errors.Errorf("helmchart: source.kind OCIRepository requires an oci:// URL")
+			}
+		default:
+			return nil, errors.Errorf("helmchart: source.kind %q is not valid for inline source; must be HelmRepository or OCIRepository", cfg.SourceKind)
+		}
+	} else {
+		// Form B: reference existing source CR
+		if srcKind == "" {
+			return nil, errors.New("helmchart: source.kind is required when source.name is set")
+		}
+		switch srcKind {
+		case "HelmRepository", "OCIRepository", "HelmChart":
+			// ok
+		default:
+			return nil, errors.Errorf("helmchart: source.kind %q is not valid for source reference; must be HelmRepository, OCIRepository, or HelmChart", srcKind)
+		}
+		if srcKind == "HelmRepository" && cfg.Chart == "" {
+			return nil, errors.New("helmchart: source.kind HelmRepository requires chart to be specified")
+		}
+		cfg.SourceRefName = srcName
+		cfg.SourceRefKind = srcKind
+		cfg.SourceRefNamespace = srcNamespace
+	}
+
+	return cfg, nil
+}
+
+// HelmchartConfig implements stack.ApplicationConfig for helmchart components.
+type HelmchartConfig struct {
+	Name      string
+	Namespace string
+	Chart     string
+	Version   string
+	Delivery  string
+
+	// Form A: inline source — URL is set, launcher creates the source CR.
+	SourceURL  string
+	SourceKind string // "HelmRepository" or "OCIRepository"
+
+	// Form B: reference — name is set, source CR already exists.
+	SourceRefName      string
+	SourceRefKind      string // "HelmRepository", "OCIRepository", or "HelmChart"
+	SourceRefNamespace string
+
+	// HelmRelease options
+	Interval        string
+	ReleaseName     string
+	TargetNamespace string
+	DriftMode       string
+	InstallCRDs     string
+	UpgradeCRDs     string
+	Values          map[string]any
+	ValuesFrom      []fluxcd.ValuesFromConfig
+
+	// dedup state (Form A only)
+	suppressSource bool
+	sharedSrcName  string
+}
+
+// ApplyPolicy is a no-op for helmchart (Helm releases have no resource-limit policy).
+func (c *HelmchartConfig) ApplyPolicy(_ oam.Policy) error { return nil }
+
+// GetSourceKey returns the dedup key for Form A sources.
+// For HelmRepository: "helm:<url>". For OCIRepository: "oci:<url>:<version>".
+// Returns "" for Form B (reference) so the dedup loop skips this config.
+// First component wins when multiple components share the same source key.
+func (c *HelmchartConfig) GetSourceKey() string {
+	if c.SourceURL == "" {
+		return ""
+	}
+	if c.SourceKind == "OCIRepository" {
+		return "oci:" + c.SourceURL + ":" + c.Version
+	}
+	return "helm:" + c.SourceURL
+}
+
+// GetSourceRefName returns the name to use when referencing this component's source CR.
+func (c *HelmchartConfig) GetSourceRefName() string { return c.Name }
+
+// SuppressSourceGeneration instructs this config to skip emitting its own source CR
+// and reference the named shared source instead.
+func (c *HelmchartConfig) SuppressSourceGeneration(refName string) {
+	c.suppressSource = true
+	c.sharedSrcName = refName
+}
+
+// Generate produces the Kubernetes objects for this helmchart component.
+// Output order: source CR (Form A only, unless suppressed by dedup) then HelmRelease.
+func (c *HelmchartConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	var objects []*client.Object
+
+	if c.SourceURL != "" {
+		// Form A: inline source
+		srcName := c.Name
+		if c.suppressSource && c.sharedSrcName != "" {
+			srcName = c.sharedSrcName
+		}
+
+		if !c.suppressSource {
+			switch c.SourceKind {
+			case "HelmRepository":
+				repo := fluxcd.HelmRepository(&fluxcd.HelmRepositoryConfig{
+					Name:      c.Name,
+					Namespace: c.Namespace,
+					URL:       c.SourceURL,
+					Interval:  effectiveInterval(c.Interval),
+				})
+				obj := client.Object(repo)
+				objects = append(objects, &obj)
+			case "OCIRepository":
+				repo := fluxcd.OCIRepository(&fluxcd.OCIRepositoryConfig{
+					Name:      c.Name,
+					Namespace: c.Namespace,
+					URL:       c.SourceURL,
+					Ref:       c.Version,
+					Interval:  effectiveInterval(c.Interval),
+				})
+				obj := client.Object(repo)
+				objects = append(objects, &obj)
+			}
+		}
+
+		relCfg := c.baseReleaseConfig()
+		switch c.SourceKind {
+		case "HelmRepository":
+			relCfg.Chart = c.Chart
+			relCfg.Version = c.Version
+			relCfg.SourceRef = helmv2.CrossNamespaceObjectReference{
+				Kind: "HelmRepository",
+				Name: srcName,
+			}
+		case "OCIRepository":
+			relCfg.ChartRef = &fluxcd.ChartRefConfig{
+				Kind: "OCIRepository",
+				Name: srcName,
+			}
+		}
+		hr := fluxcd.HelmRelease(relCfg)
+		obj := client.Object(hr)
+		objects = append(objects, &obj)
+	} else {
+		// Form B: reference existing source CR
+		relCfg := c.baseReleaseConfig()
+		switch c.SourceRefKind {
+		case "HelmRepository":
+			relCfg.Chart = c.Chart
+			relCfg.Version = c.Version
+			relCfg.SourceRef = helmv2.CrossNamespaceObjectReference{
+				Kind:      "HelmRepository",
+				Name:      c.SourceRefName,
+				Namespace: c.SourceRefNamespace,
+			}
+		default: // "OCIRepository" or "HelmChart"
+			relCfg.ChartRef = &fluxcd.ChartRefConfig{
+				Kind:      c.SourceRefKind,
+				Name:      c.SourceRefName,
+				Namespace: c.SourceRefNamespace,
+			}
+		}
+		hr := fluxcd.HelmRelease(relCfg)
+		obj := client.Object(hr)
+		objects = append(objects, &obj)
+	}
+
+	return objects, nil
+}
+
+func (c *HelmchartConfig) baseReleaseConfig() *fluxcd.HelmReleaseConfig {
+	return &fluxcd.HelmReleaseConfig{
+		Name:               c.Name,
+		Namespace:          c.Namespace,
+		Interval:           effectiveInterval(c.Interval),
+		ReleaseName:        c.ReleaseName,
+		TargetNamespace:    c.TargetNamespace,
+		DriftDetectionMode: c.DriftMode,
+		InstallCRDs:        c.InstallCRDs,
+		UpgradeCRDs:        c.UpgradeCRDs,
+		Values:             c.Values,
+		ValuesFrom:         c.ValuesFrom,
+	}
+}
+
+func effectiveInterval(interval string) string {
+	if interval == "" {
+		return "10m"
+	}
+	return interval
+}

--- a/pkg/oam/builtin/components/helmchart_test.go
+++ b/pkg/oam/builtin/components/helmchart_test.go
@@ -1,0 +1,510 @@
+package components_test
+
+import (
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestHelmchartHandler_CanHandle(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	if !h.CanHandle("helmchart") {
+		t.Error("expected true for helmchart")
+	}
+	if h.CanHandle("webservice") {
+		t.Error("expected false for webservice")
+	}
+}
+
+func TestHelmchartHandler_RequiresSource(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name:       "metrics",
+		Type:       "helmchart",
+		Properties: map[string]any{},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error when source is absent")
+	}
+}
+
+func TestHelmchartHandler_BothURLAndName_Rejected(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url":  "https://prometheus-community.github.io/helm-charts",
+				"name": "existing-repo",
+				"kind": "HelmRepository",
+			},
+		},
+	}, "default")
+	if err == nil {
+		t.Fatal("expected error when both source.url and source.name are set")
+	}
+}
+
+func TestHelmchartHandler_HelmRepository_Generate(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart":   "kube-prometheus-stack",
+			"version": "69.3.2",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("metrics", "monitoring", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Fatalf("expected 2 objects (HelmRepository + HelmRelease), got %d", len(objects))
+	}
+
+	if _, ok := (*objects[0]).(*sourcev1.HelmRepository); !ok {
+		t.Errorf("objects[0]: expected *sourcev1.HelmRepository, got %T", *objects[0])
+	}
+	hr, ok := (*objects[1]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Errorf("objects[1]: expected *helmv2.HelmRelease, got %T", *objects[1])
+	} else {
+		if hr.Spec.Chart == nil {
+			t.Fatal("HelmRelease.Spec.Chart is nil")
+		}
+		if hr.Spec.Chart.Spec.Chart != "kube-prometheus-stack" {
+			t.Errorf("chart = %q, want %q", hr.Spec.Chart.Spec.Chart, "kube-prometheus-stack")
+		}
+		if hr.Spec.Chart.Spec.SourceRef.Kind != "HelmRepository" {
+			t.Errorf("sourceRef.Kind = %q, want HelmRepository", hr.Spec.Chart.Spec.SourceRef.Kind)
+		}
+		if hr.Spec.Chart.Spec.SourceRef.Name != "metrics" {
+			t.Errorf("sourceRef.Name = %q, want metrics", hr.Spec.Chart.Spec.SourceRef.Name)
+		}
+	}
+}
+
+func TestHelmchartHandler_OCIRepository_Generate(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "cert-manager",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"version": "v1.17.2",
+			"source": map[string]any{
+				"kind": "OCIRepository",
+				"url":  "oci://ghcr.io/cert-manager/charts/cert-manager",
+			},
+		},
+	}, "cert-manager")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("cert-manager", "cert-manager", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(objects) != 2 {
+		t.Fatalf("expected 2 objects (OCIRepository + HelmRelease), got %d", len(objects))
+	}
+
+	if _, ok := (*objects[0]).(*sourcev1.OCIRepository); !ok {
+		t.Errorf("objects[0]: expected *sourcev1.OCIRepository, got %T", *objects[0])
+	}
+	hr, ok := (*objects[1]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Errorf("objects[1]: expected *helmv2.HelmRelease, got %T", *objects[1])
+	} else {
+		if hr.Spec.ChartRef == nil {
+			t.Fatal("HelmRelease.Spec.ChartRef is nil")
+		}
+		if hr.Spec.ChartRef.Kind != "OCIRepository" {
+			t.Errorf("chartRef.Kind = %q, want OCIRepository", hr.Spec.ChartRef.Kind)
+		}
+		if hr.Spec.ChartRef.Name != "cert-manager" {
+			t.Errorf("chartRef.Name = %q, want cert-manager", hr.Spec.ChartRef.Name)
+		}
+	}
+}
+
+func TestHelmchartHandler_SourceRef_ExistingHelmRepo(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "prometheus",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart":   "kube-prometheus-stack",
+			"version": "69.3.2",
+			"source": map[string]any{
+				"kind":      "HelmRepository",
+				"name":      "prometheus-community",
+				"namespace": "flux-system",
+			},
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("prometheus", "monitoring", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object (HelmRelease only, no source CR), got %d", len(objects))
+	}
+
+	hr, ok := (*objects[0]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("expected *helmv2.HelmRelease, got %T", *objects[0])
+	}
+	if hr.Spec.Chart == nil {
+		t.Fatal("HelmRelease.Spec.Chart is nil")
+	}
+	if hr.Spec.Chart.Spec.SourceRef.Kind != "HelmRepository" {
+		t.Errorf("sourceRef.Kind = %q, want HelmRepository", hr.Spec.Chart.Spec.SourceRef.Kind)
+	}
+	if hr.Spec.Chart.Spec.SourceRef.Name != "prometheus-community" {
+		t.Errorf("sourceRef.Name = %q, want prometheus-community", hr.Spec.Chart.Spec.SourceRef.Name)
+	}
+}
+
+func TestHelmchartHandler_SourceRef_ExistingChartRef(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "cert-manager",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"source": map[string]any{
+				"kind":      "HelmChart",
+				"name":      "cert-manager-chart",
+				"namespace": "flux-system",
+			},
+		},
+	}, "cert-manager")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("cert-manager", "cert-manager", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object (HelmRelease only), got %d", len(objects))
+	}
+
+	hr, ok := (*objects[0]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("expected *helmv2.HelmRelease, got %T", *objects[0])
+	}
+	if hr.Spec.ChartRef == nil {
+		t.Fatal("HelmRelease.Spec.ChartRef is nil")
+	}
+	if hr.Spec.ChartRef.Kind != "HelmChart" {
+		t.Errorf("chartRef.Kind = %q, want HelmChart", hr.Spec.ChartRef.Kind)
+	}
+	if hr.Spec.ChartRef.Name != "cert-manager-chart" {
+		t.Errorf("chartRef.Name = %q, want cert-manager-chart", hr.Spec.ChartRef.Name)
+	}
+}
+
+func TestHelmchartHandler_KindURLMismatch_Rejected(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cases := []struct {
+		name string
+		kind string
+		url  string
+	}{
+		{
+			name: "OCIRepository with https URL",
+			kind: "OCIRepository",
+			url:  "https://prometheus-community.github.io/helm-charts",
+		},
+		{
+			name: "HelmRepository with oci URL",
+			kind: "HelmRepository",
+			url:  "oci://ghcr.io/cert-manager/charts/cert-manager",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.ToApplicationConfig(&oam.Component{
+				Name: "metrics",
+				Type: "helmchart",
+				Properties: map[string]any{
+					"chart": "test-chart",
+					"source": map[string]any{
+						"kind": tc.kind,
+						"url":  tc.url,
+					},
+				},
+			}, "default")
+			if err == nil {
+				t.Fatal("expected error for kind/URL mismatch, got nil")
+			}
+		})
+	}
+}
+
+func TestHelmchartHandler_SourceDedup(t *testing.T) {
+	// Directly test dedup behavior on the config: set suppressSource and sharedSrcName,
+	// verify Generate() emits no source CR and HelmRelease references the shared name.
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart":   "kube-prometheus-stack",
+			"version": "69.3.2",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	dedup, ok := cfg.(interface {
+		SuppressSourceGeneration(string)
+		GetSourceKey() string
+		GetSourceRefName() string
+	})
+	if !ok {
+		t.Fatal("HelmchartConfig does not implement SourceDeduplicatable")
+	}
+
+	dedup.SuppressSourceGeneration("prometheus-community")
+
+	app := stack.NewApplication("metrics", "monitoring", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate after suppression: %v", err)
+	}
+
+	if len(objects) != 1 {
+		t.Fatalf("expected 1 object after dedup suppression, got %d", len(objects))
+	}
+
+	hr, ok := (*objects[0]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("expected HelmRelease, got %T", *objects[0])
+	}
+	if hr.Spec.Chart == nil {
+		t.Fatal("HelmRelease.Spec.Chart is nil")
+	}
+	if hr.Spec.Chart.Spec.SourceRef.Name != "prometheus-community" {
+		t.Errorf("sourceRef.Name = %q, want prometheus-community (shared source)", hr.Spec.Chart.Spec.SourceRef.Name)
+	}
+}
+
+func TestHelmchartHandler_DeliveryTemplate_Rejected(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart":    "kube-prometheus-stack",
+			"delivery": "template",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+		},
+	}, "monitoring")
+	if err == nil {
+		t.Fatal("expected error for delivery: template")
+	}
+}
+
+func TestHelmchartHandler_DefaultInterval(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	app := stack.NewApplication("metrics", "monitoring", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	hr, ok := (*objects[1]).(*helmv2.HelmRelease)
+	if !ok {
+		t.Fatalf("expected HelmRelease at objects[1], got %T", *objects[1])
+	}
+	if hr.Spec.Interval.Duration.String() != "10m0s" {
+		t.Errorf("interval = %q, want 10m0s (default)", hr.Spec.Interval.Duration.String())
+	}
+}
+
+func TestHelmchartHandler_SourceKindRequired_FormB(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"name": "existing-source",
+				// kind deliberately omitted
+			},
+		},
+	}, "monitoring")
+	if err == nil {
+		t.Fatal("expected error when source.kind is absent for Form B")
+	}
+}
+
+func TestHelmchartHandler_DriftDetectionMode_Validated(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+			"driftDetection": map[string]any{
+				"mode": "invalid-mode",
+			},
+		},
+	}, "monitoring")
+	if err == nil {
+		t.Fatal("expected error for invalid driftDetection.mode")
+	}
+}
+
+func TestHelmchartHandler_InstallCRDs_Validated(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+			"install": map[string]any{
+				"crds": "Bad",
+			},
+		},
+	}, "monitoring")
+	if err == nil {
+		t.Fatal("expected error for invalid install.crds")
+	}
+}
+
+func TestHelmchartHandler_UpgradeCRDs_Validated(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+			"upgrade": map[string]any{
+				"crds": "Bad",
+			},
+		},
+	}, "monitoring")
+	if err == nil {
+		t.Fatal("expected error for invalid upgrade.crds")
+	}
+}
+
+func TestHelmchartHandler_InvalidHelmRepositoryURL_Rejected(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	for _, url := range []string{"ftp://repo.example/charts", "not-a-url", "ssh://repo.example"} {
+		_, err := h.ToApplicationConfig(&oam.Component{
+			Name: "metrics",
+			Type: "helmchart",
+			Properties: map[string]any{
+				"chart": "kube-prometheus-stack",
+				"source": map[string]any{
+					"url": url,
+				},
+			},
+		}, "monitoring")
+		if err == nil {
+			t.Errorf("expected error for HelmRepository URL %q, got nil", url)
+		}
+	}
+}
+
+func TestHelmchartHandler_ValuesFrom_Validated(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cases := []struct {
+		name    string
+		vfEntry map[string]any
+	}{
+		{
+			name: "invalid kind",
+			vfEntry: map[string]any{
+				"kind": "BadKind",
+				"name": "my-config",
+			},
+		},
+		{
+			name: "missing name",
+			vfEntry: map[string]any{
+				"kind": "ConfigMap",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := h.ToApplicationConfig(&oam.Component{
+				Name: "metrics",
+				Type: "helmchart",
+				Properties: map[string]any{
+					"chart": "kube-prometheus-stack",
+					"source": map[string]any{
+						"url": "https://prometheus-community.github.io/helm-charts",
+					},
+					"valuesFrom": []any{tc.vfEntry},
+				},
+			}, "monitoring")
+			if err == nil {
+				t.Fatalf("expected error for valuesFrom case %q, got nil", tc.name)
+			}
+		})
+	}
+}

--- a/pkg/oam/classify.go
+++ b/pkg/oam/classify.go
@@ -11,7 +11,7 @@ var defaultTierMap = map[string]Tier{
 	"webservice":  TierApps,
 	"worker":      TierApps,
 	"cronjob":     TierApps,
-	"helmrelease": TierApps,
+	"helmchart":   TierApps,
 	"daemonset":   TierInfra,
 	"statefulset": TierApps,
 }

--- a/pkg/oam/classify_test.go
+++ b/pkg/oam/classify_test.go
@@ -37,7 +37,7 @@ func TestClassifyComponent_DefaultMap(t *testing.T) {
 		{"webservice", TierApps},
 		{"worker", TierApps},
 		{"cronjob", TierApps},
-		{"helmrelease", TierApps},
+		{"helmchart", TierApps},
 		{"statefulset", TierApps},
 		{"postgresql", TierServices},
 		{"daemonset", TierInfra},

--- a/pkg/oam/handler.go
+++ b/pkg/oam/handler.go
@@ -27,7 +27,8 @@ type CapabilityAware interface {
 // SourceDeduplicatable is an optional interface for ApplicationConfig types
 // that generate source CRDs (e.g. HelmRepository). The runtime uses it to
 // suppress duplicate source generation when multiple components share the
-// same source URL.
+// same source key (URL for HelmRepository, URL+version for OCIRepository);
+// first component wins.
 type SourceDeduplicatable interface {
 	GetSourceKey() string
 	GetSourceRefName() string

--- a/pkg/oam/parser_test.go
+++ b/pkg/oam/parser_test.go
@@ -743,7 +743,7 @@ metadata:
 spec:
   components:
   - name: cert-manager
-    type: helmrelease
+    type: helmchart
     properties:
       chart: cert-manager
     annotations:

--- a/pkg/oam/profile.go
+++ b/pkg/oam/profile.go
@@ -29,6 +29,10 @@ type ClusterProfileMetadata struct {
 
 // ClusterProfileSpec holds the capability bindings for a cluster.
 type ClusterProfileSpec struct {
+	// GitopsEngine selects which native GitOps delivery CRs are emitted for helmchart
+	// components. Accepted values: "fluxcd" (default). Empty string is normalized to
+	// "fluxcd" by ParseClusterProfile. Reserved for future ArgoCD support.
+	GitopsEngine string                       `yaml:"gitopsEngine,omitempty" json:"gitopsEngine,omitempty"`
 	Capabilities map[string]CapabilityBinding `yaml:"capabilities,omitempty" json:"capabilities,omitempty"`
 }
 

--- a/pkg/oam/profile_test.go
+++ b/pkg/oam/profile_test.go
@@ -151,3 +151,44 @@ metadata:
 		t.Fatal("expected error for invalid DNS name")
 	}
 }
+
+func TestParseClusterProfile_GitopsEngine(t *testing.T) {
+	cases := []struct {
+		name      string
+		engine    string
+		wantErr   bool
+		wantValue string
+	}{
+		{"absent defaults to fluxcd", "", false, "fluxcd"},
+		{"explicit fluxcd accepted", "fluxcd", false, "fluxcd"},
+		{"argocd rejected", "argocd", true, ""},
+		{"case-sensitive FLUXCD rejected", "FLUXCD", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engineField := ""
+			if tc.engine != "" {
+				engineField = "\n  gitopsEngine: " + tc.engine
+			}
+			data := []byte(`apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test-cluster
+spec:` + engineField + `
+`)
+			got, err := ParseClusterProfile(data)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for gitopsEngine %q, got nil", tc.engine)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Spec.GitopsEngine != tc.wantValue {
+				t.Errorf("GitopsEngine = %q, want %q", got.Spec.GitopsEngine, tc.wantValue)
+			}
+		})
+	}
+}

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -138,7 +138,8 @@ func (t *Transformer) EvaluateProfile(profile *ClusterProfile) (*ClusterProfile,
 		evaluated[key] = CapabilityBinding{Rendering: validated}
 	}
 	result := *profile
-	result.Spec = ClusterProfileSpec{Capabilities: evaluated}
+	result.Spec = profile.Spec           // copy all fields (future-proof: new fields survive automatically)
+	result.Spec.Capabilities = evaluated // overwrite only the evaluated capabilities
 	return &result, nil
 }
 
@@ -480,7 +481,8 @@ func (t *Transformer) applyTraits(app *Application, entries []componentEntry, bu
 // --- Helpers ---
 
 // deduplicateSourceRefs suppresses duplicate source CRD generation when multiple
-// components share the same source URL.
+// components share the same source key (URL for HelmRepository, URL+version for
+// OCIRepository); first component wins.
 func deduplicateSourceRefs(entries []componentEntry) {
 	seen := make(map[string]string) // sourceKey → sourceRefName
 	for _, entry := range entries {
@@ -607,7 +609,7 @@ var componentHealthCheckGVK = map[string]struct{ APIVersion, Kind string }{
 	"worker":      {"apps/v1", "Deployment"},
 	"statefulset": {"apps/v1", "StatefulSet"},
 	"daemonset":   {"apps/v1", "DaemonSet"},
-	"helmrelease": {"helm.toolkit.fluxcd.io/v2", "HelmRelease"},
+	"helmchart":   {"helm.toolkit.fluxcd.io/v2", "HelmRelease"},
 	"postgresql":  {"postgresql.cnpg.io/v1", "Cluster"},
 }
 

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -648,6 +648,68 @@ func TestEvaluateProfile_UnknownCapability_Passthrough(t *testing.T) {
 	}
 }
 
+func TestEvaluateProfile_GitopsEnginePreserved(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	// Must include at least one capability so EvaluateProfile reaches the spec-rebuild
+	// path (it returns early when Capabilities is empty, which would not catch the bug).
+	profile := &ClusterProfile{
+		Metadata: ClusterProfileMetadata{Name: "test"},
+		Spec: ClusterProfileSpec{
+			GitopsEngine: "fluxcd",
+			Capabilities: map[string]CapabilityBinding{
+				"unknown-cap": {Rendering: map[string]any{"k": "v"}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.GitopsEngine != "fluxcd" {
+		t.Errorf("GitopsEngine = %q, want %q", got.Spec.GitopsEngine, "fluxcd")
+	}
+}
+
+// dedupTrackingConfig implements ApplicationConfig and SourceDeduplicatable for dedup tests.
+type dedupTrackingConfig struct {
+	name       string
+	sourceKey  string
+	suppressed bool
+	sharedRef  string
+}
+
+func (c *dedupTrackingConfig) GetSourceKey() string     { return c.sourceKey }
+func (c *dedupTrackingConfig) GetSourceRefName() string { return c.name }
+func (c *dedupTrackingConfig) SuppressSourceGeneration(ref string) {
+	c.suppressed = true
+	c.sharedRef = ref
+}
+func (c *dedupTrackingConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+func TestTransform_HelmchartSourceDedup(t *testing.T) {
+	cfgA := &dedupTrackingConfig{name: "comp-a", sourceKey: "helm:https://example.com/charts"}
+	cfgB := &dedupTrackingConfig{name: "comp-b", sourceKey: "helm:https://example.com/charts"}
+
+	entries := []componentEntry{
+		{component: Component{Name: "comp-a"}, app: stack.NewApplication("comp-a", "default", cfgA)},
+		{component: Component{Name: "comp-b"}, app: stack.NewApplication("comp-b", "default", cfgB)},
+	}
+
+	deduplicateSourceRefs(entries)
+
+	if cfgA.suppressed {
+		t.Error("comp-a should not be suppressed (first component with this source key)")
+	}
+	if !cfgB.suppressed {
+		t.Error("comp-b should be suppressed (shares source key with comp-a)")
+	}
+	if cfgB.sharedRef != "comp-a" {
+		t.Errorf("comp-b.sharedRef = %q, want %q", cfgB.sharedRef, "comp-a")
+	}
+}
+
 func TestEvaluateProfile_NonVADHandler_Passthrough(t *testing.T) {
 	// A plain TraitHandler (no CapabilityAware, no ValidateAndApplyDefaults)
 	// is registered successfully; EvaluateProfile must pass its rendering through.

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -13,13 +13,13 @@ import (
 // SupportedAPIVersion is the only accepted apiVersion for Application documents.
 const SupportedAPIVersion = "launcher.gokure.dev/v1alpha1"
 
-// validComponentTypes is the Phase 1 set. Updated when Phase 2 handlers land.
+// validComponentTypes is the Phase 2 set. Updated when Phase 2 handlers land.
 var validComponentTypes = map[string]bool{
 	"webservice":  true,
 	"worker":      true,
 	"postgresql":  true,
 	"cronjob":     true,
-	"helmrelease": true,
+	"helmchart":   true,
 	"daemonset":   true,
 	"statefulset": true,
 }
@@ -191,6 +191,14 @@ func validateClusterProfile(profile *ClusterProfile) error {
 	if errs := validation.IsDNS1123Subdomain(profile.Metadata.Name); len(errs) > 0 {
 		return profileValidationError("metadata.name", fmt.Sprintf("metadata.name %q is not a valid DNS-1123 subdomain",
 			profile.Metadata.Name))
+	}
+	switch profile.Spec.GitopsEngine {
+	case "", "fluxcd":
+		// normalize the absent-field default
+		profile.Spec.GitopsEngine = "fluxcd"
+	default:
+		return profileValidationError("spec.gitopsEngine",
+			fmt.Sprintf("unsupported gitopsEngine %q; supported values: fluxcd", profile.Spec.GitopsEngine))
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #82, closes #84

## Summary

- **helmrelease → helmchart rename**: OAM component type renamed across validate.go, classify.go, transform.go, tests, and examples (#82)
- **gitopsEngine field** added to `ClusterProfileSpec`; validated (accepted: `fluxcd`); normalized to `"fluxcd"` at parse time; preserved by EvaluateProfile via copy-then-update (#84)
- **HelmchartHandler** implemented in `pkg/oam/builtin/components/helmchart.go`:
  - Form A (inline source): `source.url` → creates HelmRepository or OCIRepository CR + HelmRelease
  - Form B (reference): `source.name` → HelmRelease only, points to existing source CR
  - Source deduplication: HelmRepository key = URL; OCIRepository key = URL+version; first component wins
  - Validated at build time: delivery enum, source mutual exclusion, kind/URL scheme consistency, HelmRepository URL scheme (`https://` or `http://` required), chart requirement for HelmRepository mode, `driftDetection.mode`, `install.crds`, `upgrade.crds`, `valuesFrom[*].kind/name`
- **Registered** in kurel build command
- **3 golden fixture sets**: `helmchart-repository`, `helmchart-oci`, `helmchart-sourceref`
- **Docs updated**: `design-cluster-profile.md` (gitopsEngine), `design-kurel-package.md` (helmchart row with dedup key semantics), `design.md` (rename)

## Test plan

- [ ] `GOWORK=off go test ./pkg/oam/builtin/components/... -v -run TestHelmchart` — 18 unit tests
- [ ] `GOWORK=off go test ./pkg/cmd/kurel/... -run TestFixtures/helmchart` — 3 golden fixtures
- [ ] `GOWORK=off go test ./pkg/oam/... -run TestParseClusterProfile_GitopsEngine` — gitopsEngine validation
- [ ] `GOWORK=off go test ./pkg/oam/... -run TestEvaluateProfile_GitopsEnginePreserved` — regression for field preservation
- [ ] `GOWORK=off make precommit` — full lint + test suite