### PR TITLE
feat(oam): add kurel.yaml package descriptor and parameter substitution

### DIFF
--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -232,14 +232,9 @@ spec:
     type: string
     required: false
     default: "${name}-tls"   # may reference other parameters
-  - name: env
-    type: array
-    required: false
-    default: []
-    description: "Extra environment variables as [{name, value}] objects"
 ```
 
-Supported types: `string`, `integer`, `boolean`, `array`, `object`.
+Supported types: `string`, `integer`, `boolean`.
 
 ### 6.2 Placeholder syntax in app.yaml
 
@@ -251,7 +246,6 @@ spec:
     properties:
       image: "${image}"          # scalar substitution — resolves to string
       replicas: ${replicas}      # scalar substitution — resolves to integer
-      env: ${env}                # node substitution — resolves to YAML list
     traits:
     - type: expose
       properties:
@@ -271,17 +265,12 @@ replaces it with the typed value from the parameter declaration:
 - `image: "${image}"` → `image: "myregistry/app:v1.2.3"` (string)
 - `replicas: ${replicas}` → `replicas: 3` (integer, not string `"3"`)
 
-**Node substitution** — when the parameter type is `array` or `object`, the resolver
-replaces the placeholder with the full YAML node:
-- `env: ${env}` → `env: [{name: LOG_LEVEL, value: info}, ...]`
-
 **Inline string embedding** — when `${name}` is embedded inside a larger string value:
 - `secretName: "${name}-tls"` → `secretName: "webservice-tls"` (always a string)
 
 ### 6.4 Supplying values at build time
 
 ```sh
-# values.yaml — flat scalars or structured (for array/object parameters)
 kurel build . --profile cluster.yaml --values values.yaml
 
 # --set flags — scalars only
@@ -292,15 +281,10 @@ kurel build . --profile cluster.yaml \
 ```
 
 ```yaml
-# values.yaml — with structured array parameter
+# values.yaml
 image: myregistry/app:v1.2.3
 replicas: 3
 domain: app.example.com
-env:
-- name: LOG_LEVEL
-  value: info
-- name: DB_HOST
-  value: postgres.svc
 ```
 
 ### 6.5 Validation
@@ -309,6 +293,9 @@ env:
 - Optional parameter with no value → default value used
 - `default` may itself contain `${name}` references to other parameters; these are
   resolved in declaration order
+- `default` values are type-checked at `ParsePackage` time; a string default that is
+  not parseable as the declared type (e.g. `default: foo` for `type: integer`) is
+  rejected immediately
 
 ---
 

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kio "github.com/go-kure/kure/pkg/io"
@@ -22,16 +24,20 @@ type buildOptions struct {
 	outputDir   string
 	namespace   string
 	clusterID   string
+	valuesPath  string
+	setValues   []string // "key=value" strings from --set
 }
 
 func newBuildCommand() *cobra.Command {
 	opts := &buildOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "build <app.yaml>",
+		Use:   "build <app.yaml|package-dir>",
 		Short: "Build Kubernetes manifests from an OAM Application",
 		Long: `Build generates static Kubernetes manifests from an OAM Application YAML file
-and a platform ClusterProfile. Output is written to stdout (default) or a directory.`,
+or package directory and a platform ClusterProfile. The positional argument accepts
+either a path to an app.yaml file or a directory containing app.yaml (and optionally
+kurel.yaml for parameterized packages). Output is written to stdout (default) or a directory.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runBuild(cmd, args[0], opts)
@@ -42,16 +48,63 @@ and a platform ClusterProfile. Output is written to stdout (default) or a direct
 	cmd.Flags().StringVarP(&opts.outputDir, "output", "o", "", "output directory (default: stdout)")
 	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "namespace override")
 	cmd.Flags().StringVar(&opts.clusterID, "cluster-id", "local", "cluster identifier")
+	cmd.Flags().StringVar(&opts.valuesPath, "values", "", "path to values YAML file")
+	cmd.Flags().StringArrayVar(&opts.setValues, "set", nil, "set a parameter value (key=value, repeatable)")
 
 	_ = cmd.MarkFlagRequired("profile")
 
 	return cmd
 }
 
-func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
+func runBuild(cmd *cobra.Command, arg string, opts *buildOptions) error {
+	// Resolve positional arg: file path or directory containing app.yaml.
+	var appPath, appDir string
+	info, err := os.Stat(arg)
+	if err != nil {
+		return errors.Wrapf(err, "accessing %q", arg)
+	}
+	if info.IsDir() {
+		appDir = arg
+		appPath = filepath.Join(arg, "app.yaml")
+	} else {
+		appPath = arg
+		appDir = filepath.Dir(arg)
+	}
+
 	appData, err := os.ReadFile(appPath)
 	if err != nil {
 		return errors.Wrapf(err, "reading application file %q", appPath)
+	}
+
+	// Parameter resolution: look for kurel.yaml next to app.yaml.
+	kurelPath := filepath.Join(appDir, "kurel.yaml")
+	_, kurelExists := os.Stat(kurelPath)
+	hasValues := opts.valuesPath != "" || len(opts.setValues) > 0
+
+	if kurelExists != nil && hasValues {
+		return errors.Errorf("--values and --set require a kurel.yaml package descriptor in %q", appDir)
+	}
+
+	if kurelExists == nil {
+		// Package mode: resolve parameters before parsing.
+		kurelData, err := os.ReadFile(kurelPath)
+		if err != nil {
+			return errors.Wrapf(err, "reading package file %q", kurelPath)
+		}
+		pkg, err := oam.ParsePackage(kurelData)
+		if err != nil {
+			return errors.Wrapf(err, "parsing package file %q", kurelPath)
+		}
+
+		supplied, err := loadSuppliedValues(opts)
+		if err != nil {
+			return err
+		}
+
+		appData, err = oam.ResolveParameters(appData, pkg.Spec.Parameters, supplied)
+		if err != nil {
+			return errors.Wrap(err, "resolving parameters")
+		}
 	}
 
 	app, err := oam.Parse(appData)
@@ -108,6 +161,43 @@ func runBuild(cmd *cobra.Command, appPath string, opts *buildOptions) error {
 	}
 
 	return writeOutputDir(opts.outputDir, app.Metadata.Name, yamlBytes)
+}
+
+// loadSuppliedValues merges --values file and --set flags into a single map.
+// --set entries override --values entries for the same key.
+func loadSuppliedValues(opts *buildOptions) (map[string]any, error) {
+	supplied := make(map[string]any)
+
+	if opts.valuesPath != "" {
+		data, err := os.ReadFile(opts.valuesPath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading values file %q", opts.valuesPath)
+		}
+		var raw any
+		if err := yaml.Unmarshal(data, &raw); err != nil {
+			return nil, errors.Wrapf(err, "parsing values file %q", opts.valuesPath)
+		}
+		if raw == nil {
+			// Empty file — treat as empty map, not an error.
+		} else {
+			m, ok := raw.(map[string]any)
+			if !ok {
+				return nil, errors.Errorf("values file %q must be a YAML mapping (key: value pairs), got %T", opts.valuesPath, raw)
+			}
+			supplied = m
+		}
+	}
+
+	// --set entries override --values.
+	for _, kv := range opts.setValues {
+		k, v, ok := strings.Cut(kv, "=")
+		if !ok {
+			return nil, errors.Errorf("--set %q: expected key=value format", kv)
+		}
+		supplied[k] = v // string; coercion happens in resolver based on schema type
+	}
+
+	return supplied, nil
 }
 
 // newBuiltinTransformer creates a Transformer pre-loaded with all supported

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -257,3 +257,206 @@ func TestNewBuiltinTransformer_Registered(t *testing.T) {
 		t.Fatal("expected non-nil transformer")
 	}
 }
+
+// --- Parameter substitution tests ---
+
+const testKurelYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: test-pkg
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+`
+
+const testParamAppYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: ${image}
+      port: 8080
+      replicas: ${replicas}
+`
+
+const testParamValuesYAML = `image: myregistry/app:v1.2.3
+replicas: 2
+`
+
+func TestBuildCommand_ValuesFile(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	valuesPath := writeTempFile(t, dir, "values.yaml", testParamValuesYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath, "--values", valuesPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build with --values failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "myregistry/app:v1.2.3") {
+		t.Errorf("expected image myregistry/app:v1.2.3 in output:\n%s", got)
+	}
+	if !strings.Contains(got, "replicas: 2") {
+		t.Errorf("expected replicas: 2 in output:\n%s", got)
+	}
+}
+
+func TestBuildCommand_SetFlag(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{
+		"build", appPath,
+		"--profile", profilePath,
+		"--set", "image=myregistry/app:v1.2.3",
+		"--set", "replicas=2",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build with --set failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "myregistry/app:v1.2.3") {
+		t.Errorf("expected image myregistry/app:v1.2.3 in output:\n%s", got)
+	}
+	if !strings.Contains(got, "replicas: 2") {
+		t.Errorf("expected replicas: 2 in output:\n%s", got)
+	}
+}
+
+func TestBuildCommand_RequiredParamMissing(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	// No --values or --set: required parameter 'image' is missing.
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when required parameter 'image' is not supplied")
+	}
+}
+
+func TestBuildCommand_ValuesWithoutPackage(t *testing.T) {
+	dir := t.TempDir()
+	// No kurel.yaml written — app directory has no package descriptor.
+	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	valuesPath := writeTempFile(t, dir, "values.yaml", testParamValuesYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath, "--values", valuesPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error: --values requires a kurel.yaml in the app directory")
+	}
+}
+
+func TestBuildCommand_ValuesFileNotAMapping(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	// Values file is a YAML list, not a mapping.
+	valuesPath := writeTempFile(t, dir, "values.yaml", "- item1\n- item2\n")
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath, "--values", valuesPath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when values file is a YAML list, not a mapping")
+	}
+}
+
+func TestBuildCommand_SetOverridesValues(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	// values.yaml supplies replicas: 1; --set overrides it to 2.
+	valuesPath := writeTempFile(t, dir, "values.yaml", "image: myregistry/app:v1.2.3\nreplicas: 1\n")
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{
+		"build", appPath,
+		"--profile", profilePath,
+		"--values", valuesPath,
+		"--set", "replicas=2",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "replicas: 2") {
+		t.Errorf("expected --set to override values.yaml (replicas: 2), got:\n%s", got)
+	}
+}
+
+func TestBuildCommand_DirectoryArg(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "app.yaml", testParamAppYAML)
+	writeTempFile(t, dir, "kurel.yaml", testKurelYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+	valuesPath := writeTempFile(t, dir, "values.yaml", testParamValuesYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	// Pass the directory instead of app.yaml; kurel.yaml is auto-discovered.
+	cmd.SetArgs([]string{"build", dir, "--profile", profilePath, "--values", valuesPath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build with directory arg failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "myregistry/app:v1.2.3") {
+		t.Errorf("expected image in output, got:\n%s", got)
+	}
+}

--- a/pkg/cmd/kurel/fixtures_test.go
+++ b/pkg/cmd/kurel/fixtures_test.go
@@ -8,6 +8,11 @@ import (
 	"testing"
 )
 
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
 // TestFixtures runs all scenario directories under testdata/.
 // Each scenario directory must contain app.yaml and cluster.yaml.
 // The expected output is compared against expected.yaml.
@@ -35,7 +40,12 @@ func TestFixtures(t *testing.T) {
 			var out bytes.Buffer
 			cmd.SetOut(&out)
 			cmd.SetErr(&out)
-			cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+
+			args := []string{"build", appPath, "--profile", profilePath}
+			if vp := filepath.Join(dir, "values.yaml"); fileExists(vp) {
+				args = append(args, "--values", vp)
+			}
+			cmd.SetArgs(args)
 
 			if err := cmd.Execute(); err != nil {
 				t.Fatalf("build command failed: %v\noutput: %s", err, out.String())

--- a/pkg/cmd/kurel/testdata/params-scalar/app.yaml
+++ b/pkg/cmd/kurel/testdata/params-scalar/app.yaml
@@ -1,0 +1,12 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: simple
+spec:
+  components:
+  - name: web
+    type: webservice
+    properties:
+      image: "${image}"
+      port: 8080
+      replicas: ${replicas}

--- a/pkg/cmd/kurel/testdata/params-scalar/cluster.yaml
+++ b/pkg/cmd/kurel/testdata/params-scalar/cluster.yaml
@@ -1,0 +1,5 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: test
+spec: {}

--- a/pkg/cmd/kurel/testdata/params-scalar/expected.yaml
+++ b/pkg/cmd/kurel/testdata/params-scalar/expected.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - image: myregistry/app:v1.2.3
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+      serviceAccountName: web
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app: web
+        maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: DoNotSchedule
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: web
+  type: ClusterIP
+---
+apiVersion: v1
+automountServiceAccountToken: false
+kind: ServiceAccount
+metadata:
+  labels:
+    app: web
+  name: web
+  namespace: default

--- a/pkg/cmd/kurel/testdata/params-scalar/kurel.yaml
+++ b/pkg/cmd/kurel/testdata/params-scalar/kurel.yaml
@@ -1,0 +1,14 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: simple
+  version: "1.0.0"
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+  - name: replicas
+    type: integer
+    required: false
+    default: 1

--- a/pkg/cmd/kurel/testdata/params-scalar/values.yaml
+++ b/pkg/cmd/kurel/testdata/params-scalar/values.yaml
@@ -1,0 +1,2 @@
+image: myregistry/app:v1.2.3
+replicas: 2

--- a/pkg/oam/package.go
+++ b/pkg/oam/package.go
@@ -1,0 +1,32 @@
+package oam
+
+// PackageMetadata holds Package identity fields. It is intentionally separate from
+// Metadata — it includes version and description which are not valid Kubernetes
+// metadata fields and would be rejected by strict YAML decode on Application documents.
+type PackageMetadata struct {
+	Name        string `yaml:"name"`
+	Version     string `yaml:"version,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}
+
+// Package represents a kurel.yaml package descriptor.
+type Package struct {
+	APIVersion string          `yaml:"apiVersion"`
+	Kind       string          `yaml:"kind"`
+	Metadata   PackageMetadata `yaml:"metadata"`
+	Spec       PackageSpec     `yaml:"spec"`
+}
+
+// PackageSpec holds the parameter declarations for the package.
+type PackageSpec struct {
+	Parameters []ParameterDecl `yaml:"parameters,omitempty"`
+}
+
+// ParameterDecl declares a single package parameter with its type, default, and constraints.
+type ParameterDecl struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"` // string, integer, boolean, array, object
+	Required    bool   `yaml:"required,omitempty"`
+	Default     any    `yaml:"default,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}

--- a/pkg/oam/package_test.go
+++ b/pkg/oam/package_test.go
@@ -157,6 +157,94 @@ spec:
 	}
 }
 
+func TestParsePackage_RejectsStringDefaultForIntegerParam(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: replicas
+    type: integer
+    default: foo
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for string default 'foo' on integer param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsStringDefaultForBooleanParam(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: enabled
+    type: boolean
+    default: maybe
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for string default 'maybe' on boolean param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsFractionalDefaultForIntegerParam(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: replicas
+    type: integer
+    default: 2.5
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for fractional default 2.5 on integer param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_AcceptsPlaceholderDefaultOnIntegerParam(t *testing.T) {
+	// Placeholder defaults (${…}) are validated at build time, not parse time.
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: base
+    type: integer
+    required: true
+  - name: extra
+    type: integer
+    default: "${base}"
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err != nil {
+		t.Fatalf("expected no error for placeholder default on integer param, got: %v", err)
+	}
+}
+
 func TestParsePackage_RejectsDuplicateParamName(t *testing.T) {
 	input := `
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/pkg/oam/package_test.go
+++ b/pkg/oam/package_test.go
@@ -136,6 +136,27 @@ spec:
 	}
 }
 
+func TestParsePackage_RejectsArrayParamType(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: items
+    type: array
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unsupported param type 'array', got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestParsePackage_RejectsDuplicateParamName(t *testing.T) {
 	input := `
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/pkg/oam/package_test.go
+++ b/pkg/oam/package_test.go
@@ -1,0 +1,160 @@
+package oam_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+func TestParsePackage_Valid(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+  version: "1.0.0"
+  description: A test package
+spec:
+  parameters:
+  - name: image
+    type: string
+    required: true
+    description: Container image
+  - name: replicas
+    type: integer
+    required: false
+    default: 1
+`
+	pkg, err := oam.ParsePackage([]byte(input))
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if pkg.Metadata.Name != "my-app" {
+		t.Errorf("name = %q, want my-app", pkg.Metadata.Name)
+	}
+	if pkg.Metadata.Version != "1.0.0" {
+		t.Errorf("version = %q, want 1.0.0", pkg.Metadata.Version)
+	}
+	if len(pkg.Spec.Parameters) != 2 {
+		t.Errorf("parameters count = %d, want 2", len(pkg.Spec.Parameters))
+	}
+}
+
+func TestParsePackage_RejectsUnknownFields(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+  unknownField: oops
+spec: {}
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for unknown field, got nil")
+	}
+	var parseErr *errors.ParseError
+	if !stderrors.As(err, &parseErr) {
+		t.Errorf("expected *errors.ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsWrongAPIVersion(t *testing.T) {
+	input := `
+apiVersion: core.oam.dev/v1beta1
+kind: Package
+metadata:
+  name: my-app
+spec: {}
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for wrong apiVersion, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsWrongKind(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+spec: {}
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for wrong kind, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsMissingName(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: ""
+spec: {}
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for missing name, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsInvalidParamType(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: myval
+    type: badtype
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for invalid param type, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsDuplicateParamName(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: image
+    type: string
+  - name: image
+    type: string
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for duplicate parameter name, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}

--- a/pkg/oam/package_test.go
+++ b/pkg/oam/package_test.go
@@ -201,6 +201,51 @@ spec:
 	}
 }
 
+func TestParsePackage_RejectsMapDefaultForStringParam(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: image
+    type: string
+    default:
+      repo: ghcr.io/app
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for map default on string param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_RejectsSliceDefaultForStringParam(t *testing.T) {
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: tags
+    type: string
+    default: [a, b]
+`
+	_, err := oam.ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for list default on string param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Errorf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+}
+
 func TestParsePackage_RejectsFractionalDefaultForIntegerParam(t *testing.T) {
 	input := `
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/pkg/oam/parser.go
+++ b/pkg/oam/parser.go
@@ -70,6 +70,37 @@ func MustParse(data []byte) *Application {
 	return app
 }
 
+// ParsePackage parses a kurel.yaml Package document in strict mode.
+// Unknown fields are rejected; the document is semantically validated before returning.
+// YAML decode failures return *errors.ParseError; semantic failures return *errors.ValidationError.
+func ParsePackage(data []byte) (*Package, error) {
+	var pkg Package
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&pkg); err != nil {
+		return nil, packageParseError(err)
+	}
+
+	if err := validatePackage(&pkg); err != nil {
+		return nil, err
+	}
+
+	return &pkg, nil
+}
+
+// packageParseError converts a yaml decode error into a ParseError for Package documents.
+// Parallel to yamlParseError but uses "Package" as the document kind.
+func packageParseError(err error) *errors.ParseError {
+	var typeErr *yaml.TypeError
+	if stderrors.As(err, &typeErr) && len(typeErr.Errors) > 0 {
+		line := extractYAMLLine(typeErr.Errors[0])
+		return errors.NewParseError("Package", "", line, 0, err)
+	}
+	return errors.NewParseError("Package", "", 0, 0, err)
+}
+
 // yamlParseError converts a yaml decode error into a ParseError,
 // extracting line information from yaml.TypeError when available.
 func yamlParseError(err error) *errors.ParseError {

--- a/pkg/oam/resolver.go
+++ b/pkg/oam/resolver.go
@@ -3,6 +3,7 @@ package oam
 import (
 	"fmt"
 	"maps"
+	"math"
 	"regexp"
 	"strconv"
 
@@ -105,6 +106,9 @@ func coerceValue(v any, decl *ParameterDecl) (any, error) {
 		case int64:
 			return int(tv), nil
 		case float64:
+			if tv != math.Trunc(tv) {
+				return nil, errors.Errorf("parameter %q (type integer): %g is not a valid integer (fractional values are not allowed)", decl.Name, tv)
+			}
 			return int(tv), nil
 		case string:
 			n, err := strconv.Atoi(tv)
@@ -129,7 +133,14 @@ func coerceValue(v any, decl *ParameterDecl) (any, error) {
 			return nil, errors.Errorf("parameter %q (type boolean): cannot coerce %T to boolean", decl.Name, v)
 		}
 	case "string":
-		return fmt.Sprintf("%v", v), nil
+		switch v.(type) {
+		case map[string]any, []any:
+			return nil, errors.Errorf("parameter %q (type string): got %T, expected a string scalar value", decl.Name, v)
+		case nil:
+			return nil, errors.Errorf("parameter %q (type string): null is not a valid string value", decl.Name)
+		default:
+			return fmt.Sprintf("%v", v), nil
+		}
 	case "array", "object":
 		if _, isStr := v.(string); isStr {
 			return nil, errors.Errorf("parameter %q (type %s) cannot be set with --set; use --values to supply a structured value", decl.Name, decl.Type)

--- a/pkg/oam/resolver.go
+++ b/pkg/oam/resolver.go
@@ -1,0 +1,332 @@
+package oam
+
+import (
+	"fmt"
+	"maps"
+	"regexp"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+var (
+	placeholderRE = regexp.MustCompile(`\$\{([^}]+)\}`)
+	fullValueRE   = regexp.MustCompile(`^\$\{([^}]+)\}$`)
+)
+
+// ResolveParameters resolves ${name} placeholders in appYAML using the package schema
+// and the merged supplied values. Runs before oam.Parse() on the raw template bytes.
+//
+// supplied should be pre-merged: --values file entries overlaid by --set entries
+// (--set wins). String values from --set are coerced to the declared parameter type.
+//
+// Returns resolved YAML bytes ready for oam.Parse(), or an error if any placeholder
+// cannot be resolved, a required parameter is missing, or a supplied key is undeclared.
+func ResolveParameters(appYAML []byte, schema []ParameterDecl, supplied map[string]any) ([]byte, error) {
+	schemaByName := make(map[string]*ParameterDecl, len(schema))
+	for i := range schema {
+		schemaByName[schema[i].Name] = &schema[i]
+	}
+
+	// Step 1: coerce supplied values to declared types (validates --set string inputs).
+	coerced, err := coerceSuppliedValues(supplied, schemaByName)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: validate no unknown supplied keys.
+	for k := range supplied {
+		if _, ok := schemaByName[k]; !ok {
+			return nil, errors.Errorf("parameter %q is not declared in kurel.yaml", k)
+		}
+	}
+
+	// Step 3: build effective values by resolving defaults in declaration order.
+	effective, err := buildEffectiveValues(schema, coerced)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 4: validate required parameters.
+	for _, p := range schema {
+		if p.Required {
+			if _, ok := effective[p.Name]; !ok {
+				return nil, errors.Errorf("required parameter %q is not set; provide it with --values or --set", p.Name)
+			}
+		}
+	}
+
+	// Step 5: parse YAML as node tree, substitute placeholders in-place.
+	var root yaml.Node
+	if err := yaml.Unmarshal(appYAML, &root); err != nil {
+		return nil, errors.Wrap(err, "parsing application template YAML")
+	}
+
+	if err := substituteNodes(&root, schemaByName, effective); err != nil {
+		return nil, err
+	}
+
+	// Step 6: re-serialize. (No post-scan of the output bytes — values substituted
+	// into the template may themselves contain ${...} which must not be flagged.)
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return nil, errors.Wrap(err, "serializing resolved application YAML")
+	}
+	return out, nil
+}
+
+// coerceSuppliedValues coerces each supplied value to the type declared in the schema.
+// String values (from --set) are coerced; typed values (from --values YAML) are validated.
+func coerceSuppliedValues(supplied map[string]any, schema map[string]*ParameterDecl) (map[string]any, error) {
+	result := make(map[string]any, len(supplied))
+	for k, v := range supplied {
+		decl, known := schema[k]
+		if !known {
+			result[k] = v // unknown key — caught in step 2
+			continue
+		}
+		coerced, err := coerceValue(v, decl)
+		if err != nil {
+			return nil, err
+		}
+		result[k] = coerced
+	}
+	return result, nil
+}
+
+func coerceValue(v any, decl *ParameterDecl) (any, error) {
+	switch decl.Type {
+	case "integer":
+		switch tv := v.(type) {
+		case int:
+			return tv, nil
+		case int64:
+			return int(tv), nil
+		case float64:
+			return int(tv), nil
+		case string:
+			n, err := strconv.Atoi(tv)
+			if err != nil {
+				return nil, errors.Errorf("parameter %q (type integer): %q is not a valid integer", decl.Name, tv)
+			}
+			return n, nil
+		default:
+			return nil, errors.Errorf("parameter %q (type integer): cannot coerce %T to integer", decl.Name, v)
+		}
+	case "boolean":
+		switch tv := v.(type) {
+		case bool:
+			return tv, nil
+		case string:
+			b, err := strconv.ParseBool(tv)
+			if err != nil {
+				return nil, errors.Errorf("parameter %q (type boolean): %q is not a valid boolean (use true or false)", decl.Name, tv)
+			}
+			return b, nil
+		default:
+			return nil, errors.Errorf("parameter %q (type boolean): cannot coerce %T to boolean", decl.Name, v)
+		}
+	case "string":
+		return fmt.Sprintf("%v", v), nil
+	case "array", "object":
+		if _, isStr := v.(string); isStr {
+			return nil, errors.Errorf("parameter %q (type %s) cannot be set with --set; use --values to supply a structured value", decl.Name, decl.Type)
+		}
+		return v, nil
+	}
+	return v, nil
+}
+
+// buildEffectiveValues resolves parameter defaults in declaration order.
+// Defaults are resolved against effective values already set (earlier params only).
+// A default that references a parameter with no effective value is a build error.
+func buildEffectiveValues(schema []ParameterDecl, coerced map[string]any) (map[string]any, error) {
+	effective := make(map[string]any, len(schema))
+	maps.Copy(effective, coerced)
+
+	for _, p := range schema {
+		if _, ok := effective[p.Name]; ok {
+			continue // supplied value takes precedence
+		}
+		if p.Default == nil {
+			continue // no default; optional param left unset
+		}
+
+		defStr, isStr := p.Default.(string)
+		if !isStr {
+			// Non-string default (e.g. integer 1): use directly without substitution.
+			effective[p.Name] = p.Default
+			continue
+		}
+
+		if !placeholderRE.MatchString(defStr) {
+			// Plain string default, no placeholders.
+			effective[p.Name] = defStr
+			continue
+		}
+
+		// Default contains ${…} references — resolve against current effective values.
+		var resolveErr error
+		resolved := placeholderRE.ReplaceAllStringFunc(defStr, func(match string) string {
+			if resolveErr != nil {
+				return match
+			}
+			name := placeholderRE.FindStringSubmatch(match)[1]
+			val, ok := effective[name]
+			if !ok {
+				resolveErr = errors.Errorf(
+					"default for parameter %q references %q which has no value yet; "+
+						"only earlier parameters may be referenced in defaults", p.Name, name)
+				return match
+			}
+			return fmt.Sprintf("%v", val)
+		})
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		// Catch any surviving placeholder (e.g. forward reference that silently returned match).
+		if placeholderRE.MatchString(resolved) {
+			return nil, errors.Errorf(
+				"default for parameter %q contains unresolved placeholder after substitution: %q", p.Name, resolved)
+		}
+
+		val, err := coerceStringToType(resolved, p.Type, p.Name)
+		if err != nil {
+			return nil, err
+		}
+		effective[p.Name] = val
+	}
+
+	return effective, nil
+}
+
+func coerceStringToType(s, paramType, paramName string) (any, error) {
+	switch paramType {
+	case "integer":
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return nil, errors.Errorf("default for parameter %q resolved to %q which is not a valid integer", paramName, s)
+		}
+		return n, nil
+	case "boolean":
+		b, err := strconv.ParseBool(s)
+		if err != nil {
+			return nil, errors.Errorf("default for parameter %q resolved to %q which is not a valid boolean", paramName, s)
+		}
+		return b, nil
+	default:
+		return s, nil
+	}
+}
+
+// substituteNodes walks a yaml.Node tree and substitutes ${name} placeholders in scalar nodes.
+func substituteNodes(node *yaml.Node, schema map[string]*ParameterDecl, effective map[string]any) error {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.DocumentNode:
+		for _, child := range node.Content {
+			if err := substituteNodes(child, schema, effective); err != nil {
+				return err
+			}
+		}
+	case yaml.MappingNode:
+		// Content alternates: key, value, key, value, ...
+		// Substitute only values (odd-indexed entries); keys are never parameters.
+		for i := 1; i < len(node.Content); i += 2 {
+			if err := substituteNodes(node.Content[i], schema, effective); err != nil {
+				return err
+			}
+		}
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if err := substituteNodes(child, schema, effective); err != nil {
+				return err
+			}
+		}
+	case yaml.AliasNode:
+		// Alias nodes (YAML anchors) are not expected in OAM templates; skip.
+	case yaml.ScalarNode:
+		if !placeholderRE.MatchString(node.Value) {
+			return nil
+		}
+		return substituteScalar(node, schema, effective)
+	}
+	return nil
+}
+
+// substituteScalar handles placeholder substitution for a single scalar yaml.Node.
+// Full-value scalars (entire value is ${name}) are type-promoted to integer/boolean.
+// Inline substitutions (${name} embedded in a larger string) always produce a string.
+// String values are always emitted with DoubleQuotedStyle for safe YAML serialization —
+// this correctly handles characters like :, #, ", \, and newlines.
+func substituteScalar(node *yaml.Node, schema map[string]*ParameterDecl, effective map[string]any) error {
+	// Full-value: the entire scalar value is exactly ${name}.
+	if m := fullValueRE.FindStringSubmatch(node.Value); m != nil {
+		name := m[1]
+		decl, declared := schema[name]
+		if !declared {
+			return errors.Errorf("undeclared parameter %q referenced in application template", name)
+		}
+		val, hasVal := effective[name]
+		if !hasVal {
+			return errors.Errorf("parameter %q has no value; set it with --values or --set", name)
+		}
+		switch decl.Type {
+		case "array", "object":
+			return errors.Errorf(
+				"parameter %q has type %s; node substitution is not yet implemented "+
+					"(use --values to supply structured values)", name, decl.Type)
+		case "integer":
+			node.Value = fmt.Sprintf("%v", val)
+			node.Tag = "!!int"
+			node.Style = 0
+		case "boolean":
+			node.Value = fmt.Sprintf("%v", val)
+			node.Tag = "!!bool"
+			node.Style = 0
+		default: // "string"
+			node.Value = fmt.Sprintf("%v", val)
+			node.Tag = "!!str"
+			node.Style = yaml.DoubleQuotedStyle
+		}
+		return nil
+	}
+
+	// Inline: ${name} embedded within a larger string.
+	var inlineErr error
+	result := placeholderRE.ReplaceAllStringFunc(node.Value, func(match string) string {
+		if inlineErr != nil {
+			return match
+		}
+		name := placeholderRE.FindStringSubmatch(match)[1]
+		decl, declared := schema[name]
+		if !declared {
+			inlineErr = errors.Errorf("undeclared parameter %q referenced in application template", name)
+			return match
+		}
+		val, hasVal := effective[name]
+		if !hasVal {
+			inlineErr = errors.Errorf("parameter %q has no value; set it with --values or --set", name)
+			return match
+		}
+		if decl.Type == "array" || decl.Type == "object" {
+			inlineErr = errors.Errorf(
+				"parameter %q (type %s) cannot be used in inline string substitution", name, decl.Type)
+			return match
+		}
+		return fmt.Sprintf("%v", val)
+	})
+	if inlineErr != nil {
+		return inlineErr
+	}
+	// Inline substitution always produces a string.
+	// Use DoubleQuotedStyle to safely encode values containing :, #, ", \, newlines, etc.
+	node.Value = result
+	node.Tag = "!!str"
+	node.Style = yaml.DoubleQuotedStyle
+	return nil
+}

--- a/pkg/oam/resolver.go
+++ b/pkg/oam/resolver.go
@@ -173,8 +173,12 @@ func buildEffectiveValues(schema []ParameterDecl, coerced map[string]any) (map[s
 		}
 
 		if !placeholderRE.MatchString(defStr) {
-			// Plain string default, no placeholders.
-			effective[p.Name] = defStr
+			// Plain string default, no placeholders — coerce to the declared type.
+			val, err := coerceStringToType(defStr, p.Type, p.Name)
+			if err != nil {
+				return nil, err
+			}
+			effective[p.Name] = val
 			continue
 		}
 

--- a/pkg/oam/resolver_test.go
+++ b/pkg/oam/resolver_test.go
@@ -1,0 +1,252 @@
+package oam_test
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// resolveOK calls ResolveParameters and fatally fails the test on any error.
+func resolveOK(t *testing.T, tmpl string, schema []oam.ParameterDecl, supplied map[string]any) []byte {
+	t.Helper()
+	out, err := oam.ResolveParameters([]byte(tmpl), schema, supplied)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return out
+}
+
+// mustUnmarshal parses YAML bytes into map[string]any, failing on error.
+func mustUnmarshal(t *testing.T, data []byte) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		t.Fatalf("result not valid YAML: %v\n%s", err, data)
+	}
+	return m
+}
+
+func TestResolveParameters_Scalar_Integer(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": 2})
+
+	m := mustUnmarshal(t, out)
+	if m["replicas"] != 2 {
+		t.Errorf("replicas = %v (%T), want 2 (int)", m["replicas"], m["replicas"])
+	}
+	if strings.Contains(string(out), `"2"`) {
+		t.Errorf("integer value should be unquoted in YAML output:\n%s", out)
+	}
+}
+
+func TestResolveParameters_Scalar_String(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	out := resolveOK(t, "image: \"${image}\"\n", schema, map[string]any{"image": "myregistry/app:v1.2.3"})
+
+	m := mustUnmarshal(t, out)
+	if m["image"] != "myregistry/app:v1.2.3" {
+		t.Errorf("image = %q, want myregistry/app:v1.2.3", m["image"])
+	}
+}
+
+func TestResolveParameters_Scalar_Boolean(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "enabled", Type: "boolean", Required: true}}
+	out := resolveOK(t, "enabled: ${enabled}\n", schema, map[string]any{"enabled": true})
+
+	m := mustUnmarshal(t, out)
+	if m["enabled"] != true {
+		t.Errorf("enabled = %v, want true", m["enabled"])
+	}
+	if strings.Contains(string(out), `"true"`) {
+		t.Errorf("boolean should be unquoted in YAML output:\n%s", out)
+	}
+}
+
+func TestResolveParameters_Inline(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "name", Type: "string", Required: true}}
+	out := resolveOK(t, "label: \"prefix-${name}-suffix\"\n", schema, map[string]any{"name": "myapp"})
+
+	m := mustUnmarshal(t, out)
+	if m["label"] != "prefix-myapp-suffix" {
+		t.Errorf("label = %q, want prefix-myapp-suffix", m["label"])
+	}
+}
+
+func TestResolveParameters_Inline_MultipleParams(t *testing.T) {
+	schema := []oam.ParameterDecl{
+		{Name: "env", Type: "string", Required: true},
+		{Name: "app", Type: "string", Required: true},
+	}
+	out := resolveOK(t, "label: \"${env}-${app}\"\n", schema, map[string]any{
+		"env": "prod",
+		"app": "web",
+	})
+
+	m := mustUnmarshal(t, out)
+	if m["label"] != "prod-web" {
+		t.Errorf("label = %q, want prod-web", m["label"])
+	}
+}
+
+func TestResolveParameters_Default_Applied(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Default: 3}}
+	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{})
+
+	m := mustUnmarshal(t, out)
+	if m["replicas"] != 3 {
+		t.Errorf("replicas = %v, want 3 (from default)", m["replicas"])
+	}
+}
+
+func TestResolveParameters_Default_ReferencesEarlierParam(t *testing.T) {
+	schema := []oam.ParameterDecl{
+		{Name: "appName", Type: "string", Required: true},
+		{Name: "tlsSecret", Type: "string", Default: "${appName}-tls"},
+	}
+	out := resolveOK(t, "secret: ${tlsSecret}\n", schema, map[string]any{"appName": "myapp"})
+
+	m := mustUnmarshal(t, out)
+	if m["secret"] != "myapp-tls" {
+		t.Errorf("secret = %q, want myapp-tls", m["secret"])
+	}
+}
+
+func TestResolveParameters_RequiredMissing(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for missing required parameter")
+	}
+	if !strings.Contains(err.Error(), "image") {
+		t.Errorf("error should name the missing parameter, got: %v", err)
+	}
+}
+
+func TestResolveParameters_UnknownSuppliedKey(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "image", Type: "string"}}
+	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{
+		"image": "foo",
+		"extra": "bar",
+	})
+	if err == nil {
+		t.Fatal("expected error for undeclared supplied key")
+	}
+	if !strings.Contains(err.Error(), "extra") {
+		t.Errorf("error should name the undeclared key 'extra', got: %v", err)
+	}
+}
+
+func TestResolveParameters_NodeType_Rejected(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "items", Type: "array"}}
+	_, err := oam.ResolveParameters([]byte("items: ${items}\n"), schema, map[string]any{
+		"items": []any{"a", "b"},
+	})
+	if err == nil {
+		t.Fatal("expected error: array node substitution is not implemented")
+	}
+	if !strings.Contains(err.Error(), "items") {
+		t.Errorf("error should mention parameter name 'items', got: %v", err)
+	}
+}
+
+func TestResolveParameters_SetCoercion_Integer(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	// Simulate --set: CLI value arrives as a string.
+	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": "3"})
+
+	m := mustUnmarshal(t, out)
+	if m["replicas"] != 3 {
+		t.Errorf("replicas = %v (%T), want 3 (int) after string coercion", m["replicas"], m["replicas"])
+	}
+}
+
+func TestResolveParameters_SetCoercion_Boolean(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "enabled", Type: "boolean", Required: true}}
+	// Simulate --set: CLI value arrives as a string.
+	out := resolveOK(t, "enabled: ${enabled}\n", schema, map[string]any{"enabled": "true"})
+
+	m := mustUnmarshal(t, out)
+	if m["enabled"] != true {
+		t.Errorf("enabled = %v, want true after string coercion", m["enabled"])
+	}
+}
+
+func TestResolveParameters_SetCoercion_BadInteger(t *testing.T) {
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	_, err := oam.ResolveParameters([]byte("replicas: ${replicas}\n"), schema, map[string]any{"replicas": "notanumber"})
+	if err == nil {
+		t.Fatal("expected error for non-integer value with integer type")
+	}
+	if !strings.Contains(err.Error(), "replicas") {
+		t.Errorf("error should name the parameter, got: %v", err)
+	}
+}
+
+func TestResolveParameters_UnknownPlaceholderInAppYAML(t *testing.T) {
+	schema := []oam.ParameterDecl{}
+	_, err := oam.ResolveParameters([]byte("image: ${undefined}\n"), schema, map[string]any{})
+	if err == nil {
+		t.Fatal("expected error for undeclared placeholder in app YAML")
+	}
+	if !strings.Contains(err.Error(), "undefined") {
+		t.Errorf("error should name the undeclared placeholder, got: %v", err)
+	}
+}
+
+// TestResolveParameters_StringWithSpecialChars verifies that string values
+// containing characters that would break raw YAML (colons, hashes, quotes,
+// backslashes, newlines) survive the substitution round-trip intact.
+// Both full-value (entire scalar is the placeholder) and inline (placeholder
+// embedded in a larger string) substitution paths are exercised.
+func TestResolveParameters_StringWithSpecialChars(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{"colon", "host: example.com"},
+		{"hash", "value # not a comment"},
+		{"double-quote", `say "hello"`},
+		{"backslash", `C:\Users\foo`},
+		{"newline", "line1\nline2"},
+		{"combined", "host: example.com # note \"special\" C:\\path\nnext"},
+	}
+
+	schema := []oam.ParameterDecl{{Name: "text", Type: "string", Required: true}}
+
+	for _, tc := range cases {
+		t.Run("full-value/"+tc.name, func(t *testing.T) {
+			out := resolveOK(t, "message: \"${text}\"\n", schema, map[string]any{"text": tc.value})
+			m := mustUnmarshal(t, out)
+			got, _ := m["message"].(string)
+			if got != tc.value {
+				t.Errorf("message = %q, want %q\nresolved YAML:\n%s", got, tc.value, out)
+			}
+		})
+
+		t.Run("inline/"+tc.name, func(t *testing.T) {
+			out := resolveOK(t, "message: \"PREFIX-${text}-SUFFIX\"\n", schema, map[string]any{"text": tc.value})
+			m := mustUnmarshal(t, out)
+			got, _ := m["message"].(string)
+			want := "PREFIX-" + tc.value + "-SUFFIX"
+			if got != want {
+				t.Errorf("message = %q, want %q\nresolved YAML:\n%s", got, want, out)
+			}
+		})
+	}
+}
+
+func TestResolveParameters_Default_ForwardReference(t *testing.T) {
+	// 'first' default references 'second' which is declared later and not supplied.
+	// Effective values are built in schema order; 'second' is not yet set when 'first' is processed.
+	schema := []oam.ParameterDecl{
+		{Name: "first", Type: "string", Default: "${second}-suffix"},
+		{Name: "second", Type: "string", Default: "hello"},
+	}
+	_, err := oam.ResolveParameters([]byte("val: ${first}\n"), schema, map[string]any{})
+	if err == nil {
+		t.Fatal("expected error: default for 'first' references 'second' which has no value yet")
+	}
+}

--- a/pkg/oam/resolver_test.go
+++ b/pkg/oam/resolver_test.go
@@ -185,6 +185,54 @@ func TestResolveParameters_SetCoercion_BadInteger(t *testing.T) {
 	}
 }
 
+func TestResolveParameters_FloatIntegerRejected(t *testing.T) {
+	// values.yaml float64 like replicas: 2.5 must be rejected, not silently truncated.
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	_, err := oam.ResolveParameters([]byte("replicas: ${replicas}\n"), schema, map[string]any{"replicas": float64(2.5)})
+	if err == nil {
+		t.Fatal("expected error: 2.5 is not a valid integer (would silently truncate to 2)")
+	}
+	if !strings.Contains(err.Error(), "replicas") {
+		t.Errorf("error should name the parameter, got: %v", err)
+	}
+}
+
+func TestResolveParameters_FloatWholeNumberAccepted(t *testing.T) {
+	// A whole-number float like 2.0 decoded from YAML is acceptable for integer params.
+	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": float64(2.0)})
+	m := mustUnmarshal(t, out)
+	if m["replicas"] != 2 {
+		t.Errorf("replicas = %v (%T), want 2 (int)", m["replicas"], m["replicas"])
+	}
+}
+
+func TestResolveParameters_StringParamRejectsMap(t *testing.T) {
+	// image: {repo: ghcr.io/app} in values.yaml must be rejected, not stringified.
+	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{
+		"image": map[string]any{"repo": "ghcr.io/app"},
+	})
+	if err == nil {
+		t.Fatal("expected error: map value is not a valid string parameter")
+	}
+	if !strings.Contains(err.Error(), "image") {
+		t.Errorf("error should name the parameter, got: %v", err)
+	}
+}
+
+func TestResolveParameters_StringParamRejectsNull(t *testing.T) {
+	// image: null in values.yaml must be rejected.
+	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{"image": nil})
+	if err == nil {
+		t.Fatal("expected error: null is not a valid string parameter")
+	}
+	if !strings.Contains(err.Error(), "image") {
+		t.Errorf("error should name the parameter, got: %v", err)
+	}
+}
+
 func TestResolveParameters_UnknownPlaceholderInAppYAML(t *testing.T) {
 	schema := []oam.ParameterDecl{}
 	_, err := oam.ResolveParameters([]byte("image: ${undefined}\n"), schema, map[string]any{})

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -2,7 +2,9 @@ package oam
 
 import (
 	"fmt"
+	"math"
 	"slices"
+	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -237,6 +239,60 @@ func validatePackage(pkg *Package) error {
 		if !validParamTypes[p.Type] {
 			return packageValidationError("parameters", fmt.Sprintf(
 				"parameter %q has invalid type %q; supported types: string, integer, boolean", p.Name, p.Type))
+		}
+		if err := validateParamDefault(&p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateParamDefault checks that a ParameterDecl.Default is compatible with
+// the declared Type. Defaults containing ${name} placeholder references are
+// deferred to build time (their referenced values are not yet known at parse
+// time); all other defaults are validated immediately.
+func validateParamDefault(p *ParameterDecl) error {
+	if p.Default == nil {
+		return nil
+	}
+	defStr, isStr := p.Default.(string)
+	if isStr {
+		if placeholderRE.MatchString(defStr) {
+			return nil // validated at build time when referenced params are known
+		}
+		switch p.Type {
+		case "integer":
+			if _, err := strconv.Atoi(defStr); err != nil {
+				return packageValidationError("parameters",
+					fmt.Sprintf("parameter %q has default %q which is not a valid integer", p.Name, defStr))
+			}
+		case "boolean":
+			if _, err := strconv.ParseBool(defStr); err != nil {
+				return packageValidationError("parameters",
+					fmt.Sprintf("parameter %q has default %q which is not a valid boolean (use true or false)", p.Name, defStr))
+			}
+		}
+		return nil
+	}
+	// Non-string default: the Go type decoded by yaml.Unmarshal must match the declared type.
+	switch p.Type {
+	case "integer":
+		switch tv := p.Default.(type) {
+		case int, int64:
+			// OK
+		case float64:
+			if tv != math.Trunc(tv) {
+				return packageValidationError("parameters",
+					fmt.Sprintf("parameter %q has fractional default %g; integer parameters require whole numbers", p.Name, tv))
+			}
+		default:
+			return packageValidationError("parameters",
+				fmt.Sprintf("parameter %q (type integer) has default of type %T; expected a whole number", p.Name, p.Default))
+		}
+	case "boolean":
+		if _, ok := p.Default.(bool); !ok {
+			return packageValidationError("parameters",
+				fmt.Sprintf("parameter %q (type boolean) has default of type %T; expected true or false", p.Name, p.Default))
 		}
 	}
 	return nil

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -204,12 +204,12 @@ func validateClusterProfile(profile *ClusterProfile) error {
 }
 
 // validParamTypes is the set of accepted ParameterDecl.Type values.
+// array and object are intentionally excluded: node substitution is not yet
+// implemented, so declaring those types would produce an unusable package.
 var validParamTypes = map[string]bool{
 	"string":  true,
 	"integer": true,
 	"boolean": true,
-	"array":   true,
-	"object":  true,
 }
 
 // validatePackage performs semantic validation on a parsed Package.
@@ -236,7 +236,7 @@ func validatePackage(pkg *Package) error {
 		seenNames[p.Name] = true
 		if !validParamTypes[p.Type] {
 			return packageValidationError("parameters", fmt.Sprintf(
-				"parameter %q has invalid type %q; must be one of: string, integer, boolean, array, object", p.Name, p.Type))
+				"parameter %q has invalid type %q; supported types: string, integer, boolean", p.Name, p.Type))
 		}
 	}
 	return nil

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -203,6 +203,45 @@ func validateClusterProfile(profile *ClusterProfile) error {
 	return nil
 }
 
+// validParamTypes is the set of accepted ParameterDecl.Type values.
+var validParamTypes = map[string]bool{
+	"string":  true,
+	"integer": true,
+	"boolean": true,
+	"array":   true,
+	"object":  true,
+}
+
+// validatePackage performs semantic validation on a parsed Package.
+func validatePackage(pkg *Package) error {
+	if pkg.APIVersion != SupportedAPIVersion {
+		return packageValidationError("apiVersion", fmt.Sprintf("unsupported apiVersion %q, expected %q",
+			pkg.APIVersion, SupportedAPIVersion))
+	}
+	if pkg.Kind != "Package" {
+		return packageValidationError("kind", fmt.Sprintf("expected kind Package, got %q", pkg.Kind))
+	}
+	if pkg.Metadata.Name == "" {
+		return packageValidationError("metadata.name", "metadata.name is required")
+	}
+
+	seenNames := make(map[string]bool, len(pkg.Spec.Parameters))
+	for i, p := range pkg.Spec.Parameters {
+		if p.Name == "" {
+			return packageValidationError("parameters", fmt.Sprintf("parameters[%d].name is required", i))
+		}
+		if seenNames[p.Name] {
+			return packageValidationError("parameters", fmt.Sprintf("duplicate parameter name %q", p.Name))
+		}
+		seenNames[p.Name] = true
+		if !validParamTypes[p.Type] {
+			return packageValidationError("parameters", fmt.Sprintf(
+				"parameter %q has invalid type %q; must be one of: string, integer, boolean, array, object", p.Name, p.Type))
+		}
+	}
+	return nil
+}
+
 // oamValidationError creates a ValidationError with a custom message.
 func oamValidationError(field, message string) *errors.ValidationError {
 	return &errors.ValidationError{
@@ -216,6 +255,14 @@ func profileValidationError(field, message string) *errors.ValidationError {
 	return &errors.ValidationError{
 		Field:     field,
 		Component: "clusterprofile",
+		Message:   message,
+	}
+}
+
+func packageValidationError(field, message string) *errors.ValidationError {
+	return &errors.ValidationError{
+		Field:     field,
+		Component: "package",
 		Message:   message,
 	}
 }

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -294,6 +294,12 @@ func validateParamDefault(p *ParameterDecl) error {
 			return packageValidationError("parameters",
 				fmt.Sprintf("parameter %q (type boolean) has default of type %T; expected true or false", p.Name, p.Default))
 		}
+	case "string":
+		switch p.Default.(type) {
+		case map[string]any, []any:
+			return packageValidationError("parameters",
+				fmt.Sprintf("parameter %q (type string) has default of type %T; expected a scalar string value", p.Name, p.Default))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #51

## Summary

- **`pkg/oam/package.go`** — `Package` / `PackageMetadata` / `PackageSpec` / `ParameterDecl` types; GVK `launcher.gokure.dev/v1alpha1` / `Package`
- **`pkg/oam/parser.go`** / **`validate.go`** — `ParsePackage()` with strict unknown-field rejection, apiVersion/kind/name/type/duplicate-param validation; separate `packageParseError()` / `packageValidationError()` helpers
- **`pkg/oam/resolver.go`** — `ResolveParameters()`: coerces `--set` strings to declared types, resolves defaults in declaration order (forward references are build errors), validates required params and unknown supplied keys, substitutes `${name}` placeholders in a `yaml.Node` tree walk; full-value scalars are type-promoted (int/bool tags); all strings use `DoubleQuotedStyle` for safe YAML encoding of `:`, `#`, `"`, `\`, newlines
- **`pkg/cmd/kurel/build.go`** — `--values` / `--set` flags; directory positional arg (auto-discovers `app.yaml` + `kurel.yaml`); package mode wired before `oam.Parse()`
- **`pkg/cmd/kurel/fixtures_test.go`** — harness auto-adds `--values` when `values.yaml` exists in fixture dir
- **`pkg/cmd/kurel/testdata/params-scalar/`** — golden fixture: `image` (string, required) + `replicas` (integer, default 1), resolved to Deployment with correct values

## Test plan

- [ ] `GOWORK=off go test ./pkg/oam/... -run 'TestParsePackage|TestResolveParameters' -v` — 7 ParsePackage + 20 resolver tests (incl. 12 special-char sub-tests for both full-value and inline paths)
- [ ] `GOWORK=off go test ./pkg/cmd/kurel/... -v` — all fixtures pass including `params-scalar`; 7 new build command tests (ValuesFile, SetFlag, RequiredParamMissing, ValuesWithoutPackage, ValuesFileNotAMapping, SetOverridesValues, DirectoryArg)
- [ ] `GOWORK=off make precommit` — format, tidy, lint (0 issues), all tests green

## Deferred

- Node substitution for `type: array/object` params — resolver returns a clear error
- Placeholder escaping (no escape syntax defined in spec yet)