### PR TITLE
feat: allow routing traits on helmchart components via explicit servicePort

### DIFF
--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -49,6 +49,31 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 		ComponentName: app.Name,
 	}
 
+	// Trait-level explicit backend — same semantics as ingress: servicePort first,
+	// then serviceName; both guarded against components with a known service port.
+	traitPortProvided := false
+	defaultServiceName := resolveServiceName(app)
+	if _, hasServicePort := props["servicePort"]; hasServicePort {
+		sp, ok := toIngressPort(props["servicePort"])
+		if !ok {
+			return nil, errors.Errorf("servicePort must be a valid port number (1–65535)")
+		}
+		if existingPort := resolveDefaultPort(app); existingPort > 0 {
+			return nil, errors.Errorf(
+				"servicePort may not be set on a component that already exposes service port %d; "+
+					"use backendRef-level 'port' or an explicit 'name' instead",
+				existingPort)
+		}
+		defaultPort = sp
+		traitPortProvided = true
+	}
+	if sn, ok := props["serviceName"].(string); ok && sn != "" {
+		if !traitPortProvided {
+			return nil, errors.Errorf("serviceName requires a valid servicePort to also be set on the trait")
+		}
+		defaultServiceName = sn
+	}
+
 	// Optional: name (for multiple httproute traits on the same component)
 	if name, ok := props["name"].(string); ok && name != "" {
 		config.Name = name
@@ -165,7 +190,7 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				// nameExplicit is true only when the backendRef names a DIFFERENT service
 				// than the component's own. A self-reference is treated as implicit so
 				// the same port-mismatch guard applies.
-				selfServiceName := resolveServiceName(app)
+				selfServiceName := defaultServiceName
 				nameExplicit := false
 				br := BackendRef{
 					Name: selfServiceName,
@@ -189,8 +214,10 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 					br.Port = 0
 				}
 				if !nameExplicit {
-					if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].backendRefs[%d]", i, j)); err != nil {
-						return nil, err
+					if !traitPortProvided {
+						if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].backendRefs[%d]", i, j)); err != nil {
+							return nil, err
+						}
 					}
 					if portExplicit && br.Port != defaultPort {
 						return nil, errors.Errorf(
@@ -207,15 +234,17 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 			}
 		} else {
 			// Default: single backend pointing to the component's service
-			if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d]", i)); err != nil {
-				return nil, err
+			if !traitPortProvided {
+				if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d]", i)); err != nil {
+					return nil, err
+				}
 			}
 			if defaultPort == 0 {
 				return nil, errors.Errorf(
 					"rules[%d]: cannot determine backend port for component %q — configure the component port or specify backendRefs[].port",
 					i, app.Name)
 			}
-			rule.BackendRefs = []BackendRef{{Name: resolveServiceName(app), Port: defaultPort}}
+			rule.BackendRefs = []BackendRef{{Name: defaultServiceName, Port: defaultPort}}
 		}
 
 		// Optional: filters

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -1061,3 +1061,95 @@ func TestHTTPRouteHandler_ImplicitBackend_PortMismatch_Error(t *testing.T) {
 		}
 	})
 }
+
+// --- HTTPRouteHandler trait-level servicePort/serviceName (helmchart support) ---
+
+func TestHTTPRouteHandler_TraitLevel_ServicePort_Success(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	// nil config = no servicePortProvider (simulates helmchart)
+	app := stack.NewApplication("myapp", "default", nil)
+	cfg, err := h.parseProperties(map[string]any{
+		"servicePort": float64(8080),
+		"parentRefs":  []any{map[string]any{"name": "gw"}},
+		"rules":       []any{map[string]any{}},
+	}, app)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if cfg.Rules[0].BackendRefs[0].Port != 8080 {
+		t.Errorf("Port = %d, want 8080", cfg.Rules[0].BackendRefs[0].Port)
+	}
+	if cfg.Rules[0].BackendRefs[0].Name != "myapp" {
+		t.Errorf("Name = %q, want %q", cfg.Rules[0].BackendRefs[0].Name, "myapp")
+	}
+}
+
+func TestHTTPRouteHandler_TraitLevel_ServiceNameAndPort_Success(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("myapp", "default", nil)
+	cfg, err := h.parseProperties(map[string]any{
+		"serviceName": "my-chart-svc",
+		"servicePort": float64(8080),
+		"parentRefs":  []any{map[string]any{"name": "gw"}},
+		"rules":       []any{map[string]any{}},
+	}, app)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if cfg.Rules[0].BackendRefs[0].Name != "my-chart-svc" {
+		t.Errorf("Name = %q, want %q", cfg.Rules[0].BackendRefs[0].Name, "my-chart-svc")
+	}
+	if cfg.Rules[0].BackendRefs[0].Port != 8080 {
+		t.Errorf("Port = %d, want 8080", cfg.Rules[0].BackendRefs[0].Port)
+	}
+}
+
+func TestHTTPRouteHandler_TraitLevel_ServiceNameWithoutPort_Errors(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("myapp", "default", nil)
+	_, err := h.parseProperties(map[string]any{
+		"serviceName": "my-svc",
+		"parentRefs":  []any{map[string]any{"name": "gw"}},
+		"rules":       []any{map[string]any{}},
+	}, app)
+	if err == nil {
+		t.Fatal("expected error when serviceName set without servicePort")
+	}
+	if !strings.Contains(err.Error(), "serviceName requires a valid servicePort") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPRouteHandler_TraitLevel_InvalidServicePort_Errors(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("myapp", "default", nil)
+	for _, badPort := range []any{"oops", float64(70000), float64(0)} {
+		_, err := h.parseProperties(map[string]any{
+			"servicePort": badPort,
+			"parentRefs":  []any{map[string]any{"name": "gw"}},
+			"rules":       []any{map[string]any{}},
+		}, app)
+		if err == nil {
+			t.Fatalf("expected error for invalid servicePort %v", badPort)
+		}
+		if !strings.Contains(err.Error(), "valid port number") {
+			t.Errorf("unexpected error for port %v: %v", badPort, err)
+		}
+	}
+}
+
+func TestHTTPRouteHandler_TraitLevel_ServicePort_RejectedOnKnownPortComponent(t *testing.T) {
+	h := &HTTPRouteHandler{}
+	app := stack.NewApplication("myapp", "default", &mockServicePortConfig{port: 80})
+	_, err := h.parseProperties(map[string]any{
+		"servicePort": float64(8080),
+		"parentRefs":  []any{map[string]any{"name": "gw"}},
+		"rules":       []any{map[string]any{}},
+	}, app)
+	if err == nil {
+		t.Fatal("expected error when servicePort set on component with known service port")
+	}
+	if !strings.Contains(err.Error(), "may not be set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -48,7 +48,8 @@ func checkImplicitBackend(app *stack.Application, location string) error {
 	pp, ok := app.Config.(servicePortProvider)
 	if !ok || pp.ServicePort() == 0 {
 		return errors.Errorf(
-			"%s: component %q has no service port; configure a service port or specify an explicit backend name",
+			"%s: component %q has no service port; configure a service port or specify an explicit backend name"+
+				" (for helmchart components, set servicePort and optionally serviceName on the trait)",
 			location, app.Name)
 	}
 	return nil
@@ -92,6 +93,31 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 	config := &IngressConfig{
 		ComponentName: app.Name,
 		ServiceName:   resolveServiceName(app),
+	}
+
+	// Trait-level explicit backend — allows routing traits on component types that do not
+	// implement servicePortProvider (e.g. helmchart). servicePort is parsed first so that
+	// an invalid value is rejected before serviceName can be honoured.
+	traitPortProvided := false
+	if _, hasServicePort := props["servicePort"]; hasServicePort {
+		sp, ok := toIngressPort(props["servicePort"])
+		if !ok {
+			return nil, errors.Errorf("servicePort must be a valid port number (1–65535)")
+		}
+		if existingPort := resolveDefaultPort(app); existingPort > 0 {
+			return nil, errors.Errorf(
+				"servicePort may not be set on a component that already exposes service port %d; "+
+					"use path-level 'port' or 'backend' overrides instead",
+				existingPort)
+		}
+		defaultPort = sp
+		traitPortProvided = true
+	}
+	if sn, ok := props["serviceName"].(string); ok && sn != "" {
+		if !traitPortProvided {
+			return nil, errors.Errorf("serviceName requires a valid servicePort to also be set on the trait")
+		}
+		config.ServiceName = sn
 	}
 
 	if name, ok := props["name"].(string); ok && name != "" {
@@ -186,8 +212,10 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 			// Implicit backend: empty name OR explicit name that resolves to the component's
 			// own service — both are subject to the same port constraints.
 			if p.ServiceName == "" || p.ServiceName == config.ServiceName {
-				if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].paths[%d]", i, j)); err != nil {
-					return nil, err
+				if !traitPortProvided {
+					if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].paths[%d]", i, j)); err != nil {
+						return nil, err
+					}
 				}
 				if portExplicit && p.Port > 0 && p.Port != defaultPort {
 					return nil, errors.Errorf(

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -2051,3 +2051,138 @@ func TestIngressHandler_Apply_ImplicitBackend_PortMismatch_Error(t *testing.T) {
 		}
 	})
 }
+
+// --- IngressHandler trait-level servicePort/serviceName (helmchart support) ---
+
+func TestIngressHandler_TraitLevel_ServicePort_Success(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"servicePort": float64(8080),
+			"rules": []any{
+				map[string]any{
+					"host":  "app.example.com",
+					"paths": []any{map[string]any{"path": "/"}},
+				},
+			},
+		},
+	}
+	// newApp creates a component with no servicePortProvider (simulates helmchart)
+	app := newApp("myapp", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("expected success with trait-level servicePort, got: %v", err)
+	}
+	ic, ok := bundle.Applications[0].Config.(*traits.IngressConfig)
+	if !ok {
+		t.Fatal("expected IngressConfig")
+	}
+	if ic.Rules[0].Paths[0].Port != 8080 {
+		t.Errorf("expected port 8080, got %d", ic.Rules[0].Paths[0].Port)
+	}
+}
+
+func TestIngressHandler_TraitLevel_ServiceNameAndPort_Success(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"serviceName": "my-chart-svc",
+			"servicePort": float64(8080),
+			"rules": []any{
+				map[string]any{
+					"host":  "app.example.com",
+					"paths": []any{map[string]any{"path": "/"}},
+				},
+			},
+		},
+	}
+	app := newApp("myapp", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	ic, ok := bundle.Applications[0].Config.(*traits.IngressConfig)
+	if !ok {
+		t.Fatal("expected IngressConfig")
+	}
+	if ic.ServiceName != "my-chart-svc" {
+		t.Errorf("expected ServiceName 'my-chart-svc', got %q", ic.ServiceName)
+	}
+}
+
+func TestIngressHandler_TraitLevel_ServiceNameWithoutPort_Errors(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"serviceName": "my-svc",
+			"rules": []any{
+				map[string]any{
+					"host":  "app.example.com",
+					"paths": []any{map[string]any{"path": "/"}},
+				},
+			},
+		},
+	}
+	app := newApp("myapp", "default")
+	err := h.Apply(trait, app, newBundle())
+	if err == nil {
+		t.Fatal("expected error when serviceName set without servicePort")
+	}
+	if !strings.Contains(err.Error(), "serviceName requires a valid servicePort") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIngressHandler_TraitLevel_InvalidServicePort_Errors(t *testing.T) {
+	h := &traits.IngressHandler{}
+	for _, badPort := range []any{"oops", float64(70000), float64(0)} {
+		trait := &oam.Trait{
+			Type: "ingress",
+			Properties: map[string]any{
+				"servicePort": badPort,
+				"rules": []any{
+					map[string]any{
+						"host":  "app.example.com",
+						"paths": []any{map[string]any{"path": "/"}},
+					},
+				},
+			},
+		}
+		app := newApp("myapp", "default")
+		err := h.Apply(trait, app, newBundle())
+		if err == nil {
+			t.Fatalf("expected error for invalid servicePort %v", badPort)
+		}
+		if !strings.Contains(err.Error(), "valid port number") {
+			t.Errorf("unexpected error for port %v: %v", badPort, err)
+		}
+	}
+}
+
+func TestIngressHandler_TraitLevel_ServicePort_RejectedOnKnownPortComponent(t *testing.T) {
+	h := &traits.IngressHandler{}
+	trait := &oam.Trait{
+		Type: "ingress",
+		Properties: map[string]any{
+			"servicePort": float64(8080),
+			"rules": []any{
+				map[string]any{
+					"host":  "app.example.com",
+					"paths": []any{map[string]any{"path": "/"}},
+				},
+			},
+		},
+	}
+	// newWebApp creates a component with servicePortProvider (port 80)
+	app := newWebApp("myapp", "default")
+	err := h.Apply(trait, app, newBundle())
+	if err == nil {
+		t.Fatal("expected error when servicePort set on component with known service port")
+	}
+	if !strings.Contains(err.Error(), "may not be set") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Closes #89
- Adds trait-level `servicePort` (required) and `serviceName` (optional) properties to ingress, expose, and httproute traits
- When set, the `servicePortProvider` check is bypassed so helmchart components — which expose no declared Service port — can participate in ingress and HTTPRoute routing
- `expose` passes props through unchanged, so the feature works via all three trait types

## Guards

- `servicePort` is parsed first; an invalid value or a value set on a component that already exposes a known port is rejected with a clear error
- `serviceName` is only honoured alongside a valid `servicePort` (prevents silently routing a different service through the component's inherited port)
- Existing "no service port" behavior is unchanged for components without `servicePortProvider` and without trait-level `servicePort`

## Test plan

- [ ] `TestIngressHandler_TraitLevel_ServicePort_Success` — helmchart-like component + `servicePort` → success, correct port in output
- [ ] `TestIngressHandler_TraitLevel_ServiceNameAndPort_Success` — both props → success, custom service name
- [ ] `TestIngressHandler_TraitLevel_ServiceNameWithoutPort_Errors` — `serviceName` without `servicePort` → error
- [ ] `TestIngressHandler_TraitLevel_InvalidServicePort_Errors` — invalid port values → error
- [ ] `TestIngressHandler_TraitLevel_ServicePort_RejectedOnKnownPortComponent` — component with known port → error
- [ ] Parallel httproute tests
- [ ] Existing "no service port" tests unchanged