### PR TITLE
feat(oam): CapabilityDefinition schema for custom trait rendering (#66)

### DIFF
--- a/examples/cluster-profiles/custom-capability.yaml
+++ b/examples/cluster-profiles/custom-capability.yaml
@@ -1,0 +1,17 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: staging-with-redis-sidecar
+spec:
+  capabilities:
+    expose:
+      rendering:
+        controllerType: ingress
+        ingressClassName: nginx
+    # Rendering values for the custom redis-sidecar trait.
+    # The definitions/redis-sidecar.yaml CapabilityDefinition validates
+    # these keys and applies defaults for absent optional properties.
+    redis-sidecar:
+      rendering:
+        image: redis:7-alpine
+        maxMemory: "512Mi"

--- a/examples/custom-capability/app.yaml
+++ b/examples/custom-capability/app.yaml
@@ -1,0 +1,21 @@
+apiVersion: core.oam.dev/v1beta1
+kind: Application
+metadata:
+  name: my-app
+spec:
+  components:
+  - name: api
+    type: webservice
+    properties:
+      image: myorg/api:latest
+      port: 8080
+    traits:
+    - type: expose
+      properties:
+        port: 8080
+    # redis-sidecar is a custom trait implemented by the downstream consumer's
+    # handler. The rendering values (image, maxMemory, port) come from the
+    # ClusterProfile capability binding; the definitions/redis-sidecar.yaml
+    # schema validates those values at build time.
+    - type: redis-sidecar
+      properties: {}

--- a/examples/custom-capability/definitions/redis-sidecar.yaml
+++ b/examples/custom-capability/definitions/redis-sidecar.yaml
@@ -1,0 +1,23 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  # metadata.name IS the trait type — matches the trait type used in app.yaml.
+  name: redis-sidecar
+spec:
+  description: "Injects a Redis sidecar container alongside the main workload."
+  rendering:
+    properties:
+      image:
+        type: string
+        required: true
+        description: "Redis image reference, e.g. redis:7"
+      maxMemory:
+        type: string
+        required: false
+        default: "256Mi"
+        description: "Memory limit for the Redis sidecar container"
+      port:
+        type: integer
+        required: false
+        default: 6379
+        description: "Port the Redis sidecar listens on"

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -20,12 +20,14 @@ import (
 )
 
 type buildOptions struct {
-	profilePath string
-	outputDir   string
-	namespace   string
-	clusterID   string
-	valuesPath  string
-	setValues   []string // "key=value" strings from --set
+	profilePath        string
+	outputDir          string
+	namespace          string
+	clusterID          string
+	valuesPath         string
+	setValues          []string // "key=value" strings from --set
+	capabilityDefPaths []string
+	strictCapabilities bool
 }
 
 func newBuildCommand() *cobra.Command {
@@ -50,6 +52,8 @@ kurel.yaml for parameterized packages). Output is written to stdout (default) or
 	cmd.Flags().StringVar(&opts.clusterID, "cluster-id", "local", "cluster identifier")
 	cmd.Flags().StringVar(&opts.valuesPath, "values", "", "path to values YAML file")
 	cmd.Flags().StringArrayVar(&opts.setValues, "set", nil, "set a parameter value (key=value, repeatable)")
+	cmd.Flags().StringArrayVar(&opts.capabilityDefPaths, "capability-def", nil, "CapabilityDefinition file (repeatable)")
+	cmd.Flags().BoolVar(&opts.strictCapabilities, "strict-capabilities", false, "error instead of warn on unvalidated custom capabilities")
 
 	_ = cmd.MarkFlagRequired("profile")
 
@@ -123,6 +127,16 @@ func runBuild(cmd *cobra.Command, arg string, opts *buildOptions) error {
 	}
 
 	transformer := newBuiltinTransformer()
+
+	capDefs, err := oam.LoadCapabilityDefinitions(opts.capabilityDefPaths, filepath.Join(appDir, "definitions"))
+	if err != nil {
+		return errors.Wrap(err, "loading capability definitions")
+	}
+	transformer.SetCapabilityDefs(capDefs)
+	transformer.SetStrictCapabilities(opts.strictCapabilities)
+	transformer.SetWarningHandler(func(msg string) {
+		_, _ = fmt.Fprintln(cmd.ErrOrStderr(), "warning:", msg)
+	})
 
 	evaluatedProfile, err := transformer.EvaluateProfile(profile)
 	if err != nil {
@@ -203,7 +217,7 @@ func loadSuppliedValues(opts *buildOptions) (map[string]any, error) {
 // newBuiltinTransformer creates a Transformer pre-loaded with all supported
 // built-in component and trait handlers.
 func newBuiltinTransformer() *oam.Transformer {
-	return oam.NewTransformer(
+	t := oam.NewTransformer(
 		map[string]oam.ComponentHandler{
 			"webservice":  &components.WebserviceHandler{},
 			"worker":      &components.WorkerHandler{},
@@ -213,20 +227,20 @@ func newBuiltinTransformer() *oam.Transformer {
 			"postgresql":  &components.PostgresqlHandler{},
 			"helmchart":   &components.HelmchartHandler{},
 		},
-		map[string]oam.TraitHandler{
-			"expose":               &traits.ExposeHandler{},
-			"ingress":              &traits.IngressHandler{},
-			"httproute":            &traits.HTTPRouteHandler{},
-			"certificate":          &traits.CertificateHandler{},
-			"scaler":               &traits.ScalerHandler{},
-			"pvc":                  &traits.PVCHandler{},
-			"external-secret":      &traits.ExternalSecretHandler{},
-			"configmap":            &traits.ConfigMapHandler{},
-			"networkpolicy":        &traits.NetworkPolicyHandler{},
-			"cilium-networkpolicy": &traits.CiliumNetworkPolicyHandler{},
-			"volsync":              &traits.VolSyncHandler{},
-		},
+		nil,
 	)
+	t.RegisterBuiltinTrait("expose", &traits.ExposeHandler{})
+	t.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+	t.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+	t.RegisterBuiltinTrait("certificate", &traits.CertificateHandler{})
+	t.RegisterBuiltinTrait("scaler", &traits.ScalerHandler{})
+	t.RegisterBuiltinTrait("pvc", &traits.PVCHandler{})
+	t.RegisterBuiltinTrait("external-secret", &traits.ExternalSecretHandler{})
+	t.RegisterBuiltinTrait("configmap", &traits.ConfigMapHandler{})
+	t.RegisterBuiltinTrait("networkpolicy", &traits.NetworkPolicyHandler{})
+	t.RegisterBuiltinTrait("cilium-networkpolicy", &traits.CiliumNetworkPolicyHandler{})
+	t.RegisterBuiltinTrait("volsync", &traits.VolSyncHandler{})
+	return t
 }
 
 // collectFromNode walks the node tree and collects all generated client.Objects

--- a/pkg/oam/capability.go
+++ b/pkg/oam/capability.go
@@ -1,0 +1,190 @@
+package oam
+
+import (
+	"bytes"
+	"maps"
+	"os"
+	"path/filepath"
+	"reflect"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+const (
+	capabilityDefAPIVersion = "launcher.gokure.dev/v1alpha1"
+	capabilityDefKind       = "CapabilityDefinition"
+)
+
+var acceptedPropertyTypes = map[string]bool{
+	"string":  true,
+	"integer": true,
+	"boolean": true,
+}
+
+// kindProbe reads just the kind field from a YAML document for routing.
+type kindProbe struct {
+	Kind string `yaml:"kind"`
+}
+
+// LoadCapabilityDefinitions loads CapabilityDefinition documents from explicit
+// paths and from *.yaml files in definitionsDir ("" = skip auto-discovery).
+// Only files with kind: CapabilityDefinition are processed; other kinds are skipped.
+// Each definition file is parsed with strict YAML (KnownFields) to reject unknown fields.
+// Semantic validation:
+//   - apiVersion must equal "launcher.gokure.dev/v1alpha1"
+//   - metadata.name is required (non-empty)
+//   - spec.rendering.properties entry types: accepted values are "string", "integer", "boolean"
+//   - default value (if set) must be assignable to the declared type
+//
+// Identical definitions (same name + same spec) are deduplicated silently.
+// Conflicting definitions (same name, different spec) return an error naming both files.
+// A missing definitionsDir is not an error.
+func LoadCapabilityDefinitions(paths []string, definitionsDir string) (map[string]*CapabilityDefinition, error) {
+	allFiles := make([]string, len(paths))
+	copy(allFiles, paths)
+
+	if definitionsDir != "" {
+		entries, err := os.ReadDir(definitionsDir)
+		if err != nil && !os.IsNotExist(err) {
+			return nil, errors.Wrapf(err, "reading definitions directory %q", definitionsDir)
+		}
+		for _, e := range entries {
+			if !e.IsDir() && filepath.Ext(e.Name()) == ".yaml" {
+				allFiles = append(allFiles, filepath.Join(definitionsDir, e.Name()))
+			}
+		}
+	}
+
+	defs := make(map[string]*CapabilityDefinition)
+	sources := make(map[string]string) // name → file path (for conflict reporting)
+
+	for _, filePath := range allFiles {
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "reading capability definition file %q", filePath)
+		}
+
+		// Probe the kind field to decide whether to load this file.
+		// A YAML parse failure here means the file is malformed — fail loudly so
+		// the operator knows their schema file was never loaded.
+		var probe kindProbe
+		if err := yaml.Unmarshal(data, &probe); err != nil {
+			return nil, errors.Wrapf(err, "capability definition file %q: failed to parse YAML", filePath)
+		}
+		if probe.Kind != capabilityDefKind {
+			continue
+		}
+
+		// Strict parse — reject unknown fields.
+		dec := yaml.NewDecoder(bytes.NewReader(data))
+		dec.KnownFields(true)
+		var def CapabilityDefinition
+		if err := dec.Decode(&def); err != nil {
+			return nil, errors.Wrapf(err, "parsing capability definition file %q", filePath)
+		}
+
+		if def.APIVersion != capabilityDefAPIVersion {
+			return nil, errors.Errorf(
+				"capability definition file %q: apiVersion must be %q, got %q",
+				filePath, capabilityDefAPIVersion, def.APIVersion)
+		}
+		if def.Metadata.Name == "" {
+			return nil, errors.Errorf("capability definition file %q: metadata.name is required", filePath)
+		}
+
+		for propName, propSchema := range def.Spec.Rendering.Properties {
+			if propSchema.Type != "" && !acceptedPropertyTypes[propSchema.Type] {
+				return nil, errors.Errorf(
+					"capability definition file %q: property %q has unsupported type %q (accepted: string, integer, boolean)",
+					filePath, propName, propSchema.Type)
+			}
+			if propSchema.Default != nil {
+				if err := checkCapabilityValueType(propSchema.Default, propSchema.Type); err != nil {
+					return nil, errors.Errorf(
+						"capability definition file %q: property %q default value: %s",
+						filePath, propName, err)
+				}
+			}
+		}
+
+		name := def.Metadata.Name
+		if existing, ok := defs[name]; ok {
+			if reflect.DeepEqual(existing.Spec, def.Spec) {
+				continue // identical — silently deduplicate
+			}
+			return nil, errors.Errorf(
+				"conflicting CapabilityDefinition for %q: defined in %q and %q",
+				name, sources[name], filePath)
+		}
+
+		defs[name] = &def
+		sources[name] = filePath
+	}
+
+	return defs, nil
+}
+
+// applyDefinitionSchema validates rendering against a CapabilityDefinition schema and
+// applies declared defaults for absent optional properties.
+// Enforces: required fields present; types match declared type; no unknown keys.
+// Returns an updated rendering map (with defaults applied) or an error.
+func applyDefinitionSchema(rendering map[string]any, def *CapabilityDefinition) (map[string]any, error) {
+	props := def.Spec.Rendering.Properties
+
+	for k := range rendering {
+		if _, ok := props[k]; !ok {
+			return nil, errors.Errorf("unknown rendering property %q", k)
+		}
+	}
+
+	result := make(map[string]any, len(rendering))
+	maps.Copy(result, rendering)
+
+	for propName, propSchema := range props {
+		v, present := result[propName]
+		if !present {
+			if propSchema.Required {
+				return nil, errors.Errorf("required rendering property %q is missing", propName)
+			}
+			if propSchema.Default != nil {
+				result[propName] = propSchema.Default
+			}
+			continue
+		}
+		if propSchema.Type != "" {
+			if err := checkCapabilityValueType(v, propSchema.Type); err != nil {
+				return nil, errors.Errorf("rendering property %q: %s", propName, err)
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// checkCapabilityValueType returns an error if v is not compatible with typeName.
+func checkCapabilityValueType(v any, typeName string) error {
+	switch typeName {
+	case "string":
+		if _, ok := v.(string); !ok {
+			return errors.Errorf("expected string, got %T", v)
+		}
+	case "integer":
+		switch n := v.(type) {
+		case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+			_ = n
+		case float64:
+			if n != float64(int64(n)) {
+				return errors.Errorf("expected integer, got non-integer float %v", n)
+			}
+		default:
+			return errors.Errorf("expected integer, got %T", v)
+		}
+	case "boolean":
+		if _, ok := v.(bool); !ok {
+			return errors.Errorf("expected boolean, got %T", v)
+		}
+	}
+	return nil
+}

--- a/pkg/oam/capability_test.go
+++ b/pkg/oam/capability_test.go
@@ -1,0 +1,326 @@
+package oam
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadCapabilityDefinitions_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "custom.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+  description: "a custom trait"
+  rendering:
+    properties:
+      timeout:
+        type: integer
+        required: true
+      mode:
+        type: string
+        default: auto
+`)
+	defs, err := LoadCapabilityDefinitions(nil, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(defs) != 1 {
+		t.Fatalf("expected 1 definition, got %d", len(defs))
+	}
+	def, ok := defs["my-trait"]
+	if !ok {
+		t.Fatal("expected definition for 'my-trait'")
+	}
+	if def.Spec.Description != "a custom trait" {
+		t.Errorf("description = %q, want %q", def.Spec.Description, "a custom trait")
+	}
+	if _, ok := def.Spec.Rendering.Properties["timeout"]; !ok {
+		t.Error("expected property 'timeout'")
+	}
+}
+
+func TestLoadCapabilityDefinitions_SkipsOtherKinds(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "profile.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: staging
+spec:
+  capabilities: {}
+`)
+	defs, err := LoadCapabilityDefinitions(nil, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(defs) != 0 {
+		t.Errorf("expected 0 definitions, got %d", len(defs))
+	}
+}
+
+func TestLoadCapabilityDefinitions_MissingDirNotError(t *testing.T) {
+	defs, err := LoadCapabilityDefinitions(nil, "/nonexistent/path/that/does/not/exist")
+	if err != nil {
+		t.Fatalf("unexpected error for missing dir: %v", err)
+	}
+	if len(defs) != 0 {
+		t.Errorf("expected 0 definitions, got %d", len(defs))
+	}
+}
+
+func TestLoadCapabilityDefinitions_DeduplicatesIdentical(t *testing.T) {
+	dir := t.TempDir()
+	body := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+  rendering:
+    properties:
+      key:
+        type: string
+`
+	writeFile(t, filepath.Join(dir, "a.yaml"), body)
+	writeFile(t, filepath.Join(dir, "b.yaml"), body)
+
+	defs, err := LoadCapabilityDefinitions(nil, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(defs) != 1 {
+		t.Errorf("expected 1 definition after dedup, got %d", len(defs))
+	}
+}
+
+func TestLoadCapabilityDefinitions_ConflictErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+  rendering:
+    properties:
+      key:
+        type: string
+`)
+	writeFile(t, filepath.Join(dir, "b.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+  rendering:
+    properties:
+      key:
+        type: integer
+`)
+	_, err := LoadCapabilityDefinitions(nil, dir)
+	if err == nil {
+		t.Fatal("expected error for conflicting definitions")
+	}
+}
+
+func TestLoadCapabilityDefinitions_WrongAPIVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), `
+apiVersion: wrong.group/v1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec: {}
+`)
+	_, err := LoadCapabilityDefinitions(nil, dir)
+	if err == nil {
+		t.Fatal("expected error for wrong apiVersion")
+	}
+}
+
+func TestLoadCapabilityDefinitions_MissingName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: ""
+spec: {}
+`)
+	_, err := LoadCapabilityDefinitions(nil, dir)
+	if err == nil {
+		t.Fatal("expected error for missing metadata.name")
+	}
+}
+
+func TestLoadCapabilityDefinitions_UnsupportedPropertyType(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+  rendering:
+    properties:
+      key:
+        type: number
+`)
+	_, err := LoadCapabilityDefinitions(nil, dir)
+	if err == nil {
+		t.Fatal("expected error for unsupported property type")
+	}
+}
+
+func TestLoadCapabilityDefinitions_MalformedYAML_Errors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "bad.yaml"), `
+kind: CapabilityDefinition
+: this is not valid yaml {[
+`)
+	_, err := LoadCapabilityDefinitions(nil, dir)
+	if err == nil {
+		t.Fatal("expected error for malformed YAML in auto-discovered file")
+	}
+}
+
+func TestLoadCapabilityDefinitions_MalformedYAML_ExplicitPath_Errors(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	writeFile(t, path, `
+kind: CapabilityDefinition
+: this is not valid yaml {[
+`)
+	_, err := LoadCapabilityDefinitions([]string{path}, "")
+	if err == nil {
+		t.Fatal("expected error for malformed YAML in explicit path")
+	}
+}
+
+func TestLoadCapabilityDefinitions_ExplicitPaths(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "custom.yaml")
+	writeFile(t, path, `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: explicit-trait
+spec: {}
+`)
+	defs, err := LoadCapabilityDefinitions([]string{path}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := defs["explicit-trait"]; !ok {
+		t.Error("expected definition for 'explicit-trait' from explicit path")
+	}
+}
+
+func TestApplyDefinitionSchema_AppliesDefault(t *testing.T) {
+	def := &CapabilityDefinition{
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"mode": {Type: "string", Default: "auto"},
+				},
+			},
+		},
+	}
+	result, err := applyDefinitionSchema(map[string]any{}, def)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["mode"] != "auto" {
+		t.Errorf("mode = %v, want %q", result["mode"], "auto")
+	}
+}
+
+func TestApplyDefinitionSchema_RequiredMissing(t *testing.T) {
+	def := &CapabilityDefinition{
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"timeout": {Type: "integer", Required: true},
+				},
+			},
+		},
+	}
+	_, err := applyDefinitionSchema(map[string]any{}, def)
+	if err == nil {
+		t.Fatal("expected error for required missing property")
+	}
+}
+
+func TestApplyDefinitionSchema_TypeMismatch(t *testing.T) {
+	def := &CapabilityDefinition{
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"enabled": {Type: "boolean"},
+				},
+			},
+		},
+	}
+	_, err := applyDefinitionSchema(map[string]any{"enabled": "yes"}, def)
+	if err == nil {
+		t.Fatal("expected error for type mismatch")
+	}
+}
+
+func TestApplyDefinitionSchema_UnknownKey(t *testing.T) {
+	def := &CapabilityDefinition{
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"mode": {Type: "string"},
+				},
+			},
+		},
+	}
+	_, err := applyDefinitionSchema(map[string]any{"mode": "fast", "extra": "nope"}, def)
+	if err == nil {
+		t.Fatal("expected error for unknown key")
+	}
+}
+
+func TestApplyDefinitionSchema_ValidRendering(t *testing.T) {
+	def := &CapabilityDefinition{
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"mode":     {Type: "string"},
+					"timeout":  {Type: "integer"},
+					"enabled":  {Type: "boolean"},
+					"optional": {Type: "string", Default: "fallback"},
+				},
+			},
+		},
+	}
+	rendering := map[string]any{
+		"mode":    "fast",
+		"timeout": float64(30),
+		"enabled": true,
+	}
+	result, err := applyDefinitionSchema(rendering, def)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["optional"] != "fallback" {
+		t.Errorf("optional = %v, want %q", result["optional"], "fallback")
+	}
+	if result["mode"] != "fast" {
+		t.Errorf("mode = %v, want %q", result["mode"], "fast")
+	}
+}
+
+// writeFile writes content to path, failing the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("writeFile %q: %v", path, err)
+	}
+}

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -32,10 +32,18 @@ type TransformContext struct {
 // Transformer is the core OAM runtime. Handlers are registered at startup;
 // Transform/TransformWithPolicy (added in #53) execute the pipeline.
 // Internal storage uses maps keyed by typeName for O(1) dispatch.
+//
+// Handlers registered via RegisterTrait are treated as custom for
+// CapabilityDefinition purposes. Use RegisterBuiltinTrait for launcher's own
+// built-in handlers; built-in types are never checked against CapabilityDefinition files.
 type Transformer struct {
-	componentHandlers map[string]ComponentHandler
-	traitHandlers     map[string]TraitHandler
-	policyHandlers    map[string]PolicyHandler
+	componentHandlers  map[string]ComponentHandler
+	traitHandlers      map[string]TraitHandler
+	policyHandlers     map[string]PolicyHandler
+	builtinTraitTypes  map[string]bool
+	capabilityDefs     map[string]*CapabilityDefinition
+	strictCapabilities bool
+	warnHandler        func(string)
 }
 
 // NewTransformer creates a Transformer pre-loaded with component and trait handlers.
@@ -44,11 +52,14 @@ type Transformer struct {
 // (design-capability-schema.md §2.5) applies to pre-loaded handlers too.
 // Panics if any trait handler implements CapabilityAware but not ValidateAndApplyDefaults.
 // Nil maps are treated as empty.
+// Handlers registered through this constructor are treated as custom for
+// CapabilityDefinition purposes; use RegisterBuiltinTrait for launcher built-ins.
 func NewTransformer(componentHandlers map[string]ComponentHandler, traitHandlers map[string]TraitHandler) *Transformer {
 	t := &Transformer{
 		componentHandlers: make(map[string]ComponentHandler),
 		traitHandlers:     make(map[string]TraitHandler),
 		policyHandlers:    make(map[string]PolicyHandler),
+		builtinTraitTypes: make(map[string]bool),
 	}
 	for typeName, h := range componentHandlers {
 		t.RegisterComponent(typeName, h)
@@ -102,6 +113,31 @@ func (t *Transformer) RegisterPolicy(typeName string, h PolicyHandler) {
 	t.policyHandlers[typeName] = h
 }
 
+// RegisterBuiltinTrait is like RegisterTrait but marks the type as built-in.
+// Built-in types are never checked against CapabilityDefinition files.
+func (t *Transformer) RegisterBuiltinTrait(typeName string, h TraitHandler) {
+	t.RegisterTrait(typeName, h)
+	t.builtinTraitTypes[typeName] = true
+}
+
+// SetCapabilityDefs replaces the set of loaded CapabilityDefinition schemas.
+// Typically populated from LoadCapabilityDefinitions before calling EvaluateProfile.
+func (t *Transformer) SetCapabilityDefs(defs map[string]*CapabilityDefinition) {
+	t.capabilityDefs = defs
+}
+
+// SetStrictCapabilities controls whether a missing CapabilityDefinition for a custom
+// trait is a hard error (true) or a warning (false, default).
+func (t *Transformer) SetStrictCapabilities(strict bool) {
+	t.strictCapabilities = strict
+}
+
+// SetWarningHandler sets the callback invoked when a non-fatal capability warning is emitted.
+// If nil, warnings are silently dropped.
+func (t *Transformer) SetWarningHandler(h func(string)) {
+	t.warnHandler = h
+}
+
 // EvaluateProfile validates and applies defaults to all capability renderings in
 // the ClusterProfile. For each capability key whose trait type matches a registered
 // handler that implements ValidateAndApplyDefaults, the rendering map is passed
@@ -126,12 +162,30 @@ func (t *Transformer) EvaluateProfile(profile *ClusterProfile) (*ClusterProfile,
 			evaluated[key] = binding
 			continue
 		}
+
+		currentRendering := binding.Rendering
+
+		// For custom (non-built-in) trait types, apply CapabilityDefinition schema
+		// defaults before handler VAD so that VAD sees schema-defaulted values.
+		if !t.builtinTraitTypes[typeName] {
+			if def, hasDef := t.capabilityDefs[typeName]; hasDef {
+				withDefaults, err := applyDefinitionSchema(currentRendering, def)
+				if err != nil {
+					return nil, &TransformError{
+						Message: fmt.Sprintf("capability %q definition schema", key),
+						Cause:   err,
+					}
+				}
+				currentRendering = withDefaults
+			}
+		}
+
 		vad, ok := handler.(ValidateAndApplyDefaults)
 		if !ok {
-			evaluated[key] = binding
+			evaluated[key] = CapabilityBinding{Rendering: currentRendering}
 			continue
 		}
-		validated, err := vad.ValidateAndApplyDefaults(binding.Rendering)
+		validated, err := vad.ValidateAndApplyDefaults(currentRendering)
 		if err != nil {
 			return nil, &TransformError{Message: fmt.Sprintf("capability %q", key), Cause: err}
 		}
@@ -453,6 +507,25 @@ func (t *Transformer) applyTraits(app *Application, entries []componentEntry, bu
 						Message: fmt.Sprintf("component %q trait %q: capability %q not found in ClusterProfile",
 							entry.component.Name, trait.Type, key),
 						Cause: ErrMissingCapability,
+					}
+				}
+			}
+
+			// For custom (non-built-in) traits whose capability rendering resolved in the
+			// profile, warn or error when no CapabilityDefinition was loaded for the type.
+			if !t.builtinTraitTypes[trait.Type] {
+				key := buildCapabilityKey(trait)
+				_, foundScoped := ctx.Capabilities[key]
+				_, foundBare := ctx.Capabilities[trait.Type]
+				if foundScoped || foundBare {
+					if _, hasDef := t.capabilityDefs[trait.Type]; !hasDef {
+						msg := fmt.Sprintf("no CapabilityDefinition found for custom trait %q", trait.Type)
+						if t.strictCapabilities {
+							return &TransformError{Message: msg}
+						}
+						if t.warnHandler != nil {
+							t.warnHandler(msg)
+						}
 					}
 				}
 			}

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -812,3 +812,196 @@ func TestEvaluateProfile_ScopedKey(t *testing.T) {
 		t.Error("scoped key should resolve to base type and call VAD handler")
 	}
 }
+
+// --- CapabilityDefinition tests ---
+
+// customVADHandler is a trait handler for test custom types that accepts any rendering.
+type customVADHandler struct{ stubTraitHandler }
+
+func (h *customVADHandler) CapabilityRequired() bool { return false }
+func (h *customVADHandler) ValidateAndApplyDefaults(r map[string]any) (map[string]any, error) {
+	return r, nil
+}
+
+// capDefFixture returns a CapabilityDefinition with one required integer property.
+func capDefFixture(traitType string) *CapabilityDefinition {
+	return &CapabilityDefinition{
+		APIVersion: "launcher.gokure.dev/v1alpha1",
+		Kind:       "CapabilityDefinition",
+		Metadata:   Metadata{Name: traitType},
+		Spec: CapabilityDefSpec{
+			Rendering: CapabilityRenderingSchema{
+				Properties: map[string]CapabilityPropertySchema{
+					"timeout": {Type: "integer", Required: true},
+					"mode":    {Type: "string", Default: "auto"},
+				},
+			},
+		},
+	}
+}
+
+func TestEvaluateProfile_CapabilityDefinition_AppliesSchemaBeforeVAD(t *testing.T) {
+	// Custom trait registered via RegisterTrait; definition loaded; valid rendering.
+	// The definition applies a default for "mode", so VAD should receive it.
+	tr := NewTransformer(nil, nil)
+	tr.RegisterTrait("custom", &customVADHandler{stubTraitHandler: stubTraitHandler{typ: "custom"}})
+	tr.SetCapabilityDefs(map[string]*CapabilityDefinition{"custom": capDefFixture("custom")})
+
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"custom": {Rendering: map[string]any{"timeout": float64(30)}},
+			},
+		},
+	}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// "mode" default should have been applied.
+	if got.Spec.Capabilities["custom"].Rendering["mode"] != "auto" {
+		t.Errorf("mode = %v, want %q", got.Spec.Capabilities["custom"].Rendering["mode"], "auto")
+	}
+}
+
+func TestEvaluateProfile_CapabilityDefinition_SchemaViolationReturnsError(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	tr.RegisterTrait("custom", &customVADHandler{stubTraitHandler: stubTraitHandler{typ: "custom"}})
+	tr.SetCapabilityDefs(map[string]*CapabilityDefinition{"custom": capDefFixture("custom")})
+
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				// timeout is required but missing → definition schema rejects this.
+				"custom": {Rendering: map[string]any{"mode": "fast"}},
+			},
+		},
+	}
+	_, err := tr.EvaluateProfile(profile)
+	if err == nil {
+		t.Fatal("expected error for missing required property in definition schema")
+	}
+}
+
+func TestEvaluateProfile_CapabilityDefinition_BuiltinIgnoresDefinition(t *testing.T) {
+	// Definition for a built-in type declares timeout as required; even though the
+	// rendering omits it, no error fires because built-ins skip definition schema.
+	tr := NewTransformer(nil, nil)
+	tr.RegisterBuiltinTrait("expose", &customVADHandler{stubTraitHandler: stubTraitHandler{typ: "expose"}})
+	tr.SetCapabilityDefs(map[string]*CapabilityDefinition{"expose": capDefFixture("expose")})
+
+	profile := &ClusterProfile{
+		Spec: ClusterProfileSpec{
+			Capabilities: map[string]CapabilityBinding{
+				"expose": {Rendering: map[string]any{"controllerType": "ingress"}},
+			},
+		},
+	}
+	_, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("built-in type should ignore definition schema; got error: %v", err)
+	}
+}
+
+// minimalApp returns an OAM Application with one component and one trait for pipeline tests.
+func minimalApp(componentType, traitType string) *Application {
+	return &Application{
+		APIVersion: "core.oam.dev/v1beta1",
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name:       "comp",
+					Type:       componentType,
+					Properties: map[string]any{},
+					Traits: []Trait{
+						{Type: traitType, Properties: map[string]any{}},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestTransform_CustomTrait_CapabilityResolved_NoDefinition_Warns(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"comp": &pipelineComponentHandler{typ: "comp"}},
+		map[string]TraitHandler{"custom": &stubTraitHandler{typ: "custom"}},
+	)
+	var warned string
+	tr.SetWarningHandler(func(msg string) { warned = msg })
+
+	ctx := TransformContext{
+		ClusterID:    "test",
+		Capabilities: map[string]CapabilityBinding{"custom": {Rendering: map[string]any{"x": "y"}}},
+	}
+	_, err := tr.Transform(minimalApp("comp", "custom"), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warned == "" {
+		t.Error("expected warning for custom trait with resolved capability but no definition")
+	}
+}
+
+func TestTransform_CustomTrait_CapabilityResolved_NoDefinition_StrictErrors(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{"comp": &pipelineComponentHandler{typ: "comp"}},
+		map[string]TraitHandler{"custom": &stubTraitHandler{typ: "custom"}},
+	)
+	tr.SetStrictCapabilities(true)
+
+	ctx := TransformContext{
+		ClusterID:    "test",
+		Capabilities: map[string]CapabilityBinding{"custom": {Rendering: map[string]any{"x": "y"}}},
+	}
+	_, err := tr.Transform(minimalApp("comp", "custom"), ctx)
+	if err == nil {
+		t.Fatal("expected error with strict-capabilities and no definition")
+	}
+}
+
+func TestTransform_CustomTrait_NoCapabilityResolved_NoWarn(t *testing.T) {
+	// No capability in profile → check never fires even for custom types.
+	var warned string
+	tr := NewTransformer(
+		map[string]ComponentHandler{"comp": &pipelineComponentHandler{typ: "comp"}},
+		map[string]TraitHandler{"custom": &stubTraitHandler{typ: "custom"}},
+	)
+	tr.SetStrictCapabilities(true)
+	tr.SetWarningHandler(func(msg string) { warned = msg })
+
+	ctx := TransformContext{ClusterID: "test", Capabilities: map[string]CapabilityBinding{}}
+	_, err := tr.Transform(minimalApp("comp", "custom"), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warned != "" {
+		t.Errorf("unexpected warning: %q", warned)
+	}
+}
+
+func TestTransform_BuiltinTrait_CapabilityResolved_NoDefinition_NoWarn(t *testing.T) {
+	// Built-in trait with resolved capability and no definition: no warning, no error.
+	var warned string
+	tr := NewTransformer(
+		map[string]ComponentHandler{"comp": &pipelineComponentHandler{typ: "comp"}},
+		nil,
+	)
+	tr.RegisterBuiltinTrait("expose", &stubTraitHandler{typ: "expose"})
+	tr.SetStrictCapabilities(true)
+	tr.SetWarningHandler(func(msg string) { warned = msg })
+
+	ctx := TransformContext{
+		ClusterID:    "test",
+		Capabilities: map[string]CapabilityBinding{"expose": {Rendering: map[string]any{"type": "ingress"}}},
+	}
+	_, err := tr.Transform(minimalApp("comp", "expose"), ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if warned != "" {
+		t.Errorf("unexpected warning for built-in trait: %q", warned)
+	}
+}

--- a/pkg/oam/types.go
+++ b/pkg/oam/types.go
@@ -43,3 +43,34 @@ type ApplicationPolicy struct {
 	Type       string         `yaml:"type"`
 	Properties map[string]any `yaml:"properties,omitempty"`
 }
+
+// CapabilityDefinition declares the rendering schema for a custom capability trait type.
+// metadata.name is the trait type. Scope: platform-facing rendering schema only
+// (what keys a ClusterProfile capability binding may contain).
+// See docs/oam/design-capability-schema.md §3.2.
+type CapabilityDefinition struct {
+	APIVersion string            `yaml:"apiVersion"`
+	Kind       string            `yaml:"kind"`
+	Metadata   Metadata          `yaml:"metadata"` // metadata.name = trait type
+	Spec       CapabilityDefSpec `yaml:"spec"`
+}
+
+// CapabilityDefSpec holds the rendering schema declaration.
+type CapabilityDefSpec struct {
+	Description string                    `yaml:"description,omitempty"`
+	Rendering   CapabilityRenderingSchema `yaml:"rendering,omitempty"`
+}
+
+// CapabilityRenderingSchema lists the accepted rendering properties.
+type CapabilityRenderingSchema struct {
+	Properties map[string]CapabilityPropertySchema `yaml:"properties,omitempty"`
+}
+
+// CapabilityPropertySchema describes one rendering property.
+// Accepted types: "string", "integer", "boolean" (same vocabulary as kurel.yaml parameters).
+type CapabilityPropertySchema struct {
+	Type        string `yaml:"type,omitempty"`
+	Required    bool   `yaml:"required,omitempty"`
+	Default     any    `yaml:"default,omitempty"`
+	Description string `yaml:"description,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Adds the `CapabilityDefinition` document kind so downstream embedders can declare a rendering schema for their custom trait handlers
- Schema is validated at `EvaluateProfile` time (before handler VAD), applying declared defaults so VAD sees fully-defaulted rendering
- Dispatch-time check warns (or errors with `--strict-capabilities`) when a capability resolves in the profile but no `CapabilityDefinition` was loaded for the custom trait type
- Built-in types (registered via new `RegisterBuiltinTrait`) are never checked against definition files — their schema lives in typed Go structs + VAD

## Changes

| Area | What |
|---|---|
| `pkg/oam/types.go` | Four new types: `CapabilityDefinition`, `CapabilityDefSpec`, `CapabilityRenderingSchema`, `CapabilityPropertySchema` |
| `pkg/oam/capability.go` | `LoadCapabilityDefinitions` — strict YAML parse, kind routing (malformed YAML always errors), dedup/conflict detection, type-vocabulary validation (`string`/`integer`/`boolean`) |
| `pkg/oam/capability.go` | `applyDefinitionSchema` — required/type/unknown-key enforcement + default application |
| `pkg/oam/transform.go` | `RegisterBuiltinTrait`, `SetCapabilityDefs`, `SetStrictCapabilities`, `SetWarningHandler`; two-phase hook in `EvaluateProfile` and `applyTraits` |
| `pkg/cmd/kurel/build.go` | `--capability-def` and `--strict-capabilities` flags; `newBuiltinTransformer` uses `RegisterBuiltinTrait` for all 11 built-ins; definitions loaded and warning handler wired |
| `examples/custom-capability/` | Illustrative package layout (app + CapabilityDefinition + companion profile) per design §3.3 |

## Test plan

- [ ] `pkg/oam/capability_test.go`: `LoadCapabilityDefinitions` — valid file, skips other kinds, missing dir not error, dedup identical, conflict errors, malformed YAML errors (auto-discovered and explicit path), wrong apiVersion, missing name, unsupported property type, explicit paths
- [ ] `pkg/oam/capability_test.go`: `applyDefinitionSchema` — applies default, required missing, type mismatch, unknown key, valid rendering
- [ ] `pkg/oam/transform_test.go`: `EvaluateProfile` — definition schema applied before VAD (default injected), schema violation returns error, built-in type ignores definition
- [ ] `pkg/oam/transform_test.go`: `Transform` — custom trait + cap resolved + no definition → warn; strict → error; no cap resolved → no warn; built-in + strict → no warn

Closes #66