### PR TITLE
fix: add actions: read permission to release-create workflow

### DIFF
--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -29,6 +29,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 jobs:
   release-create:


### PR DESCRIPTION
## Summary

- Adds `actions: read` permission to `release-create.yml`, required by the canonical reusable workflow in go-kure/.github to poll `gh run list` / `gh run watch`
- Without this permission the reusable workflow fails when it tries to monitor workflow run status
- The same fix was already applied to kure's version in dot-github#17

## Test plan

- [ ] After merge, trigger a dry-run via workflow_dispatch with `dry_run: true` and confirm it completes without permission errors