### PR TITLE
fix(examples): correct cluster profiles, custom-capability app, and custom trait parsing

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,116 @@
+# Examples
+
+This directory contains runnable OAM Application YAMLs paired with the ClusterProfiles needed
+to build them. All commands assume the working directory is the **repo root** and the binary is
+at `bin/kurel` (built with `mise run build`).
+
+## Quick start
+
+```bash
+mise run build
+bin/kurel build examples/01-webservice-minimal.yaml \
+  --profile examples/cluster-profiles/minimal.yaml
+```
+
+## Application examples
+
+| # | File | Components | Traits | Profile |
+|---|------|-----------|--------|---------|
+| 01 | [01-webservice-minimal.yaml](01-webservice-minimal.yaml) | webservice | — | minimal |
+| 02 | [02-webservice-with-expose.yaml](02-webservice-with-expose.yaml) | webservice | expose | minimal |
+| 03 | [03-webservice-with-tls.yaml](03-webservice-with-tls.yaml) | webservice | expose, certificate | nginx-certmanager-vault |
+| 04 | [04-webservice-full.yaml](04-webservice-full.yaml) | webservice | expose, certificate, external-secret, scaler | nginx-certmanager-vault |
+| 05 | [05-worker-minimal.yaml](05-worker-minimal.yaml) | worker | — | minimal |
+| 06 | [06-worker-with-traits.yaml](06-worker-with-traits.yaml) | worker | external-secret, configmap | nginx-certmanager-vault |
+| 07 | [07-cronjob-minimal.yaml](07-cronjob-minimal.yaml) | cronjob | — | minimal |
+| 08 | [08-cronjob-full.yaml](08-cronjob-full.yaml) | cronjob | external-secret | nginx-certmanager-vault |
+| 09 | [09-postgresql-minimal.yaml](09-postgresql-minimal.yaml) | postgresql | — | minimal |
+| 10 | [10-postgresql-ha.yaml](10-postgresql-ha.yaml) | postgresql | — | minimal |
+| 11 | [11-helmchart.yaml](11-helmchart.yaml) | helmchart | — | minimal |
+| 12 | [12-daemonset.yaml](12-daemonset.yaml) | daemonset | — | minimal |
+| 13 | [13-statefulset.yaml](13-statefulset.yaml) | statefulset | — | minimal |
+| 14 | [14-full-stack.yaml](14-full-stack.yaml) | webservice×3, worker, cronjob, postgresql, helmchart, daemonset, statefulset | expose, expose.internal, certificate, external-secret, configmap, scaler | gateway-certmanager-aws |
+
+**Profile compatibility notes:**
+- Examples 03–04, 06, 08 also work with `gateway-certmanager-aws.yaml`
+- Example 14 also works with `nginx-certmanager-vault.yaml`
+- Examples 01, 05, 07, 09–13 work with any profile
+
+## Cluster profiles
+
+| File | Profile name | Capabilities | Use for |
+|------|-------------|-------------|---------|
+| [minimal.yaml](cluster-profiles/minimal.yaml) | `staging-minimal` | expose (Traefik ingress) | dev/staging with no TLS or secrets |
+| [nginx-certmanager-vault.yaml](cluster-profiles/nginx-certmanager-vault.yaml) | `prod-nginx` | expose (NGINX), certificate (Let's Encrypt), external-secret (Vault) | production with NGINX and Vault |
+| [gateway-certmanager-aws.yaml](cluster-profiles/gateway-certmanager-aws.yaml) | `prod-gateway` | expose (Gateway API), expose.internal (internal gateway), certificate (internal CA), external-secret (AWS Secrets Manager) | production with Gateway API and AWS |
+| [custom-capability.yaml](cluster-profiles/custom-capability.yaml) | `staging-with-redis-sidecar` | expose (NGINX), redis-sidecar (custom) | custom-capability library example only |
+
+## Custom capability extension example
+
+Directory: [`custom-capability/`](custom-capability/)
+
+| File | Purpose |
+|------|---------|
+| [`app.yaml`](custom-capability/app.yaml) | Application using the custom `redis-sidecar` trait alongside `expose` |
+| [`definitions/redis-sidecar.yaml`](custom-capability/definitions/redis-sidecar.yaml) | CapabilityDefinition schema: validates `image` (required), `maxMemory`, `port` |
+| [`cluster-profiles/custom-capability.yaml`](cluster-profiles/custom-capability.yaml) | ClusterProfile that supplies rendering values for the `redis-sidecar` capability |
+
+### Why this example cannot be run with `kurel build`
+
+Running the following command will fail:
+
+```bash
+bin/kurel build examples/custom-capability/app.yaml \
+  --profile examples/cluster-profiles/custom-capability.yaml \
+  --capability-def examples/custom-capability/definitions/redis-sidecar.yaml
+# Error: transforming application: no handler for trait type "redis-sidecar"
+```
+
+**Two separate mechanisms are involved:**
+
+1. **CapabilityDefinition** (`definitions/redis-sidecar.yaml`) — declares the *schema* for the
+   trait's rendering configuration: required fields, types, and default values. This runs at
+   profile evaluation time to validate and fill defaults on the rendering values coming from the
+   ClusterProfile. It is pure data — no code.
+
+2. **TraitHandler** — a Go struct with an `Apply` method that actually generates Kubernetes
+   objects (Deployments, ConfigMaps, annotations, sidecar containers, etc.) from the resolved
+   trait properties. This must be registered with the Transformer at runtime.
+
+`kurel build` only registers the 15 built-in handlers. When the Transformer reaches
+`type: redis-sidecar` it finds no registered handler and returns the error above.
+
+### Using custom traits from Go
+
+This example is intended for developers building on the kurel library. The workflow:
+
+1. Implement `oam.TraitHandler`:
+
+```go
+type RedisSidecarHandler struct{}
+
+func (h *RedisSidecarHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
+    image := trait.Properties["image"].(string)
+    // inject sidecar container into the bundle...
+    return nil
+}
+```
+
+2. Optionally implement `oam.CapabilityAware` if the trait must fail when no matching capability
+   exists in the ClusterProfile.
+
+3. Register the handler and wire capability definitions:
+
+```go
+transformer := oam.NewTransformer(componentHandlers, nil)
+transformer.RegisterTrait("redis-sidecar", &RedisSidecarHandler{})
+
+capDefs, _ := oam.LoadCapabilityDefinitions(defPaths, definitionsDir)
+transformer.SetCapabilityDefs(capDefs)
+```
+
+### Future work
+
+Config-driven extensibility (custom traits and components without Go code, CRD passthrough,
+standard Kubernetes API coverage) is tracked in
+[issue #102](https://github.com/go-kure/launcher/issues/102).

--- a/examples/cluster-profiles/gateway-certmanager-aws.yaml
+++ b/examples/cluster-profiles/gateway-certmanager-aws.yaml
@@ -16,9 +16,8 @@ spec:
         gatewayNamespace: gateway-system
     certificate:
       rendering:
-        issuerRef:
-          name: internal-ca
-          kind: ClusterIssuer
+        issuerRefName: internal-ca
+        issuerRefKind: ClusterIssuer
     external-secret:
       rendering:
         secretStoreRef:

--- a/examples/cluster-profiles/nginx-certmanager-vault.yaml
+++ b/examples/cluster-profiles/nginx-certmanager-vault.yaml
@@ -10,9 +10,8 @@ spec:
         ingressClassName: nginx
     certificate:
       rendering:
-        issuerRef:
-          name: letsencrypt-prod
-          kind: ClusterIssuer
+        issuerRefName: letsencrypt-prod
+        issuerRefKind: ClusterIssuer
     external-secret:
       rendering:
         secretStoreRef:

--- a/examples/custom-capability/app.yaml
+++ b/examples/custom-capability/app.yaml
@@ -1,4 +1,4 @@
-apiVersion: core.oam.dev/v1beta1
+apiVersion: launcher.gokure.dev/v1alpha1
 kind: Application
 metadata:
   name: my-app
@@ -7,12 +7,16 @@ spec:
   - name: api
     type: webservice
     properties:
-      image: myorg/api:latest
+      image: myorg/api:v1.0.0
       port: 8080
     traits:
     - type: expose
       properties:
-        port: 8080
+        rules:
+        - host: my-app.example.com
+          paths:
+          - path: /
+            port: 8080
     # redis-sidecar is a custom trait implemented by the downstream consumer's
     # handler. The rendering values (image, maxMemory, port) come from the
     # ClusterProfile capability binding; the definitions/redis-sidecar.yaml

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -111,7 +111,19 @@ func runBuild(cmd *cobra.Command, arg string, opts *buildOptions) error {
 		}
 	}
 
-	app, err := oam.Parse(appData)
+	// Load capability definitions before parsing the app so that custom trait
+	// types from --capability-def pass the trait type validation in oam.Parse.
+	capDefs, err := oam.LoadCapabilityDefinitions(opts.capabilityDefPaths, filepath.Join(appDir, "definitions"))
+	if err != nil {
+		return errors.Wrap(err, "loading capability definitions")
+	}
+
+	customTraitTypes := make([]string, 0, len(capDefs))
+	for name := range capDefs {
+		customTraitTypes = append(customTraitTypes, name)
+	}
+
+	app, err := oam.ParseWithExtraTraitTypes(appData, customTraitTypes)
 	if err != nil {
 		return errors.Wrapf(err, "parsing application file %q", appPath)
 	}
@@ -128,10 +140,6 @@ func runBuild(cmd *cobra.Command, arg string, opts *buildOptions) error {
 
 	transformer := newBuiltinTransformer()
 
-	capDefs, err := oam.LoadCapabilityDefinitions(opts.capabilityDefPaths, filepath.Join(appDir, "definitions"))
-	if err != nil {
-		return errors.Wrap(err, "loading capability definitions")
-	}
 	transformer.SetCapabilityDefs(capDefs)
 	transformer.SetStrictCapabilities(opts.strictCapabilities)
 	transformer.SetWarningHandler(func(msg string) {

--- a/pkg/oam/parser.go
+++ b/pkg/oam/parser.go
@@ -60,6 +60,30 @@ func ParseMulti(data []byte) ([]*Application, error) {
 	return apps, nil
 }
 
+// ParseWithExtraTraitTypes is like Parse but also accepts custom trait type names
+// from CapabilityDefinition files so they pass validation.
+func ParseWithExtraTraitTypes(data []byte, extraTraitTypes []string) (*Application, error) {
+	var app Application
+
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	if err := dec.Decode(&app); err != nil {
+		return nil, yamlParseError(err)
+	}
+
+	custom := make(map[string]bool, len(extraTraitTypes))
+	for _, t := range extraTraitTypes {
+		custom[t] = true
+	}
+
+	if err := validateWithCustomTraits(&app, custom); err != nil {
+		return nil, err
+	}
+
+	return &app, nil
+}
+
 // MustParse parses an Application YAML document and panics on error.
 // Use only in tests or initialization code where errors are truly unexpected.
 func MustParse(data []byte) *Application {

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -53,6 +53,12 @@ var traitComponentRestrictions = map[string]map[string]bool{
 
 // validate performs semantic validation on a parsed Application.
 func validate(app *Application) error {
+	return validateWithCustomTraits(app, nil)
+}
+
+// validateWithCustomTraits is like validate but also accepts custom trait type names
+// derived from CapabilityDefinition files supplied via --capability-def.
+func validateWithCustomTraits(app *Application, customTraitTypes map[string]bool) error {
 	if app.APIVersion != SupportedAPIVersion {
 		return oamValidationError("apiVersion", fmt.Sprintf("unsupported apiVersion %q, expected %q",
 			app.APIVersion, SupportedAPIVersion))
@@ -84,7 +90,7 @@ func validate(app *Application) error {
 
 	seenNames := make(map[string]bool)
 	for i, c := range app.Spec.Components {
-		if err := validateComponent(&c, i, seenNames); err != nil {
+		if err := validateComponent(&c, i, seenNames, customTraitTypes); err != nil {
 			return err
 		}
 	}
@@ -99,7 +105,7 @@ func validate(app *Application) error {
 	return nil
 }
 
-func validateComponent(c *Component, index int, seenNames map[string]bool) error {
+func validateComponent(c *Component, index int, seenNames map[string]bool, customTraitTypes map[string]bool) error {
 	if c.Name == "" {
 		return oamValidationError("name", fmt.Sprintf("spec.components[%d].name is required", index))
 	}
@@ -122,7 +128,7 @@ func validateComponent(c *Component, index int, seenNames map[string]bool) error
 	}
 
 	for j, t := range c.Traits {
-		if err := validateTrait(&t, c.Name, c.Type, j); err != nil {
+		if err := validateTrait(&t, c.Name, c.Type, j, customTraitTypes); err != nil {
 			return err
 		}
 	}
@@ -130,13 +136,13 @@ func validateComponent(c *Component, index int, seenNames map[string]bool) error
 	return nil
 }
 
-func validateTrait(t *Trait, componentName, componentType string, index int) error {
+func validateTrait(t *Trait, componentName, componentType string, index int, customTraitTypes map[string]bool) error {
 	if t.Type == "" {
 		return oamValidationError("type", fmt.Sprintf("component %q trait[%d] missing type",
 			componentName, index))
 	}
 
-	if !validTraitTypes[t.Type] {
+	if !validTraitTypes[t.Type] && !customTraitTypes[t.Type] {
 		return errors.NewValidationError("type", t.Type, componentName, supportedTraitTypes())
 	}
 


### PR DESCRIPTION
## Summary

- **Cluster profile issuerRef bug**: `nginx-certmanager-vault.yaml` and `gateway-certmanager-aws.yaml` used a nested `issuerRef.name/kind` structure that doesn't match the flat `issuerRefName`/`issuerRefKind` fields in `builtin.CertificateRendering`. This caused `evaluating profile: capability "certificate": field issuerRef not found` for any example using those profiles.
- **Custom-capability app fixes**: Updated `apiVersion` from deprecated `core.oam.dev/v1beta1` to `launcher.gokure.dev/v1alpha1`, replaced `:latest` image tag, and corrected the `expose` trait format.
- **Custom trait parsing**: Custom traits declared via `--capability-def` were rejected at parse time because `oam.Parse` validates trait types against a hardcoded allowlist before capability definitions are loaded. Fix moves `LoadCapabilityDefinitions` before `oam.Parse` in `build.go` and adds `ParseWithExtraTraitTypes` / `validateWithCustomTraits` to thread custom type names into the validator.
- **`examples/README.md`**: New file documenting all 14 examples, the four cluster profiles, and the custom-capability extension pattern (including why it requires a Go `TraitHandler` and what to implement). References #102 for future config-driven extensibility.

## Test plan

- [ ] `mise run test` passes (all existing tests green)
- [ ] `bin/kurel build examples/01-webservice-minimal.yaml --profile examples/cluster-profiles/minimal.yaml` produces a Deployment + Service + ServiceAccount
- [ ] `bin/kurel build examples/03-webservice-with-tls.yaml --profile examples/cluster-profiles/nginx-certmanager-vault.yaml` no longer errors on `issuerRef`
- [ ] `bin/kurel build examples/14-full-stack.yaml --profile examples/cluster-profiles/gateway-certmanager-aws.yaml` produces 34 resource documents
- [ ] `bin/kurel build examples/custom-capability/app.yaml --profile examples/cluster-profiles/custom-capability.yaml --capability-def examples/custom-capability/definitions/redis-sidecar.yaml` fails at the expected point: `no handler for trait type "redis-sidecar"` (not at parse time)