### PR TITLE
fix(oam): change default HelmRelease interval from 10m to 60m

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -144,6 +144,29 @@ kure remains a standalone library with no dependency on launcher. Launcher impor
 
 `pkg/stack/generators/kurelpackage/` — historically a kure *generator* that produced kurel package structure from a kure Application. This package is now being removed from kure (unused by all known consumers; removal tracked in [kure#539](https://github.com/go-kure/kure/issues/539)). It does not move to launcher.
 
+### What launcher does not use from kure (intentional)
+
+Launcher does **not** use the following kure packages. This is by design, not an oversight.
+
+| Package | Why not used |
+|---|---|
+| `pkg/stack/generators/` (AppWorkload, FluxHelm, KurelPackage) | kure's pre-built generator types; consumed only by kure's own tests, not by crane or launcher |
+| `pkg/stack/application_wrapper.go` (ApplicationWrapper) | kure's GVK YAML dispatch mechanism; launcher defines its own OAM parser under `launcher.gokure.dev/v1alpha1` |
+| `pkg/gvk` | kure's generic GVK registry; not relevant to launcher's static-file OAM model |
+| `generators.gokure.dev/*`, `stack.gokure.dev/*` API groups | kure's versioning space; launcher's documents use `launcher.gokure.dev` exclusively |
+
+### What launcher does use from kure (intentional)
+
+| Package | Purpose |
+|---|---|
+| `pkg/stack.ApplicationConfig` | Handler output interface — `ComponentHandler.ToApplicationConfig()` in `pkg/oam/handler.go` returns `stack.ApplicationConfig`, which is the bridge to kure's resource builders |
+| `pkg/kubernetes` | Kubernetes resource construction (Deployment, Service, etc.) |
+| `pkg/stack/fluxcd` | GitOps delivery object generation (OCIRepository, Kustomization) |
+| `pkg/errors` | Error types |
+| `pkg/io` | YAML parsing utilities |
+| `pkg/logger` | Logging interface |
+| `pkg/cmd/shared` | CLI infrastructure |
+
 ---
 
 ## 6. Comparison with Helm

--- a/pkg/cmd/kurel/testdata/helmchart-oci/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-oci/expected.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cert-manager
   namespace: default
 spec:
-  interval: 10m0s
+  interval: 1h0m0s
   ref:
     tag: v1.17.2
   url: oci://ghcr.io/cert-manager/charts/cert-manager
@@ -18,4 +18,4 @@ spec:
   chartRef:
     kind: OCIRepository
     name: cert-manager
-  interval: 10m0s
+  interval: 1h0m0s

--- a/pkg/cmd/kurel/testdata/helmchart-repository/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-repository/expected.yaml
@@ -4,7 +4,7 @@ metadata:
   name: metrics
   namespace: default
 spec:
-  interval: 10m0s
+  interval: 1h0m0s
   url: https://prometheus-community.github.io/helm-charts
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -20,5 +20,5 @@ spec:
         kind: HelmRepository
         name: metrics
       version: 69.3.2
-  interval: 10m0s
+  interval: 1h0m0s
   targetNamespace: monitoring

--- a/pkg/cmd/kurel/testdata/helmchart-sourceref/expected.yaml
+++ b/pkg/cmd/kurel/testdata/helmchart-sourceref/expected.yaml
@@ -12,4 +12,4 @@ spec:
         name: prometheus-community
         namespace: flux-system
       version: 69.3.2
-  interval: 10m0s
+  interval: 1h0m0s

--- a/pkg/oam/builtin/components/helmchart.go
+++ b/pkg/oam/builtin/components/helmchart.go
@@ -458,7 +458,7 @@ func (c *HelmchartConfig) buildHelmRelease() *helmv2.HelmRelease {
 
 func effectiveInterval(interval string) string {
 	if interval == "" {
-		return "10m"
+		return "60m"
 	}
 	return interval
 }

--- a/pkg/oam/builtin/components/helmchart_test.go
+++ b/pkg/oam/builtin/components/helmchart_test.go
@@ -543,8 +543,8 @@ func TestHelmchartHandler_DefaultInterval(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected HelmRelease at objects[1], got %T", *objects[1])
 	}
-	if hr.Spec.Interval.Duration.String() != "10m0s" {
-		t.Errorf("interval = %q, want 10m0s (default)", hr.Spec.Interval.Duration.String())
+	if hr.Spec.Interval.Duration.String() != "1h0m0s" {
+		t.Errorf("interval = %q, want 1h0m0s (default)", hr.Spec.Interval.Duration.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- Changes `effectiveInterval()` default from `10m` to `60m` per FluxCD upstream recommendation, reducing unnecessary API server load on HelmRelease reconciliation
- Adds documentation in `docs/design.md` clarifying which kure packages launcher intentionally uses vs. avoids

## Test plan

- [x] `mise run test` passes
- [ ] Generated HelmRelease objects without explicit `interval` render `1h0m0s`

Closes #106