### PR TITLE
ci: redesign release workflows (Create/Promote/Bump/Publish)

### DIFF
--- a/.github/workflows/release-bump.yml
+++ b/.github/workflows/release-bump.yml
@@ -1,8 +1,15 @@
-name: Release / Create
+name: Release / Bump
 
 on:
   workflow_dispatch:
     inputs:
+      scope:
+        description: 'Version scope to bump'
+        required: true
+        type: choice
+        options:
+          - minor
+          - major
       dry_run:
         description: 'Dry run (preview only, no changes)'
         required: false
@@ -14,8 +21,9 @@ permissions:
   actions: read
 
 jobs:
-  release-create:
-    uses: go-kure/.github/.github/workflows/release-create.yml@main
+  release-bump:
+    uses: go-kure/.github/.github/workflows/release-bump.yml@main
     with:
+      scope: ${{ inputs.scope }}
       dry_run: ${{ inputs.dry_run }}
     secrets: inherit

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,30 @@
+name: Release / Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      to:
+        description: 'Target release type'
+        required: true
+        type: choice
+        options:
+          - beta
+          - rc
+          - stable
+      dry_run:
+        description: 'Dry run (preview only, no changes)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release-promote:
+    uses: go-kure/.github/.github/workflows/release-promote.yml@main
+    with:
+      to: ${{ inputs.to }}
+      dry_run: ${{ inputs.dry_run }}
+    secrets: inherit

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release / Publish
 
 on:
   push:
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release:
-    uses: go-kure/.github/.github/workflows/release.yml@main
+    uses: go-kure/.github/.github/workflows/release-publish.yml@main
     with:
       go_module: github.com/go-kure/launcher
     secrets: inherit

--- a/scripts/release-trigger.sh
+++ b/scripts/release-trigger.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# Release trigger — dry-run by default, --do-it to execute via CI.
+#
+# Usage:
+#   ./scripts/release-trigger.sh                         # Preview release (auto-infer from VERSION)
+#   ./scripts/release-trigger.sh promote <rc|beta|stable> # Preview type promotion
+#   ./scripts/release-trigger.sh bump <minor|major>      # Preview version bump
+#   ./scripts/release-trigger.sh --do-it                 # Execute release via CI
+#   ./scripts/release-trigger.sh promote rc --do-it      # Execute promotion via CI
+#   ./scripts/release-trigger.sh bump minor --do-it      # Execute bump via CI
+#
+# The script shows a dry-run preview, then exits. Pass --do-it to trigger CI.
+#
+# See: https://gitlab.com/autops/wharf/meta/-/blob/main/standards/release-process.md
+
+set -eu
+
+# ── Parse arguments ──────────────────────────────────────────────────────
+
+DO_IT=0
+SUBCOMMAND=""
+ARG=""
+
+for _arg in "$@"; do
+    case "$_arg" in
+        --do-it) DO_IT=1 ;;
+        promote|bump)
+            if [ -n "$SUBCOMMAND" ]; then
+                echo "ERROR: unexpected argument: $_arg" >&2; exit 1
+            fi
+            SUBCOMMAND="$_arg"
+            ;;
+        *)
+            if [ -n "$SUBCOMMAND" ] && [ -z "$ARG" ]; then
+                ARG="$_arg"
+            else
+                echo "ERROR: unexpected argument: '$_arg'" >&2
+                echo "       Usage: release-trigger.sh [promote <type>|bump <scope>] [--do-it]" >&2
+                exit 1
+            fi
+            ;;
+    esac
+done
+
+# ── Validate subcommand arguments ────────────────────────────────────────
+
+if [ "$SUBCOMMAND" = "promote" ]; then
+    case "$ARG" in
+        beta|rc|stable) ;;
+        "") echo "ERROR: 'promote' requires a target: beta, rc, or stable" >&2; exit 1 ;;
+        *)  echo "ERROR: invalid promote target '$ARG' (use: beta, rc, stable)" >&2; exit 1 ;;
+    esac
+elif [ "$SUBCOMMAND" = "bump" ]; then
+    case "$ARG" in
+        minor|major) ;;
+        "") echo "ERROR: 'bump' requires a scope: minor or major" >&2; exit 1 ;;
+        *)  echo "ERROR: invalid bump scope '$ARG' (use: minor, major)" >&2; exit 1 ;;
+    esac
+fi
+
+# ── Show dry-run preview ────────────────────────────────────────────────
+
+if [ "$SUBCOMMAND" = "bump" ]; then
+    echo "=== Version Bump Preview ==="
+    echo ""
+    DRY_RUN=1 RELEASE_TYPE=bump RELEASE_SCOPE="$ARG" ./scripts/release.sh
+else
+    echo "=== Release Preview ==="
+    echo ""
+    if [ "$SUBCOMMAND" = "promote" ]; then
+        DRY_RUN=1 RELEASE_TYPE="$ARG" ./scripts/release.sh
+    else
+        DRY_RUN=1 ./scripts/release.sh
+    fi
+fi
+echo ""
+
+# ── If not --do-it, show how to proceed and exit ─────────────────────────
+
+if [ "$DO_IT" != "1" ]; then
+    echo "---"
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "To execute, run:"
+        echo "  mise run release bump $ARG -- --do-it"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "To execute, run:"
+        echo "  mise run release promote $ARG -- --do-it"
+    else
+        echo "To execute, run:"
+        echo "  mise run release -- --do-it"
+    fi
+    exit 0
+fi
+
+# ── Trigger CI ───────────────────────────────────────────────────────────
+
+echo "=== Triggering CI ==="
+echo ""
+
+REMOTE=$(git remote get-url origin 2>/dev/null || true)
+if echo "$REMOTE" | grep -q github.com; then
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "Dispatching GitHub workflow: release-bump.yml (scope=${ARG})"
+        gh workflow run release-bump.yml --field "scope=${ARG}"
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-bump.yml"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "Dispatching GitHub workflow: release-promote.yml (to=${ARG})"
+        gh workflow run release-promote.yml --field "to=${ARG}"
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-promote.yml"
+    else
+        echo "Dispatching GitHub workflow: release-create.yml"
+        gh workflow run release-create.yml
+        echo ""
+        echo "Watch progress:"
+        echo "  gh run list --workflow=release-create.yml"
+    fi
+elif echo "$REMOTE" | grep -q gitlab; then
+    if [ "$SUBCOMMAND" = "bump" ]; then
+        echo "Creating GitLab pipeline on main (BUMP_SCOPE=${ARG})"
+        glab ci run --branch main --variables-env "BUMP_SCOPE:${ARG}"
+    elif [ "$SUBCOMMAND" = "promote" ]; then
+        echo "Creating GitLab pipeline on main (PROMOTE_TO=${ARG})"
+        glab ci run --branch main --variables-env "PROMOTE_TO:${ARG}"
+    else
+        echo "Creating GitLab pipeline on main (RELEASE_CREATE=1)"
+        glab ci run --branch main --variables-env "RELEASE_CREATE:1"
+    fi
+    echo ""
+    echo "Watch progress:"
+    echo "  glab ci status"
+else
+    echo "ERROR: unsupported remote: $REMOTE" >&2
+    exit 1
+fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -8,7 +8,8 @@
 #   RELEASE_TYPE=alpha ./scripts/release.sh  # Via env var (CI)
 #
 # Environment:
-#   RELEASE_TYPE   Release type: alpha|beta|rc|stable|bump (or positional arg)
+#   RELEASE_TYPE   Release type: auto|alpha|beta|rc|stable|bump (or positional arg)
+#                  When unset or 'auto', infers from VERSION file.
 #   RELEASE_SCOPE  Bump scope: minor|major (or positional arg after "bump")
 #   DRY_RUN        1 = preview without changes (default: 0)
 #   CI             Set by CI runners; enables push and git identity setup
@@ -156,6 +157,15 @@ transition_prerelease() {
     echo "${base}-${target}.0"
 }
 
+type_order() {
+    case "$1" in
+        alpha) echo 0 ;;
+        beta)  echo 1 ;;
+        rc)    echo 2 ;;
+        *)     echo 99 ;;
+    esac
+}
+
 # ── Validation ────────────────────────────────────────────────────────────
 
 validate_version() {
@@ -272,11 +282,23 @@ release_prerelease() {
 
     current_type=$(prerelease_type "$current")
 
-    # Determine release version
+    # Regression guard: block downgrade transitions
+    if [ -n "$current_type" ] && [ "$current_type" != "$target_type" ]; then
+        current_order=$(type_order "$current_type")
+        target_order=$(type_order "$target_type")
+        if [ "$target_order" -lt "$current_order" ]; then
+            die "Requested type '$target_type' is a regression from current type '$current_type'.
+To restart from $target_type, use release-bump to advance to the next cycle first."
+        fi
+    fi
+
+    # Block prerelease creation from stable version
     if [ -z "$current_type" ]; then
-        # No prerelease suffix — start new prerelease cycle
-        release_version=$(start_prerelease "$current" "$target_type")
-    elif [ "$current_type" = "$target_type" ]; then
+        die "No prerelease in VERSION ($current). Use release-bump to start a new cycle."
+    fi
+
+    # Determine release version
+    if [ "$current_type" = "$target_type" ]; then
         # Same type — current version IS the release version
         release_version="$current"
     else
@@ -452,7 +474,20 @@ EOF
 }
 
 main() {
-    [ -n "$RELEASE_TYPE" ] || usage
+    # Auto-infer type from VERSION if not specified
+    if [ -z "$RELEASE_TYPE" ] || [ "$RELEASE_TYPE" = "auto" ]; then
+        current=$(read_version)
+        validate_version "$current"
+        case "$current" in
+            *-alpha.*) RELEASE_TYPE=alpha ;;
+            *-beta.*)  RELEASE_TYPE=beta ;;
+            *-rc.*)    RELEASE_TYPE=rc ;;
+            *)
+                die "No prerelease in VERSION ($current). Use release-bump to start a new cycle."
+                ;;
+        esac
+        log_info "Auto-detected release type: $RELEASE_TYPE"
+    fi
 
     if [ "$DRY_RUN" = "1" ]; then
         log_warn "DRY_RUN mode — no changes will be made"


### PR DESCRIPTION
Depends on go-kure/.github PR (already merged).

Applies the same release workflow redesign as go-kure/kure#581:
- `release-create` auto-infers release type from VERSION (no type dropdown)
- `release-promote` for intentional type transitions (beta/rc/stable)
- `release-bump` for advancing version cycle (minor/major)
- `release-publish` (renamed from `release`) triggered by tag push

Also adds the missing `scripts/release-trigger.sh`.

## Verification

```bash
# Regression guard works
DRY_RUN=1 RELEASE_TYPE=stable ./scripts/release.sh  # should error (alpha→stable without explicit promote)
# Auto-infer works
DRY_RUN=1 ./scripts/release.sh  # should show alpha release preview
```