### PR TITLE
feat(oam): passthrough component for arbitrary CRDs / non-standard objects

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -319,6 +319,7 @@ This monolithic layout is owned by launcher and generated as part of `kurel buil
 - Component handlers: webservice, worker, postgresql, cronjob, helmchart, daemonset, statefulset (#48)
 - Trait handlers — workload set: expose, certificate, external-secret, pvc, scaler (#49)
 - Trait handlers — network/infra set: ingress, httproute, configmap, networkpolicy, cilium-networkpolicy, volsync (#50)
+- Generic `passthrough` component — emits arbitrary CRDs / non-standard objects with no per-type Go handler (#105)
 
 **Phase 3: CLI integration** (#33)
 - `kurel build` — OAM mode (app.yaml + --profile cluster.yaml → manifests) (#51)
@@ -338,9 +339,11 @@ This monolithic layout is owned by launcher and generated as part of `kurel buil
    publish always-on packages; separate packages cover distinct deployment variants.
    Boolean on/off gates and multi-instance support are Phase 2 (issue #39).
 
-2. **Generic/raw YAML escape hatch** — A component type that passes through arbitrary
-   YAML would let package authors handle cases outside the built-in handler set. Not
-   in scope for Phase 1; tracked as future work.
+2. **Generic/raw YAML escape hatch** — Implemented as the `passthrough` component
+   (#105): it emits an arbitrary Kubernetes object declared inline under `object:`,
+   with a `clusterScoped` flag for cluster-scoped resources, covering cases outside the
+   built-in handler set. Config-driven custom *traits* and template/plugin rendering
+   remain future work (#102).
 
 3. **Package distribution** — How kurel packages are published, versioned, and referenced
    by consumers. A standard local layout that lets `kurel build` run without extra flags

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -116,6 +116,7 @@ Migrated from crane. Each type maps to a `ComponentHandler` implementation in
 | `helmchart` | FluxCD HelmRelease for third-party charts. Supports inline source creation (`source.url`) and reference to existing source CRs (`source.name`). Multiple components sharing the same source key share a single source CR (first component wins). For HelmRepository the key is the URL; for OCIRepository the key is URL+version, so two OCI components with the same URL but different versions each get their own source CR. |
 | `daemonset` | DaemonSet for node-level agents. Optional `port: <N>` generates a ClusterIP Service exposing port N; required when the daemonset acts as an implicit backend for ingress, httproute, or expose traits. |
 | `statefulset` | StatefulSet for ordered, persistent workloads |
+| `passthrough` | Generic escape hatch (launcher-native, not migrated from crane): emits an arbitrary Kubernetes object — CRD or non-standard type — declared inline under `object:`. Set `clusterScoped: true` for cluster-scoped resources (no namespace injected). `object.metadata.name` defaults to the component name. No standard trait/port integration or auto health check. |
 
 ### 4.3 Supported trait types (Phase 1)
 

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -116,7 +116,7 @@ Migrated from crane. Each type maps to a `ComponentHandler` implementation in
 | `helmchart` | FluxCD HelmRelease for third-party charts. Supports inline source creation (`source.url`) and reference to existing source CRs (`source.name`). Multiple components sharing the same source key share a single source CR (first component wins). For HelmRepository the key is the URL; for OCIRepository the key is URL+version, so two OCI components with the same URL but different versions each get their own source CR. |
 | `daemonset` | DaemonSet for node-level agents. Optional `port: <N>` generates a ClusterIP Service exposing port N; required when the daemonset acts as an implicit backend for ingress, httproute, or expose traits. |
 | `statefulset` | StatefulSet for ordered, persistent workloads |
-| `passthrough` | Generic escape hatch (launcher-native, not migrated from crane): emits an arbitrary Kubernetes object — CRD or non-standard type — declared inline under `object:`. Set `clusterScoped: true` for cluster-scoped resources (no namespace injected). `object.metadata.name` defaults to the component name. No standard trait/port integration or auto health check. |
+| `passthrough` | Generic escape hatch (launcher-native, not migrated from crane): emits an arbitrary Kubernetes object — CRD or non-standard type — declared inline under `object:`. Set `clusterScoped: true` for cluster-scoped resources (no namespace injected). `object.metadata.name` defaults to the component name. For namespaced objects `object.metadata.namespace` defaults to the build namespace when unset, but an inline value is respected (intentional cross-namespace). No standard trait/port integration or auto health check. |
 
 ### 4.3 Supported trait types (Phase 1)
 

--- a/examples/15-passthrough-minimal.yaml
+++ b/examples/15-passthrough-minimal.yaml
@@ -1,0 +1,30 @@
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: passthrough-demo
+spec:
+  components:
+  # A namespaced CRD with no built-in handler — emitted verbatim.
+  - name: word-count
+    type: passthrough
+    properties:
+      object:
+        apiVersion: sparkoperator.k8s.io/v1beta2
+        kind: SparkApplication
+        spec:
+          type: Scala
+          mode: cluster
+          image: spark:3.5.0
+          mainClass: org.apache.spark.examples.JavaWordCount
+  # A cluster-scoped object — set clusterScoped so no namespace is injected.
+  - name: word-count-reader
+    type: passthrough
+    properties:
+      clusterScoped: true
+      object:
+        apiVersion: rbac.authorization.k8s.io/v1
+        kind: ClusterRole
+        rules:
+        - apiGroups: ["sparkoperator.k8s.io"]
+          resources: ["sparkapplications"]
+          verbs: ["get", "list", "watch"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,11 +30,12 @@ bin/kurel build examples/01-webservice-minimal.yaml \
 | 12 | [12-daemonset.yaml](12-daemonset.yaml) | daemonset | — | minimal |
 | 13 | [13-statefulset.yaml](13-statefulset.yaml) | statefulset | — | minimal |
 | 14 | [14-full-stack.yaml](14-full-stack.yaml) | webservice×3, worker, cronjob, postgresql, helmchart, daemonset, statefulset | expose, expose.internal, certificate, external-secret, configmap, scaler | gateway-certmanager-aws |
+| 15 | [15-passthrough-minimal.yaml](15-passthrough-minimal.yaml) | passthrough (SparkApplication CRD + cluster-scoped ClusterRole) | — | minimal |
 
 **Profile compatibility notes:**
 - Examples 03–04, 06, 08 also work with `gateway-certmanager-aws.yaml`
 - Example 14 also works with `nginx-certmanager-vault.yaml`
-- Examples 01, 05, 07, 09–13 work with any profile
+- Examples 01, 05, 07, 09–13, 15 work with any profile
 
 ## Cluster profiles
 
@@ -111,6 +112,7 @@ transformer.SetCapabilityDefs(capDefs)
 
 ### Future work
 
-Config-driven extensibility (custom traits and components without Go code, CRD passthrough,
-standard Kubernetes API coverage) is tracked in
+The `passthrough` component type (see example 15) already emits arbitrary CRDs and
+non-standard objects with no Go handler. Broader config-driven extensibility — custom
+*traits* and template/plugin-rendered components without Go code — is tracked in
 [issue #102](https://github.com/go-kure/launcher/issues/102).

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -234,6 +234,7 @@ func newBuiltinTransformer() *oam.Transformer {
 			"statefulset": &components.StatefulsetHandler{},
 			"postgresql":  &components.PostgresqlHandler{},
 			"helmchart":   &components.HelmchartHandler{},
+			"passthrough": &components.PassthroughHandler{},
 		},
 		nil,
 	)

--- a/pkg/oam/builtin/components/passthrough.go
+++ b/pkg/oam/builtin/components/passthrough.go
@@ -1,8 +1,6 @@
 package components
 
 import (
-	"maps"
-
 	"github.com/go-kure/kure/pkg/stack"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,15 +93,17 @@ type PassthroughConfig struct {
 	Object        map[string]any
 }
 
-// Generate emits the declared object as an unstructured resource. It clones the
-// object and metadata maps before the metadata fixup so the source properties are
-// never mutated; other nested values are not mutated and may be aliased.
+// Generate emits the declared object as an unstructured resource. It deep-copies
+// the object first so the metadata fixup — and any later in-place mutation of
+// labels/annotations by the delivery layer (kure stack.Bundle.Generate) — never
+// touches the source component properties.
 func (c *PassthroughConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
-	obj := maps.Clone(c.Object)
+	obj := deepCopyMap(c.Object)
 
-	meta := map[string]any{}
-	if existing, ok := obj["metadata"].(map[string]any); ok {
-		meta = maps.Clone(existing)
+	meta, _ := obj["metadata"].(map[string]any)
+	if meta == nil {
+		meta = map[string]any{}
+		obj["metadata"] = meta
 	}
 	if name, ok := meta["name"].(string); !ok || name == "" {
 		meta["name"] = c.ComponentName
@@ -113,9 +113,35 @@ func (c *PassthroughConfig) Generate(_ *stack.Application) ([]*client.Object, er
 			meta["namespace"] = c.Namespace
 		}
 	}
-	obj["metadata"] = meta
 
 	u := &unstructured.Unstructured{Object: obj}
 	out := client.Object(u)
 	return []*client.Object{&out}, nil
+}
+
+// deepCopyMap returns a deep copy of a decoded YAML/JSON map: nested maps and
+// slices are cloned, scalars (immutable) are copied by value. Unlike
+// runtime.DeepCopyJSON it does not assume JSON-typed scalars, so it is safe for
+// whatever scalar types the OAM decoder produces.
+func deepCopyMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCopyMap(t)
+	case []any:
+		out := make([]any, len(t))
+		for i, e := range t {
+			out[i] = deepCopyValue(e)
+		}
+		return out
+	default:
+		return v
+	}
 }

--- a/pkg/oam/builtin/components/passthrough.go
+++ b/pkg/oam/builtin/components/passthrough.go
@@ -1,0 +1,121 @@
+package components
+
+import (
+	"maps"
+
+	"github.com/go-kure/kure/pkg/stack"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// PassthroughHandler handles the generic "passthrough" component type, which emits
+// an arbitrary Kubernetes object (CRD or non-standard type) declared inline. The
+// component properties separate control (clusterScoped) from the emitted body (object):
+//
+//	type: passthrough
+//	properties:
+//	  clusterScoped: false   # optional, default false
+//	  object:                # the Kubernetes object, emitted verbatim
+//	    apiVersion: ...
+//	    kind: ...
+//	    metadata: { ... }    # optional; name defaults to the component name
+//	    spec: { ... }        # any top-level fields pass through
+type PassthroughHandler struct{}
+
+// CanHandle returns true for the passthrough component type.
+func (h *PassthroughHandler) CanHandle(componentType string) bool {
+	return componentType == "passthrough"
+}
+
+// ToApplicationConfig validates the passthrough properties and returns a PassthroughConfig.
+func (h *PassthroughHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	props := component.Properties
+
+	for key := range props {
+		if key != "object" && key != "clusterScoped" {
+			return nil, errors.Errorf("passthrough component %q: unsupported property %q (only 'object' and 'clusterScoped' are allowed)", component.Name, key)
+		}
+	}
+
+	clusterScoped := false
+	if raw, ok := props["clusterScoped"]; ok {
+		b, isBool := raw.(bool)
+		if !isBool {
+			return nil, errors.Errorf("passthrough component %q: 'clusterScoped' must be a bool", component.Name)
+		}
+		clusterScoped = b
+	}
+
+	rawObj, ok := props["object"]
+	if !ok {
+		return nil, errors.Errorf("passthrough component %q: required property 'object' missing", component.Name)
+	}
+	object, ok := rawObj.(map[string]any)
+	if !ok {
+		return nil, errors.Errorf("passthrough component %q: 'object' must be a map", component.Name)
+	}
+
+	if apiVersion, ok := object["apiVersion"].(string); !ok || apiVersion == "" {
+		return nil, errors.Errorf("passthrough component %q: object.apiVersion is required and must be a non-empty string", component.Name)
+	}
+	if kind, ok := object["kind"].(string); !ok || kind == "" {
+		return nil, errors.Errorf("passthrough component %q: object.kind is required and must be a non-empty string", component.Name)
+	}
+
+	if rawMeta, ok := object["metadata"]; ok {
+		meta, ok := rawMeta.(map[string]any)
+		if !ok {
+			return nil, errors.Errorf("passthrough component %q: object.metadata must be a map", component.Name)
+		}
+		if clusterScoped {
+			if ns, ok := meta["namespace"].(string); ok && ns != "" {
+				return nil, errors.Errorf("passthrough component %q: object.metadata.namespace must not be set when clusterScoped is true", component.Name)
+			}
+		}
+	}
+
+	return &PassthroughConfig{
+		ComponentName: component.Name,
+		Namespace:     namespace,
+		ClusterScoped: clusterScoped,
+		Object:        object,
+	}, nil
+}
+
+// PassthroughConfig implements stack.ApplicationConfig for passthrough components.
+// It emits the declared object verbatim, defaulting metadata.name to the component
+// name and (for namespaced objects) metadata.namespace to the build namespace.
+type PassthroughConfig struct {
+	ComponentName string
+	Namespace     string
+	ClusterScoped bool
+	Object        map[string]any
+}
+
+// Generate emits the declared object as an unstructured resource. It clones the
+// object and metadata maps before the metadata fixup so the source properties are
+// never mutated; other nested values are not mutated and may be aliased.
+func (c *PassthroughConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	obj := maps.Clone(c.Object)
+
+	meta := map[string]any{}
+	if existing, ok := obj["metadata"].(map[string]any); ok {
+		meta = maps.Clone(existing)
+	}
+	if name, ok := meta["name"].(string); !ok || name == "" {
+		meta["name"] = c.ComponentName
+	}
+	if !c.ClusterScoped {
+		if ns, ok := meta["namespace"].(string); !ok || ns == "" {
+			meta["namespace"] = c.Namespace
+		}
+	}
+	obj["metadata"] = meta
+
+	u := &unstructured.Unstructured{Object: obj}
+	out := client.Object(u)
+	return []*client.Object{&out}, nil
+}

--- a/pkg/oam/builtin/components/passthrough_test.go
+++ b/pkg/oam/builtin/components/passthrough_test.go
@@ -1,0 +1,184 @@
+package components_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func passthroughComponent(props map[string]any) *oam.Component {
+	return &oam.Component{Name: "my-res", Type: "passthrough", Properties: props}
+}
+
+// generate runs ToApplicationConfig + Generate and returns the single emitted object.
+func generatePassthrough(t *testing.T, props map[string]any, namespace string) *unstructured.Unstructured {
+	t.Helper()
+	h := &components.PassthroughHandler{}
+	cfg, err := h.ToApplicationConfig(passthroughComponent(props), namespace)
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	objs, err := cfg.Generate(nil)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	u, ok := (*objs[0]).(*unstructured.Unstructured)
+	if !ok {
+		t.Fatalf("expected *unstructured.Unstructured, got %T", *objs[0])
+	}
+	return u
+}
+
+func TestPassthroughHandler_CanHandle(t *testing.T) {
+	h := &components.PassthroughHandler{}
+	if !h.CanHandle("passthrough") {
+		t.Error("expected true for passthrough")
+	}
+	if h.CanHandle("webservice") {
+		t.Error("expected false for webservice")
+	}
+}
+
+func TestPassthroughHandler_NamespacedSpecObject(t *testing.T) {
+	u := generatePassthrough(t, map[string]any{
+		"object": map[string]any{
+			"apiVersion": "sparkoperator.k8s.io/v1beta2",
+			"kind":       "SparkApplication",
+			"spec":       map[string]any{"mode": "cluster"},
+		},
+	}, "data")
+
+	if u.GetAPIVersion() != "sparkoperator.k8s.io/v1beta2" {
+		t.Errorf("apiVersion = %q", u.GetAPIVersion())
+	}
+	if u.GetKind() != "SparkApplication" {
+		t.Errorf("kind = %q", u.GetKind())
+	}
+	if u.GetName() != "my-res" {
+		t.Errorf("name = %q, want defaulted to component name", u.GetName())
+	}
+	if u.GetNamespace() != "data" {
+		t.Errorf("namespace = %q, want build namespace", u.GetNamespace())
+	}
+	spec, _ := u.Object["spec"].(map[string]any)
+	if spec["mode"] != "cluster" {
+		t.Errorf("spec passthrough lost: %#v", u.Object["spec"])
+	}
+}
+
+func TestPassthroughHandler_PreservesUserMetadata(t *testing.T) {
+	u := generatePassthrough(t, map[string]any{
+		"object": map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata": map[string]any{
+				"name":   "explicit-name",
+				"labels": map[string]any{"team": "data"},
+			},
+			"spec": map[string]any{},
+		},
+	}, "ns1")
+
+	if u.GetName() != "explicit-name" {
+		t.Errorf("name = %q, want user-set name preserved", u.GetName())
+	}
+	if u.GetLabels()["team"] != "data" {
+		t.Errorf("labels lost: %#v", u.GetLabels())
+	}
+	if u.GetNamespace() != "ns1" {
+		t.Errorf("namespace = %q, want build namespace", u.GetNamespace())
+	}
+}
+
+func TestPassthroughHandler_NonSpecObject(t *testing.T) {
+	u := generatePassthrough(t, map[string]any{
+		"object": map[string]any{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"data":       map[string]any{"key": "value"},
+		},
+	}, "ns1")
+
+	data, _ := u.Object["data"].(map[string]any)
+	if data["key"] != "value" {
+		t.Errorf("data passthrough lost: %#v", u.Object["data"])
+	}
+	if u.GetName() != "my-res" || u.GetNamespace() != "ns1" {
+		t.Errorf("metadata fixup wrong: name=%q ns=%q", u.GetName(), u.GetNamespace())
+	}
+}
+
+func TestPassthroughHandler_ClusterScoped(t *testing.T) {
+	u := generatePassthrough(t, map[string]any{
+		"clusterScoped": true,
+		"object": map[string]any{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"rules":      []any{map[string]any{"verbs": []any{"get"}}},
+		},
+	}, "data")
+
+	if u.GetNamespace() != "" {
+		t.Errorf("cluster-scoped object must not get a namespace, got %q", u.GetNamespace())
+	}
+	if u.GetName() != "my-res" {
+		t.Errorf("name = %q", u.GetName())
+	}
+	if _, ok := u.Object["rules"].([]any); !ok {
+		t.Errorf("rules passthrough lost: %#v", u.Object["rules"])
+	}
+}
+
+func TestPassthroughHandler_Errors(t *testing.T) {
+	h := &components.PassthroughHandler{}
+	cases := map[string]map[string]any{
+		"missing object":       {},
+		"object not a map":     {"object": "nope"},
+		"missing apiVersion":   {"object": map[string]any{"kind": "Widget"}},
+		"missing kind":         {"object": map[string]any{"apiVersion": "example.com/v1"}},
+		"empty apiVersion":     {"object": map[string]any{"apiVersion": "", "kind": "Widget"}},
+		"unknown top key":      {"object": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}, "extra": 1},
+		"clusterScoped string": {"clusterScoped": "yes", "object": map[string]any{"apiVersion": "v1", "kind": "ConfigMap"}},
+		"metadata not a map":   {"object": map[string]any{"apiVersion": "v1", "kind": "ConfigMap", "metadata": "nope"}},
+		"clusterScoped with namespace": {
+			"clusterScoped": true,
+			"object": map[string]any{
+				"apiVersion": "rbac.authorization.k8s.io/v1", "kind": "ClusterRole",
+				"metadata": map[string]any{"namespace": "x"},
+			},
+		},
+	}
+	for name, props := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := h.ToApplicationConfig(passthroughComponent(props), "ns1"); err == nil {
+				t.Errorf("expected error for %q", name)
+			}
+		})
+	}
+}
+
+func TestPassthroughHandler_DoesNotMutateSource(t *testing.T) {
+	objMeta := map[string]any{"name": ""}
+	object := map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   objMeta,
+	}
+	props := map[string]any{"object": object}
+
+	_ = generatePassthrough(t, props, "ns1")
+
+	// Source metadata must be untouched (no injected name/namespace).
+	if _, ok := objMeta["namespace"]; ok {
+		t.Errorf("source metadata mutated: namespace injected into %#v", objMeta)
+	}
+	if objMeta["name"] != "" {
+		t.Errorf("source metadata mutated: name set to %q", objMeta["name"])
+	}
+}

--- a/pkg/oam/builtin/components/passthrough_test.go
+++ b/pkg/oam/builtin/components/passthrough_test.go
@@ -234,6 +234,45 @@ func walkBundles(n *stack.Node, fn func(*stack.Bundle)) {
 	}
 }
 
+func TestPassthroughHandler_RespectsInlineNamespace(t *testing.T) {
+	// clusterScoped:false respects a user-supplied namespace (intentional
+	// cross-namespace escape hatch); the build namespace is only a fallback.
+	u := generatePassthrough(t, map[string]any{
+		"object": map[string]any{
+			"apiVersion": "example.com/v1",
+			"kind":       "Widget",
+			"metadata":   map[string]any{"namespace": "other"},
+		},
+	}, "ns1")
+	if u.GetNamespace() != "other" {
+		t.Errorf("inline namespace not respected: got %q, want \"other\"", u.GetNamespace())
+	}
+}
+
+func TestPassthroughHandler_DeepCopyIsolatesSource(t *testing.T) {
+	srcSpec := map[string]any{"replicas": int64(1)}
+	srcLabels := map[string]any{"team": "data"}
+	object := map[string]any{
+		"apiVersion": "example.com/v1",
+		"kind":       "Widget",
+		"metadata":   map[string]any{"labels": srcLabels},
+		"spec":       srcSpec,
+	}
+
+	u := generatePassthrough(t, map[string]any{"object": object}, "ns1")
+
+	// Simulate downstream in-place edits to nested maps of the emitted object.
+	u.Object["spec"].(map[string]any)["replicas"] = int64(99)
+	u.Object["metadata"].(map[string]any)["labels"].(map[string]any)["team"] = "ops"
+
+	if srcSpec["replicas"] != int64(1) {
+		t.Errorf("source spec mutated through emitted object: %#v", srcSpec)
+	}
+	if srcLabels["team"] != "data" {
+		t.Errorf("source labels mutated through emitted object: %#v", srcLabels)
+	}
+}
+
 func TestPassthroughHandler_DoesNotMutateSource(t *testing.T) {
 	objMeta := map[string]any{"name": ""}
 	object := map[string]any{

--- a/pkg/oam/builtin/components/passthrough_test.go
+++ b/pkg/oam/builtin/components/passthrough_test.go
@@ -3,6 +3,7 @@ package components_test
 import (
 	"testing"
 
+	"github.com/go-kure/kure/pkg/stack"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/go-kure/launcher/pkg/oam"
@@ -160,6 +161,76 @@ func TestPassthroughHandler_Errors(t *testing.T) {
 				t.Errorf("expected error for %q", name)
 			}
 		})
+	}
+}
+
+func TestPassthrough_TransformWithPolicy(t *testing.T) {
+	tr := oam.NewTransformer(map[string]oam.ComponentHandler{
+		"passthrough": &components.PassthroughHandler{},
+	}, nil)
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "app", Namespace: "ns1"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name: "my-cr",
+				Type: "passthrough",
+				Properties: map[string]any{
+					"object": map[string]any{
+						"apiVersion": "example.com/v1",
+						"kind":       "Widget",
+						"spec":       map[string]any{"size": int64(3)},
+					},
+				},
+			}},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "ns1"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+
+	found := false
+	walkBundles(cluster.Node, func(b *stack.Bundle) {
+		for _, a := range b.Applications {
+			objs, err := a.Generate()
+			if err != nil {
+				t.Fatalf("Generate: %v", err)
+			}
+			for _, o := range objs {
+				u, ok := (*o).(*unstructured.Unstructured)
+				if !ok || u.GetKind() != "Widget" {
+					continue
+				}
+				found = true
+				if u.GetName() != "my-cr" || u.GetNamespace() != "ns1" {
+					t.Errorf("Widget metadata: name=%q ns=%q", u.GetName(), u.GetNamespace())
+				}
+			}
+		}
+	})
+	if !found {
+		t.Error("passthrough Widget was not emitted by the transform")
+	}
+}
+
+func walkBundles(n *stack.Node, fn func(*stack.Bundle)) {
+	if n == nil {
+		return
+	}
+	var visit func(b *stack.Bundle)
+	visit = func(b *stack.Bundle) {
+		if b == nil {
+			return
+		}
+		fn(b)
+		for _, ch := range b.Children {
+			visit(ch)
+		}
+	}
+	visit(n.Bundle)
+	for _, ch := range n.Children {
+		walkBundles(ch, fn)
 	}
 }
 

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -24,6 +24,7 @@ var validComponentTypes = map[string]bool{
 	"helmchart":   true,
 	"daemonset":   true,
 	"statefulset": true,
+	"passthrough": true,
 }
 
 // validTraitTypes is the set of supported trait types from design-kurel-package.md §4.3.

--- a/pkg/oam/validate_test.go
+++ b/pkg/oam/validate_test.go
@@ -5,6 +5,31 @@ import (
 	"testing"
 )
 
+func TestValidate_PassthroughComponent(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name: "my-cr",
+					Type: "passthrough",
+					Properties: map[string]any{
+						"object": map[string]any{
+							"apiVersion": "example.com/v1",
+							"kind":       "Widget",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := validate(app); err != nil {
+		t.Errorf("unexpected error for passthrough component: %v", err)
+	}
+}
+
 func TestValidate_ScalerTraitOnCronjob(t *testing.T) {
 	app := &Application{
 		APIVersion: SupportedAPIVersion,


### PR DESCRIPTION
Closes #105.

Adds a generic `passthrough` component type that emits an arbitrary Kubernetes object (CRD or non-standard type) declared inline — no per-type Go handler. Additive and non-breaking.

## OAM shape

```yaml
- name: my-spark-app
  type: passthrough
  properties:
    clusterScoped: false        # optional, default false
    object:                     # the emitted object, verbatim
      apiVersion: sparkoperator.k8s.io/v1beta2
      kind: SparkApplication
      metadata: { labels: { team: data } }   # optional; name defaults to component name
      spec: { ... }             # any top-level fields pass through (spec/data/rules/...)
```

Control (`clusterScoped`) is separated from the emitted body (`object`); only those two top-level properties are allowed.

## Behavior

- Validates `object` is a map with non-empty `apiVersion` and `kind`; rejects unknown top-level properties and a non-bool `clusterScoped`.
- **Scope-aware namespace:** `clusterScoped:false` (default) → `metadata.namespace` defaults to the build namespace when unset; `clusterScoped:true` → namespace is never set (and setting `object.metadata.namespace` is an error). Avoids rendering CRD/ClusterRole/ClusterIssuer/Namespace invalid.
- `metadata.name` defaults to the component name; user-set name/labels are preserved.
- Emits via `unstructured.Unstructured`. The `object`/`metadata` maps are cloned before the fixup so the source properties are never mutated.
- Registered in `validComponentTypes` and the kurel builtin transformer.

## Limitations (intentional, noted in docs)

- No routing/scaler trait integration (implements no `servicePortProvider`).
- No auto health check (not in `componentHealthCheckGVK`).
- A hard-coded `object.metadata.namespace` different from the build namespace emits cross-namespace — intended for the escape hatch.
- Template rendering / plugin handler registration / config-driven custom *traits* remain in #102.

## Verification

`mise run verify` green (tidy, lint 0 issues, all tests). Unit tests cover namespaced/cluster-scoped/non-spec objects, metadata defaulting/preservation, all validation errors, copy-safety, and an end-to-end `TransformWithPolicy`. Smoke-tested via `kurel build examples/15-passthrough-minimal.yaml` (SparkApplication gets the build namespace; ClusterRole gets none).

Bundled with #114 (already merged) in the upcoming kure-beta.3 launcher release that unblocks crane#216.