### PR TITLE
feat: rename daemonset Service port name from tcp to http

### DIFF
--- a/pkg/cmd/kurel/testdata/daemonset-httproute/expected.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-httproute/expected.yaml
@@ -20,7 +20,7 @@ spec:
         name: agent
         ports:
         - containerPort: 9090
-          name: tcp
+          name: http
           protocol: TCP
         resources:
           limits:
@@ -40,7 +40,7 @@ metadata:
   namespace: default
 spec:
   ports:
-  - name: tcp
+  - name: http
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/pkg/cmd/kurel/testdata/daemonset-ingress/expected.yaml
+++ b/pkg/cmd/kurel/testdata/daemonset-ingress/expected.yaml
@@ -20,7 +20,7 @@ spec:
         name: agent
         ports:
         - containerPort: 9090
-          name: tcp
+          name: http
           protocol: TCP
         resources:
           limits:
@@ -40,7 +40,7 @@ metadata:
   namespace: default
 spec:
   ports:
-  - name: tcp
+  - name: http
     port: 9090
     protocol: TCP
     targetPort: 9090

--- a/pkg/oam/builtin/components/daemonset.go
+++ b/pkg/oam/builtin/components/daemonset.go
@@ -189,7 +189,7 @@ func (c *DaemonsetConfig) createService(app *stack.Application) *corev1.Service 
 	kubernetes.SetServiceType(svc, corev1.ServiceTypeClusterIP)
 	kubernetes.SetServiceSelector(svc, map[string]string{"app": app.Name})
 	kubernetes.AddServicePort(svc, corev1.ServicePort{
-		Name:       "tcp",
+		Name:       "http",
 		Port:       c.Port,
 		TargetPort: intstr.FromInt32(c.Port),
 		Protocol:   corev1.ProtocolTCP,
@@ -212,7 +212,7 @@ func (c *DaemonsetConfig) createDaemonSet(app *stack.Application) (*appsv1.Daemo
 	applyProbes(container, c.Probes)
 	if c.Port > 0 {
 		kubernetes.AddContainerPort(container, corev1.ContainerPort{
-			Name:          "tcp",
+			Name:          "http",
 			ContainerPort: c.Port,
 			Protocol:      corev1.ProtocolTCP,
 		})

--- a/pkg/oam/builtin/components/daemonset_test.go
+++ b/pkg/oam/builtin/components/daemonset_test.go
@@ -266,7 +266,7 @@ func TestDaemonsetConfig_WithPort(t *testing.T) {
 			}
 			ports := o.Spec.Template.Spec.Containers[0].Ports
 			if len(ports) == 0 || ports[0].ContainerPort != 9090 {
-				t.Errorf("container port = %v, want [{tcp 9090}]", ports)
+				t.Errorf("container port = %v, want [{http 9090}]", ports)
 			}
 		case *corev1.Service:
 			foundSvc = true
@@ -333,5 +333,43 @@ func TestDaemonsetConfig_WithoutPort(t *testing.T) {
 	}
 	if len(objects) != 2 {
 		t.Errorf("expected 2 objects (DaemonSet + ServiceAccount), got %d", len(objects))
+	}
+}
+
+func TestDaemonsetHandler_ServicePortName_IsHttp(t *testing.T) {
+	h := &components.DaemonsetHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "node-exporter",
+		Type: "daemonset",
+		Properties: map[string]any{
+			"image": "prom/node-exporter:v1.0.0",
+			"port":  float64(9100),
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	app := stack.NewApplication("node-exporter", "monitoring", cfg)
+	objects, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	for _, objPtr := range objects {
+		switch obj := (*objPtr).(type) {
+		case *corev1.Service:
+			for _, p := range obj.Spec.Ports {
+				if p.Name != "http" {
+					t.Errorf("Service port name = %q, want %q", p.Name, "http")
+				}
+			}
+		case *appsv1.DaemonSet:
+			for _, c := range obj.Spec.Template.Spec.Containers {
+				for _, p := range c.Ports {
+					if p.Name != "http" {
+						t.Errorf("DaemonSet container port name = %q, want %q", p.Name, "http")
+					}
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Renames the Service and ContainerPort name from `tcp` to `http` on the daemonset component
- Matches the webservice component's port naming and crane's historical behavior
- Consumers routing by `portName: "http"` (e.g. ingress, httproute) would break on a straight swap without this fix

## Test plan
- [x] `TestDaemonsetHandler_ServicePortName_IsHttp` — asserts Service port name is `http`
- [x] `mise run verify` green

Closes #121