### PR TITLE
feat: revert volsync sub-app name to {sourcePVC}-backup

### DIFF
--- a/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
+++ b/pkg/cmd/kurel/testdata/volsync-minimal/expected.yaml
@@ -76,7 +76,7 @@ metadata:
 apiVersion: volsync.backube/v1alpha1
 kind: ReplicationSource
 metadata:
-  name: db-data-backup
+  name: data-backup
   namespace: default
 spec:
   restic:

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -1308,8 +1308,8 @@ func TestVolSyncHandler_Apply_AppendsToBundle(t *testing.T) {
 	if len(bundle.Applications) != 1 {
 		t.Fatalf("expected 1 bundle application, got %d", len(bundle.Applications))
 	}
-	if bundle.Applications[0].Name != "db-data-backup" {
-		t.Errorf("expected name 'db-data-backup', got %q", bundle.Applications[0].Name)
+	if bundle.Applications[0].Name != "data-backup" {
+		t.Errorf("expected name 'data-backup', got %q", bundle.Applications[0].Name)
 	}
 }
 
@@ -1382,7 +1382,7 @@ func TestVolSyncHandler_Apply_NegativePruneIntervalDays(t *testing.T) {
 	}
 }
 
-func TestVolSyncHandler_Apply_BundleNameIsComponentScoped(t *testing.T) {
+func TestVolSyncHandler_Apply_BundleNameIsPVCScoped(t *testing.T) {
 	h := &traits.VolSyncHandler{}
 	bundle := newBundle()
 	if err := h.Apply(&oam.Trait{
@@ -1391,8 +1391,8 @@ func TestVolSyncHandler_Apply_BundleNameIsComponentScoped(t *testing.T) {
 	}, newApp("mydb", "default"), bundle); err != nil {
 		t.Fatalf("Apply: %v", err)
 	}
-	if bundle.Applications[0].Name != "mydb-data-backup" {
-		t.Errorf("expected 'mydb-data-backup', got %q", bundle.Applications[0].Name)
+	if bundle.Applications[0].Name != "data-backup" {
+		t.Errorf("expected 'data-backup', got %q", bundle.Applications[0].Name)
 	}
 }
 

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -36,7 +36,10 @@ func (h *VolSyncHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 		return err
 	}
 
-	rsApp := stack.NewApplication(app.Name+"-"+config.SourcePVC+"-backup", app.Namespace, config)
+	// Sub-app name uses sourcePVC as identifier (not component name) to match
+	// crane's stable naming. Two components with the same PVC name in the same
+	// bundle would collide; OAM authors are expected to use unique PVC names.
+	rsApp := stack.NewApplication(config.SourcePVC+"-backup", app.Namespace, config)
 	bundle.Applications = append(bundle.Applications, rsApp)
 	return nil
 }

--- a/pkg/oam/builtin/traits/volsync_test.go
+++ b/pkg/oam/builtin/traits/volsync_test.go
@@ -1,0 +1,33 @@
+package traits_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+func TestVolSyncHandler_SubAppName_MatchesCrane(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	app := stack.NewApplication("myapp", "default", nil)
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{
+		Type: "volsync",
+		Properties: map[string]any{
+			"sourcePVC": "data-pvc",
+			"schedule":  "0 2 * * *",
+		},
+	}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(bundle.Applications))
+	}
+	want := "data-pvc-backup"
+	if got := bundle.Applications[0].Name; got != want {
+		t.Errorf("sub-app Name = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Removes the `app.Name` prefix from the volsync sub-app name, reverting to `{sourcePVC}-backup`
- Matches crane's stable naming convention; the prefix would cause resource renames on migration, orphaning backup snapshot history

## Test plan
- [x] `TestVolSyncHandler_SubAppName_MatchesCrane` — asserts sub-app name equals `{sourcePVC}-backup`
- [x] All volsync tests pass (includes updates to two tests with outdated expectations)
- [x] `mise run verify` green (tidy, lint, test)

Closes #120