### PR TITLE
feat: add FluxNamespace forwarding for configmap+helmchart combos

### DIFF
--- a/pkg/oam/builtin/components/helmchart.go
+++ b/pkg/oam/builtin/components/helmchart.go
@@ -253,6 +253,11 @@ type HelmchartConfig struct {
 	// renderChart is the function used to render Helm charts in template delivery mode.
 	// Defaults to helm.RenderChart; injectable for testing.
 	renderChart func(chartURL, version string, values map[string]any) ([]byte, error)
+
+	// fluxNS overrides the namespace for emitted Flux control-plane CRs
+	// (HelmRelease, HelmRepository, OCIRepository). Set by postProcessFluxNamespace
+	// via TransformContext.FluxNamespace. Empty means use c.Namespace.
+	fluxNS string
 }
 
 // ApplyPolicy is a no-op for helmchart (Helm releases have no resource-limit policy).
@@ -283,6 +288,20 @@ func (c *HelmchartConfig) SuppressSourceGeneration(refName string) {
 	c.sharedSrcName = refName
 }
 
+// fluxNamespace returns the namespace for Flux control-plane CRs.
+func (c *HelmchartConfig) fluxNamespace() string {
+	if c.fluxNS != "" {
+		return c.fluxNS
+	}
+	return c.Namespace
+}
+
+// SetFluxNamespace re-stamps the Flux control-plane namespace for HelmRelease,
+// HelmRepository, and OCIRepository. Satisfies pkg/oam.fluxNamespaceSettable.
+func (c *HelmchartConfig) SetFluxNamespace(ns string) {
+	c.fluxNS = ns
+}
+
 // Generate produces the Kubernetes objects for this helmchart component.
 // For delivery: template, renders the chart client-side and returns raw manifests.
 // For delivery: native (default), emits a source CR (Form A only) and a HelmRelease.
@@ -304,13 +323,13 @@ func (c *HelmchartConfig) Generate(app *stack.Application) ([]*client.Object, er
 		if !c.suppressSource {
 			switch c.SourceKind {
 			case "HelmRepository":
-				repo := fluxcd.CreateHelmRepository(c.Name, c.Namespace)
+				repo := fluxcd.CreateHelmRepository(c.Name, c.fluxNamespace())
 				fluxcd.SetHelmRepositoryURL(repo, c.SourceURL)
 				fluxcd.SetHelmRepositoryInterval(repo, interval)
 				obj := client.Object(repo)
 				objects = append(objects, &obj)
 			case "OCIRepository":
-				repo := fluxcd.CreateOCIRepository(c.Name, c.Namespace)
+				repo := fluxcd.CreateOCIRepository(c.Name, c.fluxNamespace())
 				fluxcd.SetOCIRepositoryURL(repo, c.SourceURL)
 				fluxcd.SetOCIRepositoryInterval(repo, interval)
 				if c.Version != "" {
@@ -428,7 +447,7 @@ func decodeKubeManifests(raw []byte) ([]*client.Object, error) {
 // buildHelmRelease creates a HelmRelease with the shared options applied.
 func (c *HelmchartConfig) buildHelmRelease() *helmv2.HelmRelease {
 	interval := parseDuration(effectiveInterval(c.Interval))
-	hr := fluxcd.CreateHelmRelease(c.Name, c.Namespace)
+	hr := fluxcd.CreateHelmRelease(c.Name, c.fluxNamespace())
 	fluxcd.SetHelmReleaseInterval(hr, interval)
 
 	if c.ReleaseName != "" {

--- a/pkg/oam/builtin/components/helmchart_test.go
+++ b/pkg/oam/builtin/components/helmchart_test.go
@@ -645,6 +645,45 @@ func TestHelmchartHandler_InvalidHelmRepositoryURL_Rejected(t *testing.T) {
 	}
 }
 
+func TestHelmchartConfig_SetFluxNamespace_AffectsFluxCRNamespace(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "metrics",
+		Type: "helmchart",
+		Properties: map[string]any{
+			"chart": "kube-prometheus-stack",
+			"source": map[string]any{
+				"url": "https://prometheus-community.github.io/helm-charts",
+			},
+		},
+	}, "monitoring")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+
+	setter, ok := cfg.(interface{ SetFluxNamespace(string) })
+	if !ok {
+		t.Fatal("HelmchartConfig does not implement SetFluxNamespace")
+	}
+	setter.SetFluxNamespace("custom-flux")
+
+	app := stack.NewApplication("metrics", "monitoring", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	for _, objPtr := range objs {
+		obj := *objPtr
+		switch obj.(type) {
+		case *helmv2.HelmRelease, *sourcev1.HelmRepository:
+			if ns := obj.GetNamespace(); ns != "custom-flux" {
+				t.Errorf("%T.Namespace = %q, want %q", obj, ns, "custom-flux")
+			}
+		}
+	}
+}
+
 func TestHelmchartHandler_ValuesFrom_Validated(t *testing.T) {
 	h := &components.HelmchartHandler{}
 	cases := []struct {

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -15,6 +15,12 @@ import (
 	"github.com/go-kure/launcher/pkg/oam/builtin"
 )
 
+// fluxNamespaceSettable mirrors oam.fluxNamespaceSettable locally because
+// oam.fluxNamespaceSettable is unexported and cannot be referenced cross-package.
+type fluxNamespaceSettable interface {
+	SetFluxNamespace(string)
+}
+
 // ConfigMapHandler handles OAM configmap traits.
 type ConfigMapHandler struct{}
 
@@ -160,4 +166,14 @@ func (d *ConfigMapDecorator) Generate(app *stack.Application) ([]*client.Object,
 	}
 
 	return objects, nil
+}
+
+// SetFluxNamespace forwards the per-request Flux namespace to the inner config
+// when it satisfies fluxNamespaceSettable (e.g. HelmchartConfig). Without this,
+// a helmchart component with configmap.mountPath emits Flux CRs in the wrong
+// namespace when TransformContext.FluxNamespace is set.
+func (d *ConfigMapDecorator) SetFluxNamespace(ns string) {
+	if setter, ok := d.Inner.(fluxNamespaceSettable); ok {
+		setter.SetFluxNamespace(ns)
+	}
 }

--- a/pkg/oam/builtin/traits/configmap_test.go
+++ b/pkg/oam/builtin/traits/configmap_test.go
@@ -1,0 +1,171 @@
+package traits_test
+
+import (
+	"testing"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// fluxNSCapture is a stub ApplicationConfig that implements SetFluxNamespace.
+type fluxNSCapture struct {
+	lastNS string
+}
+
+func (f *fluxNSCapture) SetFluxNamespace(ns string) { f.lastNS = ns }
+func (f *fluxNSCapture) Generate(_ *stack.Application) ([]*client.Object, error) {
+	return nil, nil
+}
+
+func TestConfigMapDecorator_SetFluxNamespace_Forwards(t *testing.T) {
+	inner := &fluxNSCapture{}
+	dec := &traits.ConfigMapDecorator{
+		Inner:         inner,
+		ConfigMapName: "my-config",
+		MountPath:     "/etc/config",
+	}
+
+	setter, ok := any(dec).(interface{ SetFluxNamespace(string) })
+	if !ok {
+		t.Fatal("ConfigMapDecorator does not implement SetFluxNamespace")
+	}
+
+	setter.SetFluxNamespace("custom-flux")
+
+	if inner.lastNS != "custom-flux" {
+		t.Errorf("inner.lastNS = %q, want %q", inner.lastNS, "custom-flux")
+	}
+}
+
+func TestConfigMapDecorator_SetFluxNamespace_NoopWhenInnerLacksInterface(t *testing.T) {
+	inner := &cmStub{name: "app", namespace: "default"} // defined in pruneprotection_test.go
+	dec := &traits.ConfigMapDecorator{
+		Inner:         inner,
+		ConfigMapName: "my-config",
+		MountPath:     "/etc/config",
+	}
+
+	setter, ok := any(dec).(interface{ SetFluxNamespace(string) })
+	if !ok {
+		t.Fatal("ConfigMapDecorator does not implement SetFluxNamespace")
+	}
+
+	// Must not panic when inner doesn't implement the interface.
+	setter.SetFluxNamespace("custom-flux")
+}
+
+func TestConfigMapHandler_Apply_NoMountPath(t *testing.T) {
+	h := &traits.ConfigMapHandler{}
+	app := stack.NewApplication("myapp", "default", nil)
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{
+		Type: "configmap",
+		Properties: map[string]any{
+			"name": "my-config",
+			"data": map[string]any{"key": "val"},
+		},
+	}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(bundle.Applications) != 1 {
+		t.Fatalf("expected 1 bundle app, got %d", len(bundle.Applications))
+	}
+}
+
+func TestTransform_FluxNamespace_ReachesHelmRelease(t *testing.T) {
+	// Build a transformer with helmchart component handler and configmap trait handler.
+	transformer := oam.NewTransformer(
+		map[string]oam.ComponentHandler{
+			"helmchart": &components.HelmchartHandler{},
+		},
+		nil,
+	)
+	transformer.RegisterBuiltinTrait("configmap", &traits.ConfigMapHandler{})
+
+	// OAM app: helmchart component + configmap trait WITHOUT mountPath.
+	// Without mountPath the configmap trait adds a sibling ConfigMap app but does NOT
+	// wrap the helmchart config, so postProcessFluxNamespace calls SetFluxNamespace
+	// directly on HelmchartConfig — exercising the pipeline wiring.
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name: "metrics",
+					Type: "helmchart",
+					Properties: map[string]any{
+						"chart": "kube-prometheus-stack",
+						"source": map[string]any{
+							"url": "https://prometheus-community.github.io/helm-charts",
+						},
+					},
+					Traits: []oam.Trait{
+						{
+							Type: "configmap",
+							Properties: map[string]any{
+								"name": "metrics-config",
+								"data": map[string]any{"key": "val"},
+								// no mountPath — configmap adds sibling, does not wrap
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cluster, err := transformer.Transform(app, oam.TransformContext{
+		FluxNamespace: "custom-flux",
+	})
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+
+	// Collect all apps from all leaf bundles.
+	var allApps []*stack.Application
+	var collectApps func(node *stack.Node)
+	collectApps = func(node *stack.Node) {
+		if node == nil {
+			return
+		}
+		if node.Bundle != nil && !node.Bundle.IsUmbrella() {
+			allApps = append(allApps, node.Bundle.Applications...)
+		}
+		for _, child := range node.Children {
+			collectApps(child)
+		}
+	}
+	collectApps(cluster.Node)
+
+	// Find the helmchart app, generate its resources, and assert namespaces.
+	var found bool
+	for _, bundleApp := range allApps {
+		if bundleApp.Name != "metrics" {
+			continue
+		}
+		objs, genErr := bundleApp.Config.Generate(bundleApp)
+		if genErr != nil {
+			t.Fatalf("Generate: %v", genErr)
+		}
+		for _, objPtr := range objs {
+			obj := *objPtr
+			switch obj.(type) {
+			case *helmv2.HelmRelease, *sourcev1.HelmRepository:
+				found = true
+				if ns := obj.GetNamespace(); ns != "custom-flux" {
+					t.Errorf("%T.Namespace = %q, want %q", obj, ns, "custom-flux")
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("no HelmRelease or HelmRepository found in cluster")
+	}
+}

--- a/pkg/oam/builtin/traits/pruneprotection.go
+++ b/pkg/oam/builtin/traits/pruneprotection.go
@@ -61,3 +61,11 @@ func (p *pruneProtectedConfig) Validate() error {
 	}
 	return nil
 }
+
+// SetFluxNamespace forwards the per-request Flux namespace to the wrapped
+// config when it satisfies fluxNamespaceSettable (e.g. HelmchartConfig).
+func (p *pruneProtectedConfig) SetFluxNamespace(ns string) {
+	if setter, ok := p.wrapped.(fluxNamespaceSettable); ok {
+		setter.SetFluxNamespace(ns)
+	}
+}

--- a/pkg/oam/builtin/traits/pruneprotection_test.go
+++ b/pkg/oam/builtin/traits/pruneprotection_test.go
@@ -142,6 +142,23 @@ func TestPruneProtectionHandler_Apply_DoesNotProtectSiblingApps(t *testing.T) {
 	}
 }
 
+func TestPruneProtectionHandler_Apply_ForwardsSetFluxNamespace(t *testing.T) {
+	// fluxNSCapture is defined in configmap_test.go in the same package traits_test.
+	inner := &fluxNSCapture{}
+	app := stack.NewApplication("myapp", "default", inner)
+	if err := (&traits.PruneProtectionHandler{}).Apply(&oam.Trait{Type: "prune-protection"}, app, &stack.Bundle{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	setter, ok := app.Config.(interface{ SetFluxNamespace(string) })
+	if !ok {
+		t.Fatal("pruneProtectedConfig does not implement SetFluxNamespace")
+	}
+	setter.SetFluxNamespace("custom-flux")
+	if inner.lastNS != "custom-flux" {
+		t.Errorf("inner.lastNS = %q, want %q", inner.lastNS, "custom-flux")
+	}
+}
+
 // cmStub is a minimal ApplicationConfig that emits a single ConfigMap.
 type cmStub struct {
 	name      string

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -19,14 +19,23 @@ type ValidateAndApplyDefaults interface {
 
 // TransformContext carries per-transform state passed to the pipeline.
 type TransformContext struct {
-	ClusterID    string
-	TenantID     string
-	Environment  string
-	AppVersion   string
-	TeamID       string
-	Namespace    string // overrides OAM metadata.namespace when set
-	Policy       Policy
-	Capabilities map[string]CapabilityBinding
+	ClusterID     string
+	TenantID      string
+	Environment   string
+	AppVersion    string
+	TeamID        string
+	Namespace     string // overrides OAM metadata.namespace when set
+	FluxNamespace string // Flux control-plane namespace; "" means use component namespace
+	Policy        Policy
+	Capabilities  map[string]CapabilityBinding
+}
+
+// fluxNamespaceSettable is implemented by ApplicationConfig types that emit
+// Flux CRDs (HelmRelease, HelmRepository, OCIRepository) and support per-request
+// namespace re-stamping. Decorators that wrap such configs must also implement
+// this interface and forward the call.
+type fluxNamespaceSettable interface {
+	SetFluxNamespace(string)
 }
 
 // Transformer is the core OAM runtime. Handlers are registered at startup;
@@ -288,6 +297,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides)
 	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
 	synthesizeNetworkPolicies(cluster)
+	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
 
 	return cluster, policyResult, nil
 }
@@ -685,6 +695,21 @@ var componentHealthCheckGVK = map[string]struct{ APIVersion, Kind string }{
 	"daemonset":   {"apps/v1", "DaemonSet"},
 	"helmchart":   {"helm.toolkit.fluxcd.io/v2", "HelmRelease"},
 	"postgresql":  {"postgresql.cnpg.io/v1", "Cluster"},
+}
+
+// postProcessFluxNamespace walks all leaf bundle applications and calls
+// SetFluxNamespace on any config that satisfies fluxNamespaceSettable.
+func postProcessFluxNamespace(cluster *stack.Cluster, ns string) {
+	if cluster == nil || ns == "" {
+		return
+	}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		for _, app := range bundle.Applications {
+			if setter, ok := app.Config.(fluxNamespaceSettable); ok {
+				setter.SetFluxNamespace(ns)
+			}
+		}
+	})
 }
 
 // applyAutoHealthChecks walks all leaf bundles and appends inferred health check


### PR DESCRIPTION
## Summary
- Adds `TransformContext.FluxNamespace` — per-request Flux control-plane namespace
- Adds `HelmchartConfig.SetFluxNamespace` — re-stamps the namespace on emitted HelmRelease/HelmRepository/OCIRepository
- Adds `ConfigMapDecorator.SetFluxNamespace` — forwards the call through the decorator chain
- Adds `postProcessFluxNamespace` walk in `TransformWithPolicy` that propagates the field after cluster build

Without this fix, applying a `configmap` trait with `mountPath` to a helmchart component silently wraps the HelmchartConfig in a ConfigMapDecorator that drops any `SetFluxNamespace` call, causing Flux CRs to land in the wrong namespace.

## Test plan
- [x] `TestConfigMapDecorator_SetFluxNamespace_Forwards` — verifies forwarding to inner
- [x] `TestConfigMapDecorator_SetFluxNamespace_NoopWhenInnerLacksInterface` — no panic when inner lacks interface
- [x] `TestHelmchartConfig_SetFluxNamespace_AffectsFluxCRNamespace` — HelmRelease/HelmRepository get correct namespace
- [x] `mise run verify` green

Closes #118