### PR TITLE
fix(oam): emit the flux namespace for helmchart auto health checks (crane#234)

### DIFF
--- a/pkg/oam/builtin/components/helmchart.go
+++ b/pkg/oam/builtin/components/helmchart.go
@@ -302,6 +302,14 @@ func (c *HelmchartConfig) SetFluxNamespace(ns string) {
 	c.fluxNS = ns
 }
 
+// EmitsAutoHealthCheck reports whether this component emits a HelmRelease that
+// the auto health-check can reference. Template delivery renders manifests
+// client-side and emits no HelmRelease, so no HelmRelease health check should
+// be synthesized. Satisfies pkg/oam.autoHealthCheckEmitter.
+func (c *HelmchartConfig) EmitsAutoHealthCheck() bool {
+	return c.Delivery != "template"
+}
+
 // Generate produces the Kubernetes objects for this helmchart component.
 // For delivery: template, renders the chart client-side and returns raw manifests.
 // For delivery: native (default), emits a source CR (Form A only) and a HelmRelease.

--- a/pkg/oam/builtin/components/helmchart_test.go
+++ b/pkg/oam/builtin/components/helmchart_test.go
@@ -723,3 +723,38 @@ func TestHelmchartHandler_ValuesFrom_Validated(t *testing.T) {
 		})
 	}
 }
+
+func TestHelmchartConfig_EmitsAutoHealthCheck(t *testing.T) {
+	h := &components.HelmchartHandler{}
+	mk := func(props map[string]any) stack.ApplicationConfig {
+		cfg, err := h.ToApplicationConfig(&oam.Component{Name: "c", Type: "helmchart", Properties: props}, "demo")
+		if err != nil {
+			t.Fatalf("ToApplicationConfig: %v", err)
+		}
+		return cfg
+	}
+	emitter := func(cfg stack.ApplicationConfig) bool {
+		e, ok := cfg.(interface{ EmitsAutoHealthCheck() bool })
+		if !ok {
+			t.Fatal("HelmchartConfig does not implement EmitsAutoHealthCheck")
+		}
+		return e.EmitsAutoHealthCheck()
+	}
+
+	native := mk(map[string]any{
+		"chart":  "redis",
+		"source": map[string]any{"url": "https://charts.example.com"},
+	})
+	if !emitter(native) {
+		t.Error("native delivery must emit a HelmRelease auto health check")
+	}
+
+	template := mk(map[string]any{
+		"chart":    "redis",
+		"delivery": "template",
+		"source":   map[string]any{"url": "https://charts.example.com"},
+	})
+	if emitter(template) {
+		t.Error("template delivery emits no HelmRelease, so must veto the auto health check")
+	}
+}

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -21,6 +21,13 @@ type fluxNamespaceSettable interface {
 	SetFluxNamespace(string)
 }
 
+// autoHealthCheckEmitter mirrors oam.autoHealthCheckEmitter locally (unexported
+// cross-package). Decorators forward it so a wrapped helmchart's template-delivery
+// veto still reaches the auto health-check synthesis.
+type autoHealthCheckEmitter interface {
+	EmitsAutoHealthCheck() bool
+}
+
 // ConfigMapHandler handles OAM configmap traits.
 type ConfigMapHandler struct{}
 
@@ -176,4 +183,14 @@ func (d *ConfigMapDecorator) SetFluxNamespace(ns string) {
 	if setter, ok := d.Inner.(fluxNamespaceSettable); ok {
 		setter.SetFluxNamespace(ns)
 	}
+}
+
+// EmitsAutoHealthCheck forwards the inner config's auto-health-check veto (e.g. a
+// wrapped helmchart with delivery=template emits no HelmRelease). Defaults to
+// true when the inner config does not implement the interface.
+func (d *ConfigMapDecorator) EmitsAutoHealthCheck() bool {
+	if e, ok := d.Inner.(autoHealthCheckEmitter); ok {
+		return e.EmitsAutoHealthCheck()
+	}
+	return true
 }

--- a/pkg/oam/builtin/traits/configmap_test.go
+++ b/pkg/oam/builtin/traits/configmap_test.go
@@ -169,3 +169,28 @@ func TestTransform_FluxNamespace_ReachesHelmRelease(t *testing.T) {
 		t.Error("no HelmRelease or HelmRepository found in cluster")
 	}
 }
+
+// hcVetoConfig implements ApplicationConfig + autoHealthCheckEmitter and vetoes
+// its auto health check (like a helmchart with delivery=template).
+type hcVetoConfig struct{ fluxNSCapture }
+
+func (c *hcVetoConfig) EmitsAutoHealthCheck() bool { return false }
+
+func TestConfigMapDecorator_EmitsAutoHealthCheck_Forwards(t *testing.T) {
+	dec := &traits.ConfigMapDecorator{Inner: &hcVetoConfig{}, ConfigMapName: "c", MountPath: "/etc/c"}
+	e, ok := any(dec).(interface{ EmitsAutoHealthCheck() bool })
+	if !ok {
+		t.Fatal("ConfigMapDecorator does not implement EmitsAutoHealthCheck")
+	}
+	if e.EmitsAutoHealthCheck() {
+		t.Error("expected veto (false) forwarded from inner template-delivery config")
+	}
+}
+
+func TestConfigMapDecorator_EmitsAutoHealthCheck_DefaultsTrue(t *testing.T) {
+	dec := &traits.ConfigMapDecorator{Inner: &cmStub{name: "app", namespace: "default"}, ConfigMapName: "c", MountPath: "/etc/c"}
+	e := any(dec).(interface{ EmitsAutoHealthCheck() bool })
+	if !e.EmitsAutoHealthCheck() {
+		t.Error("expected default true when inner does not implement autoHealthCheckEmitter")
+	}
+}

--- a/pkg/oam/builtin/traits/pruneprotection.go
+++ b/pkg/oam/builtin/traits/pruneprotection.go
@@ -69,3 +69,13 @@ func (p *pruneProtectedConfig) SetFluxNamespace(ns string) {
 		setter.SetFluxNamespace(ns)
 	}
 }
+
+// EmitsAutoHealthCheck forwards the wrapped config's auto-health-check veto so a
+// prune-protected helmchart with delivery=template still suppresses the bogus
+// HelmRelease health check. Defaults to true when the inner config lacks it.
+func (p *pruneProtectedConfig) EmitsAutoHealthCheck() bool {
+	if e, ok := p.wrapped.(autoHealthCheckEmitter); ok {
+		return e.EmitsAutoHealthCheck()
+	}
+	return true
+}

--- a/pkg/oam/builtin/traits/pruneprotection_test.go
+++ b/pkg/oam/builtin/traits/pruneprotection_test.go
@@ -159,6 +159,22 @@ func TestPruneProtectionHandler_Apply_ForwardsSetFluxNamespace(t *testing.T) {
 	}
 }
 
+func TestPruneProtectionHandler_Apply_ForwardsEmitsAutoHealthCheck(t *testing.T) {
+	// hcVetoConfig (configmap_test.go) vetoes its auto health check, like a
+	// helmchart with delivery=template.
+	app := stack.NewApplication("rendered", "default", &hcVetoConfig{})
+	if err := (&traits.PruneProtectionHandler{}).Apply(&oam.Trait{Type: "prune-protection"}, app, &stack.Bundle{}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	e, ok := app.Config.(interface{ EmitsAutoHealthCheck() bool })
+	if !ok {
+		t.Fatal("pruneProtectedConfig does not implement EmitsAutoHealthCheck")
+	}
+	if e.EmitsAutoHealthCheck() {
+		t.Error("expected veto (false) forwarded through prune-protection wrapper")
+	}
+}
+
 // cmStub is a minimal ApplicationConfig that emits a single ConfigMap.
 type cmStub struct {
 	name      string

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -38,6 +38,17 @@ type fluxNamespaceSettable interface {
 	SetFluxNamespace(string)
 }
 
+// autoHealthCheckEmitter is implemented by ApplicationConfig types whose
+// auto health-check (from componentHealthCheckGVK) is only valid when the
+// config actually emits the referenced object. Helmchart returns false for
+// delivery=template (it renders manifests and emits no HelmRelease), so no
+// HelmRelease health check should be synthesized. Decorators that wrap such
+// configs must forward this call (mirroring fluxNamespaceSettable). Configs
+// that do not implement it are assumed to emit their object.
+type autoHealthCheckEmitter interface {
+	EmitsAutoHealthCheck() bool
+}
+
 // Transformer is the core OAM runtime. Handlers are registered at startup;
 // Transform/TransformWithPolicy (added in #53) execute the pipeline.
 // Internal storage uses maps keyed by typeName for O(1) dispatch.
@@ -294,7 +305,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	for _, e := range entries {
 		componentMap[e.component.Name] = e
 	}
-	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides)
+	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides, ctx.FluxNamespace)
 	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
 	synthesizeNetworkPolicies(cluster)
 	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
@@ -712,9 +723,29 @@ func postProcessFluxNamespace(cluster *stack.Cluster, ns string) {
 	})
 }
 
+// isFluxControlPlaneGVK reports whether an auto health-check GVK targets a Flux
+// control-plane CR (a *.toolkit.fluxcd.io kind, e.g. HelmRelease) that
+// postProcessFluxNamespace relocates to the flux namespace. Workload kinds
+// (Deployment/StatefulSet/…) and app-namespace CRs (CNPG Cluster) stay in the
+// app namespace even when their config is wrapped by a fluxNamespaceSettable
+// decorator, so the namespace switch must be gated on this.
+func isFluxControlPlaneGVK(apiVersion string) bool {
+	group, _, _ := strings.Cut(apiVersion, "/")
+	return strings.HasSuffix(group, ".toolkit.fluxcd.io")
+}
+
 // applyAutoHealthChecks walks all leaf bundles and appends inferred health check
 // references based on each component's type, followed by any explicit overrides.
-func applyAutoHealthChecks(cluster *stack.Cluster, componentMap map[string]componentEntry, overrides []stack.HealthCheck) {
+//
+// The synthesized check's namespace must point at the namespace where the
+// referenced object actually lands. For Flux-CR configs (helmchart →
+// HelmRelease) the object is relocated to the flux namespace by
+// postProcessFluxNamespace, so the check must carry the same flux namespace —
+// this mirrors that function's predicate exactly (fluxNamespaceSettable +
+// non-empty fluxNamespace) so the check always follows its object. Configs that
+// will not emit the referenced object (helmchart delivery=template) are skipped
+// via autoHealthCheckEmitter.
+func applyAutoHealthChecks(cluster *stack.Cluster, componentMap map[string]componentEntry, overrides []stack.HealthCheck, fluxNamespace string) {
 	if cluster == nil {
 		return
 	}
@@ -728,11 +759,29 @@ func applyAutoHealthChecks(cluster *stack.Cluster, componentMap map[string]compo
 			if !ok {
 				continue
 			}
+			// Skip when the config will not emit the referenced object
+			// (e.g. helmchart delivery=template emits manifests, no HelmRelease).
+			if e, ok := app.Config.(autoHealthCheckEmitter); ok && !e.EmitsAutoHealthCheck() {
+				continue
+			}
+			// Mirror postProcessFluxNamespace: a config that re-stamps the flux
+			// namespace on its object emits that object in the flux namespace, so
+			// its health check must reference the flux namespace too. Gate on the
+			// target being a Flux control-plane CR (e.g. HelmRelease): wrappers
+			// (configmap/prune-protection) implement fluxNamespaceSettable even
+			// when wrapping a workload whose Deployment stays in the app namespace,
+			// so the settable check alone is too broad.
+			ns := app.Namespace
+			if fluxNamespace != "" && isFluxControlPlaneGVK(gvk.APIVersion) {
+				if _, settable := app.Config.(fluxNamespaceSettable); settable {
+					ns = fluxNamespace
+				}
+			}
 			bundle.HealthChecks = append(bundle.HealthChecks, stack.HealthCheck{
 				APIVersion: gvk.APIVersion,
 				Kind:       gvk.Kind,
 				Name:       app.Name,
-				Namespace:  app.Namespace,
+				Namespace:  ns,
 			})
 		}
 		bundle.HealthChecks = append(bundle.HealthChecks, overrides...)

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -1005,3 +1005,105 @@ func TestTransform_BuiltinTrait_CapabilityResolved_NoDefinition_NoWarn(t *testin
 		t.Errorf("unexpected warning for built-in trait: %q", warned)
 	}
 }
+
+// --- applyAutoHealthChecks namespace + delivery=template veto (#234) ---
+
+// fluxHCConfig implements ApplicationConfig + fluxNamespaceSettable (like a
+// native helmchart whose HelmRelease is relocated to the flux namespace).
+type fluxHCConfig struct{ ns string }
+
+func (c *fluxHCConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+func (c *fluxHCConfig) SetFluxNamespace(ns string)                              { c.ns = ns }
+
+// templateHCConfig is a fluxHCConfig that vetoes its auto health check (like a
+// helmchart with delivery=template: no HelmRelease object emitted).
+type templateHCConfig struct{ fluxHCConfig }
+
+func (c *templateHCConfig) EmitsAutoHealthCheck() bool { return false }
+
+// plainHCConfig implements only ApplicationConfig (a workload component whose
+// object stays in the app namespace; not flux-relocated).
+type plainHCConfig struct{}
+
+func (c *plainHCConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+
+func leafClusterWith(app *stack.Application) *stack.Cluster {
+	return &stack.Cluster{Node: &stack.Node{Bundle: &stack.Bundle{Applications: []*stack.Application{app}}}}
+}
+
+func helmchartEntryMap(app *stack.Application, typ string) map[string]componentEntry {
+	return map[string]componentEntry{app.Name: {component: Component{Name: app.Name, Type: typ}, app: app}}
+}
+
+func TestApplyAutoHealthChecks_FluxConfigUsesFluxNamespace(t *testing.T) {
+	app := stack.NewApplication("redis", "demo", &fluxHCConfig{})
+	cluster := leafClusterWith(app)
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "helmchart"), nil, "flux-system")
+
+	hc := cluster.Node.Bundle.HealthChecks
+	if len(hc) != 1 {
+		t.Fatalf("expected 1 health check, got %d", len(hc))
+	}
+	if hc[0].Kind != "HelmRelease" || hc[0].Namespace != "flux-system" {
+		t.Errorf("got %s/%s in %q, want HelmRelease in flux-system", hc[0].Kind, hc[0].Name, hc[0].Namespace)
+	}
+}
+
+func TestApplyAutoHealthChecks_EmptyFluxNamespaceUsesAppNamespace(t *testing.T) {
+	app := stack.NewApplication("redis", "demo", &fluxHCConfig{})
+	cluster := leafClusterWith(app)
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "helmchart"), nil, "")
+
+	hc := cluster.Node.Bundle.HealthChecks
+	if len(hc) != 1 || hc[0].Namespace != "demo" {
+		t.Fatalf("expected HelmRelease check in app namespace 'demo', got %+v", hc)
+	}
+}
+
+func TestApplyAutoHealthChecks_WorkloadKeepsAppNamespace(t *testing.T) {
+	app := stack.NewApplication("web", "demo", &plainHCConfig{})
+	cluster := leafClusterWith(app)
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "webservice"), nil, "flux-system")
+
+	hc := cluster.Node.Bundle.HealthChecks
+	if len(hc) != 1 || hc[0].Kind != "Deployment" || hc[0].Namespace != "demo" {
+		t.Fatalf("expected Deployment check in app namespace 'demo', got %+v", hc)
+	}
+}
+
+func TestApplyAutoHealthChecks_SettableWorkloadKeepsAppNamespace(t *testing.T) {
+	// A workload (webservice → Deployment) whose config is fluxNamespaceSettable
+	// — e.g. wrapped by configmap/prune-protection, whose wrapper implements
+	// SetFluxNamespace even though the Deployment stays in the app namespace.
+	// The check must NOT move to the flux namespace (target is not a Flux CR).
+	app := stack.NewApplication("web", "demo", &fluxHCConfig{})
+	cluster := leafClusterWith(app)
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "webservice"), nil, "flux-system")
+
+	hc := cluster.Node.Bundle.HealthChecks
+	if len(hc) != 1 || hc[0].Kind != "Deployment" || hc[0].Namespace != "demo" {
+		t.Fatalf("settable workload check must stay in app namespace 'demo', got %+v", hc)
+	}
+}
+
+func TestApplyAutoHealthChecks_TemplateDeliverySkipped(t *testing.T) {
+	app := stack.NewApplication("rendered", "demo", &templateHCConfig{})
+	cluster := leafClusterWith(app)
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "helmchart"), nil, "flux-system")
+
+	if hc := cluster.Node.Bundle.HealthChecks; len(hc) != 0 {
+		t.Fatalf("expected no auto health check for template delivery, got %+v", hc)
+	}
+}
+
+func TestApplyAutoHealthChecks_OverridesAppendedVerbatim(t *testing.T) {
+	app := stack.NewApplication("rendered", "demo", &templateHCConfig{})
+	cluster := leafClusterWith(app)
+	override := stack.HealthCheck{APIVersion: "helm.toolkit.fluxcd.io/v2", Kind: "HelmRelease", Name: "external", Namespace: "other-ns"}
+	applyAutoHealthChecks(cluster, helmchartEntryMap(app, "helmchart"), []stack.HealthCheck{override}, "flux-system")
+
+	hc := cluster.Node.Bundle.HealthChecks
+	if len(hc) != 1 || hc[0] != override {
+		t.Fatalf("expected the user override appended verbatim (namespace untouched), got %+v", hc)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the source of crane#234: a `helmchart` component's auto health-check was
synthesized with the **app namespace**, but its HelmRelease **object** is
relocated to the **flux namespace** by `postProcessFluxNamespace`. Flux resolves
a health-check by the referenced object's own namespace, so the auto check never
went healthy. crane patched it after the fact by rewriting the namespace
(name-matched), which could silently retarget a user-authored `health-checks`
policy entry referencing an external HelmRelease of the same name.

## Change

`applyAutoHealthChecks` now receives the flux namespace and, for configs that
re-stamp it onto their object (`fluxNamespaceSettable`, non-empty flux ns),
points the synthesized check at the flux namespace too — **mirroring
`postProcessFluxNamespace`'s predicate exactly** so the check always follows its
object. Workload/CR checks (webservice/worker/postgresql/…) keep the app
namespace. User `health-checks` overrides are appended verbatim and never
re-namespaced.

Additionally, stop synthesizing a HelmRelease auto-check when the component emits
no HelmRelease: new `autoHealthCheckEmitter` interface, implemented by the
helmchart config as `Delivery != "template"` (template delivery renders manifests
client-side and emits no HelmRelease). The `ConfigMapDecorator` and
prune-protection wrappers forward both `SetFluxNamespace` and
`EmitsAutoHealthCheck`, so a wrapped helmchart is handled identically (guards the
silent-fallback-to-emit failure mode).

## Tests

- `applyAutoHealthChecks`: flux-config → flux ns; empty flux ns → app ns; workload
  → app ns; delivery=template → no check; user override appended verbatim.
- helmchart `EmitsAutoHealthCheck()`: native true, template false.
- wrapper forwarding: `ConfigMapDecorator` and prune-protection forward
  `EmitsAutoHealthCheck` (veto + default-true).

Full `go test ./...` passes.

## Downstream (crane#234)

After this releases, crane bumps launcher and **removes** its
`normalizeHelmReleaseHealthChecks` rewrite (keeping the unrelated inner-CR dedup).
Validated locally against this branch: crane's scenario goldens are **unchanged**
(launcher now emits exactly the namespace crane previously normalized to; its
rewrite becomes a no-op), and there are no `delivery: template` scenarios in crane
today.
