### PR TITLE
chore: set explicit dependabot rebase-strategy auto (parity with kure)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
+    rebase-strategy: "auto"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -42,6 +43,7 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    rebase-strategy: "auto"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
launcher relied on the default `rebase-strategy` while kure sets it explicitly. Pin both ecosystems (gomod, github-actions) to `"auto"` so the two repos' Dependabot behavior is identical and obvious from config.

Config-only change; no functional difference (default is already `auto`) — this makes it explicit and consistent with kure's `dependabot.yml`.