### PR TITLE
feat(oam): add crd and manifests component handlers

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -320,6 +320,7 @@ This monolithic layout is owned by launcher and generated as part of `kurel buil
 - Trait handlers — workload set: expose, certificate, external-secret, pvc, scaler (#49)
 - Trait handlers — network/infra set: ingress, httproute, configmap, networkpolicy, cilium-networkpolicy, volsync (#50)
 - Generic `passthrough` component — emits arbitrary CRDs / non-standard objects with no per-type Go handler (#105)
+- Manifest-source components: `crd`, `manifests` — emit CRDs / arbitrary manifests from inline or http(s) URL sources, with scope-aware namespace stamping (classifier in kure `pkg/manifest`); migrated from crane (#237)
 
 **Phase 3: CLI integration** (#33)
 - `kurel build` — OAM mode (app.yaml + --profile cluster.yaml → manifests) (#51)

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -117,6 +117,8 @@ Migrated from crane. Each type maps to a `ComponentHandler` implementation in
 | `daemonset` | DaemonSet for node-level agents. Optional `port: <N>` generates a ClusterIP Service exposing port N; required when the daemonset acts as an implicit backend for ingress, httproute, or expose traits. |
 | `statefulset` | StatefulSet for ordered, persistent workloads |
 | `passthrough` | Generic escape hatch (launcher-native, not migrated from crane): emits an arbitrary Kubernetes object — CRD or non-standard type — declared inline under `object:`. Set `clusterScoped: true` for cluster-scoped resources (no namespace injected). `object.metadata.name` defaults to the component name. For namespaced objects `object.metadata.namespace` defaults to the build namespace when unset, but an inline value is respected (intentional cross-namespace). No standard trait/port integration or auto health check. |
+| `crd` | Emits `CustomResourceDefinition` manifests from a multi-doc YAML source — `inline:` (offline) or `url:` (http/https only; `oci://` not yet supported). Rejects any non-CRD document. Emitted CRDs are auto-staged early by stack-compile's CRD inference. URL hosts are constrained by the policy registry allowlist (`AllowedRegistries`), re-checked on every redirect. |
+| `manifests` | Emits arbitrary Kubernetes manifests from the same sources as `crd` (`inline` / `url`). Each object's scope is resolved (built-in kinds plus any CRD in the same source); namespaced objects that omit `metadata.namespace` are stamped with the build namespace, cluster-scoped objects are left untouched, and an unknown-scope object with no namespace fails closed. Same URL allowlist as `crd`. |
 
 ### 4.3 Supported trait types (Phase 1)
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/spf13/viper v1.21.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.36.1
+	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.1
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/gateway-api v1.5.1
@@ -169,7 +170,6 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	helm.sh/helm/v4 v4.2.0 // indirect
-	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/cli-runtime v0.36.0 // indirect
 	k8s.io/client-go v0.36.0 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/external-secrets/external-secrets/apis v0.0.0-20260213133823-31b0c7c37342
 	github.com/fluxcd/helm-controller/api v1.5.5
 	github.com/fluxcd/source-controller/api v1.8.5
-	github.com/go-kure/kure v0.2.0-beta.4
+	github.com/go-kure/kure v0.2.0-beta.5
 	github.com/google/go-containerregistry v0.21.6
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -47,7 +47,7 @@ require (
 	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/cloudnative-pg/barman-cloud v0.5.1 // indirect
 	github.com/cloudnative-pg/cnpg-i v0.5.0 // indirect
-	github.com/cloudnative-pg/machinery v0.4.0 // indirect
+	github.com/cloudnative-pg/machinery v0.5.0 // indirect
 	github.com/controlplaneio-fluxcd/flux-operator v0.48.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/cloudnative-pg/cloudnative-pg v1.29.1 h1:ZNEt1TMlnQKXI1kho2UqQuqdfvIv
 github.com/cloudnative-pg/cloudnative-pg v1.29.1/go.mod h1:Sbgx9jVmkle4/gR2U5JHrzDd74sRPOBHDtPkvncg5v8=
 github.com/cloudnative-pg/cnpg-i v0.5.0 h1:/TOzpNT6cwNgrpftTtrnLKdoHgMwd+88vZgXjlVgXeE=
 github.com/cloudnative-pg/cnpg-i v0.5.0/go.mod h1:7Gh4+UzhBpGhr4DreB1GN9wGYfvxwXCXZUyVt3zE/3I=
-github.com/cloudnative-pg/machinery v0.4.0 h1:3sfqrBptH4QQSVB4g10Z+7aiQRnh4g+6AsqsK0ibKaQ=
-github.com/cloudnative-pg/machinery v0.4.0/go.mod h1:OIwaTYAnLv8PmBmBvEf0BvMK2JBX6J+naTMg9UgV1FQ=
+github.com/cloudnative-pg/machinery v0.5.0 h1:hhTnkzn+AiN3NmbjCQ6RXj5rfqV3K6arzq6kdXAzcnQ=
+github.com/cloudnative-pg/machinery v0.5.0/go.mod h1:uuFjqBUjWn0a9uvAk1ixTSzPM0PrjaS+QiKLOIBqLm4=
 github.com/cloudnative-pg/plugin-barman-cloud v0.12.0 h1:zq1hJYpyfRsVXp1CJ2ncZGQoIDfus614x6VYMtWfwEQ=
 github.com/cloudnative-pg/plugin-barman-cloud v0.12.0/go.mod h1:7pMLhJalzyTO0sx9uelGT7bKA53o+uWbrG4ktVIBWQM=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
@@ -144,8 +144,8 @@ github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+r
 github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
-github.com/go-kure/kure v0.2.0-beta.4 h1:csc1ww63kRuLtkq1rsU+4ja7e03yhTvb6OUbAXCkSG8=
-github.com/go-kure/kure v0.2.0-beta.4/go.mod h1:PS/QxwQziZ4/tQkwk0O355TJpEtgReI6sQ/134RM9rw=
+github.com/go-kure/kure v0.2.0-beta.5 h1:HksOGEPQYIhqELonpUTv0s6RpAJVKqnWGmDR9k9aXoE=
+github.com/go-kure/kure v0.2.0-beta.5/go.mod h1:SOb3kRr2P8QG4MiOKVsMmtL1CVQEp2sikGSnZpyILGA=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -294,10 +294,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
 github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
-github.com/onsi/ginkgo/v2 v2.28.3 h1:4JvMdwtFU0imd8fHx25OJXoDMRexnf8v5NHKYSTTji4=
-github.com/onsi/ginkgo/v2 v2.28.3/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/onsi/ginkgo/v2 v2.29.0 h1:rfh+ZFjgJhYWRoIqVf3Uwx/W20yLrcrE2h2GmYVRaag=
+github.com/onsi/ginkgo/v2 v2.29.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -235,6 +235,8 @@ func newBuiltinTransformer() *oam.Transformer {
 			"postgresql":  &components.PostgresqlHandler{},
 			"helmchart":   &components.HelmchartHandler{},
 			"passthrough": &components.PassthroughHandler{},
+			"crd":         &components.CRDHandler{},
+			"manifests":   &components.ManifestsHandler{},
 		},
 		nil,
 	)

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -83,6 +83,81 @@ func TestBuildCommand_StdoutOutput(t *testing.T) {
 	}
 }
 
+// testCRDManifestsAppYAML exercises the launcher-native crd and manifests
+// component handlers (#237): an inline CRD plus an inline namespaced manifest
+// that omits metadata.namespace and must be stamped with the app namespace.
+const testCRDManifestsAppYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: appns
+spec:
+  components:
+    - name: widget-crds
+      type: crd
+      properties:
+        inline: |
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: widgets.example.com
+          spec:
+            group: example.com
+            names:
+              kind: Widget
+              plural: widgets
+            scope: Namespaced
+            versions:
+              - name: v1
+                served: true
+                storage: true
+                schema:
+                  openAPIV3Schema:
+                    type: object
+    - name: extra
+      type: manifests
+      properties:
+        inline: |
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: cm
+          data:
+            k: v
+`
+
+func TestBuildCommand_CRDAndManifestsComponents(t *testing.T) {
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", testCRDManifestsAppYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("build with crd/manifests components failed: %v\noutput: %s", err, out.String())
+	}
+
+	got := out.String()
+	if !strings.Contains(got, "kind: CustomResourceDefinition") {
+		t.Errorf("expected emitted CustomResourceDefinition, got:\n%s", got)
+	}
+	if !strings.Contains(got, "widgets.example.com") {
+		t.Errorf("expected CRD name in output, got:\n%s", got)
+	}
+	if !strings.Contains(got, "kind: ConfigMap") {
+		t.Errorf("expected manifests ConfigMap in output, got:\n%s", got)
+	}
+	// The ConfigMap omitted metadata.namespace; the manifests handler must stamp
+	// it with the app namespace.
+	if !strings.Contains(got, "namespace: appns") {
+		t.Errorf("expected namespaced manifest stamped with app namespace 'appns', got:\n%s", got)
+	}
+}
+
 func TestBuildCommand_OutputDir(t *testing.T) {
 	dir := t.TempDir()
 	appPath := writeTempFile(t, dir, "app.yaml", testAppYAML)

--- a/pkg/oam/builtin/components/crd.go
+++ b/pkg/oam/builtin/components/crd.go
@@ -1,0 +1,43 @@
+package components
+
+import (
+	"github.com/go-kure/kure/pkg/manifest"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// CRDHandler handles the `crd` OAM component type: it emits CustomResourceDefinition
+// manifests from an inline or url source and rejects any non-CRD document. The
+// emitted CRDs are auto-staged early by stack-compile's CRD inference.
+type CRDHandler struct{}
+
+func (h *CRDHandler) CanHandle(componentType string) bool { return componentType == "crd" }
+
+func (h *CRDHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	src, err := parseManifestSource(component.Properties)
+	if err != nil {
+		return nil, errors.Errorf("crd component %q: %w", component.Name, err)
+	}
+	cfg := &manifestConfig{name: component.Name, namespace: namespace, src: src, process: requireAllCRDs}
+	if err := cfg.validateInline(); err != nil {
+		return nil, errors.Errorf("crd component %q: %w", component.Name, err)
+	}
+	return cfg, nil
+}
+
+// requireAllCRDs fails closed if any resolved object is not a CRD.
+func requireAllCRDs(_ string, objs []client.Object) ([]client.Object, error) {
+	if len(objs) == 0 {
+		return nil, errors.Errorf("source resolved to no manifests")
+	}
+	for _, o := range objs {
+		if !manifest.IsCRD(o) {
+			gvk := o.GetObjectKind().GroupVersionKind()
+			return nil, errors.Errorf("object %s %q is not a CustomResourceDefinition (the crd component emits only CRDs; use the manifests component for other kinds)", gvk.Kind, o.GetName())
+		}
+	}
+	return objs, nil
+}

--- a/pkg/oam/builtin/components/crd_test.go
+++ b/pkg/oam/builtin/components/crd_test.go
@@ -1,0 +1,64 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+func TestCRDHandler_CanHandle(t *testing.T) {
+	h := &CRDHandler{}
+	if !h.CanHandle("crd") || h.CanHandle("manifests") {
+		t.Error("CRDHandler should handle only \"crd\"")
+	}
+}
+
+func TestCRDHandler_InlineCRDPasses(t *testing.T) {
+	h := &CRDHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "widget-crds", Type: "crd",
+		Properties: map[string]any{"inline": crdYAML},
+	}, "widgets")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	objs, err := cfg.Generate(nil)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 || (*objs[0]).GetObjectKind().GroupVersionKind().Kind != "CustomResourceDefinition" {
+		t.Errorf("want one CRD, got %d objects", len(objs))
+	}
+}
+
+func TestCRDHandler_RejectsNonCRDInline(t *testing.T) {
+	h := &CRDHandler{}
+	_, err := h.ToApplicationConfig(&oam.Component{
+		Name: "bad", Type: "crd",
+		Properties: map[string]any{"inline": "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: x\n  namespace: nsx\n"},
+	}, "widgets")
+	if err == nil || !strings.Contains(err.Error(), "CustomResourceDefinition") {
+		t.Errorf("want non-CRD rejection, got %v", err)
+	}
+}
+
+func TestCRDHandler_URLHostPolicyDenied(t *testing.T) {
+	h := &CRDHandler{}
+	cfg, err := h.ToApplicationConfig(&oam.Component{
+		Name: "remote-crds", Type: "crd",
+		Properties: map[string]any{"url": "https://evil.example.com/crds.yaml"},
+	}, "widgets")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig (url, no eager fetch): %v", err)
+	}
+	ap, ok := cfg.(interface {
+		ApplyPolicy(oam.Policy) error
+	})
+	if !ok {
+		t.Fatal("config must implement ApplyPolicy")
+	}
+	if err := ap.ApplyPolicy(fakePolicy{allowed: []string{"trusted.example.com"}}); err == nil {
+		t.Error("want policy denial for a disallowed url host")
+	}
+}

--- a/pkg/oam/builtin/components/manifests.go
+++ b/pkg/oam/builtin/components/manifests.go
@@ -1,0 +1,63 @@
+package components
+
+import (
+	"github.com/go-kure/kure/pkg/manifest"
+	"github.com/go-kure/kure/pkg/stack"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// ManifestsHandler handles the `manifests` OAM component type: it emits arbitrary
+// Kubernetes manifests from an inline or url source. CRDs in the payload are
+// auto-staged early by stack-compile's CRD inference.
+type ManifestsHandler struct{}
+
+func (h *ManifestsHandler) CanHandle(componentType string) bool { return componentType == "manifests" }
+
+func (h *ManifestsHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
+	src, err := parseManifestSource(component.Properties)
+	if err != nil {
+		return nil, errors.Errorf("manifests component %q: %w", component.Name, err)
+	}
+	cfg := &manifestConfig{name: component.Name, namespace: namespace, src: src, process: stampManifestNamespaces}
+	if err := cfg.validateInline(); err != nil {
+		return nil, errors.Errorf("manifests component %q: %w", component.Name, err)
+	}
+	return cfg, nil
+}
+
+// stampManifestNamespaces resolves each object's scope (built-in maps, plus the
+// scope of any CRD in the same source) and stamps the app namespace on
+// namespaced objects that omit one. Cluster-scoped objects are left untouched;
+// an unknown-scope object with no namespace fails closed rather than be guessed.
+func stampManifestNamespaces(namespace string, objs []client.Object) ([]client.Object, error) {
+	if len(objs) == 0 {
+		return nil, errors.Errorf("source resolved to no manifests")
+	}
+	crdScopes := map[schema.GroupKind]apiextv1.ResourceScope{}
+	for _, o := range objs {
+		if gk, scope, ok := manifest.CRDScope(o); ok {
+			crdScopes[gk] = scope
+		}
+	}
+	for _, o := range objs {
+		switch manifest.Scope(o, crdScopes) {
+		case manifest.ScopeNamespaced:
+			if o.GetNamespace() == "" {
+				o.SetNamespace(namespace)
+			}
+		case manifest.ScopeUnknown:
+			if o.GetNamespace() == "" {
+				gvk := o.GetObjectKind().GroupVersionKind()
+				return nil, errors.Errorf("object %s %q has unknown scope and no metadata.namespace; set an explicit namespace (no CRD defining it is present in this source)", gvk.Kind, o.GetName())
+			}
+		case manifest.ScopeCluster:
+			// cluster-scoped: leave as-is
+		}
+	}
+	return objs, nil
+}

--- a/pkg/oam/builtin/components/manifests_test.go
+++ b/pkg/oam/builtin/components/manifests_test.go
@@ -1,0 +1,87 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+func generateManifests(t *testing.T, ns, inline string) ([]string, error) {
+	t.Helper()
+	cfg, err := (&ManifestsHandler{}).ToApplicationConfig(&oam.Component{
+		Name: "m", Type: "manifests", Properties: map[string]any{"inline": inline},
+	}, ns)
+	if err != nil {
+		return nil, err
+	}
+	objs, err := cfg.Generate(nil)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, len(objs))
+	for i, o := range objs {
+		out[i] = (*o).GetObjectKind().GroupVersionKind().Kind + ":" + (*o).GetNamespace()
+	}
+	return out, nil
+}
+
+func TestManifestsHandler_StampsBuiltinNamespaced(t *testing.T) {
+	got, err := generateManifests(t, "app-ns",
+		"apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: d\n")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Deployment:app-ns" {
+		t.Errorf("built-in namespaced object must be stamped with app ns, got %v", got)
+	}
+}
+
+func TestManifestsHandler_ClusterScopedUntouched(t *testing.T) {
+	got, err := generateManifests(t, "app-ns",
+		"apiVersion: v1\nkind: Namespace\nmetadata:\n  name: foo\n")
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Namespace:" {
+		t.Errorf("cluster-scoped object must not be stamped, got %v", got)
+	}
+}
+
+func TestManifestsHandler_CustomResourceScopeFromSameSourceCRD(t *testing.T) {
+	inline := crdYAML + "---\napiVersion: example.com/v1\nkind: Widget\nmetadata:\n  name: w1\n"
+	got, err := generateManifests(t, "app-ns", inline)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	// The CRD (cluster-scoped) is untouched; the Widget instance is namespaced
+	// (its CRD declares scope Namespaced) and stamped with the app ns.
+	var widgetNS string
+	for _, g := range got {
+		if after, ok := strings.CutPrefix(g, "Widget:"); ok {
+			widgetNS = after
+		}
+	}
+	if widgetNS != "app-ns" {
+		t.Errorf("custom resource scope must be inferred from same-source CRD and stamped; got %v", got)
+	}
+}
+
+func TestManifestsHandler_UnknownGVKNoNamespaceFailsClosed(t *testing.T) {
+	_, err := generateManifests(t, "app-ns",
+		"apiVersion: unknown.io/v1\nkind: Mystery\nmetadata:\n  name: m1\n")
+	if err == nil || !strings.Contains(err.Error(), "namespace") {
+		t.Errorf("unknown GVK without a namespace must fail closed, got %v", err)
+	}
+}
+
+func TestManifestsHandler_UnknownGVKWithNamespacePasses(t *testing.T) {
+	got, err := generateManifests(t, "app-ns",
+		"apiVersion: unknown.io/v1\nkind: Mystery\nmetadata:\n  name: m1\n  namespace: explicit\n")
+	if err != nil {
+		t.Fatalf("explicit namespace should pass: %v", err)
+	}
+	if len(got) != 1 || got[0] != "Mystery:explicit" {
+		t.Errorf("explicit namespace must be preserved, got %v", got)
+	}
+}

--- a/pkg/oam/builtin/components/manifestsource.go
+++ b/pkg/oam/builtin/components/manifestsource.go
@@ -1,0 +1,261 @@
+package components
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	kureio "github.com/go-kure/kure/pkg/io"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// URL fetch limits. Vars (not consts) so tests can lower them.
+var (
+	maxManifestBytes int64 = 5 << 20 // 5 MiB
+	maxRedirects           = 10
+	fetchTimeout           = 30 * time.Second
+)
+
+// manifestSource is the shared core behind the `crd` and `manifests` OAM
+// components: exactly one of inline/url (chart is recognized but not yet
+// implemented). resolve() parses/fetches once and memoizes, handing back
+// defensive copies so repeated Generate() calls and downstream mutators never
+// corrupt the cache.
+type manifestSource struct {
+	inline string
+	url    string
+
+	// allowedHosts is the policy registry allowlist, stored by the owning
+	// config's ApplyPolicy so the URL resolver (and its redirect check) has
+	// policy context at fetch time. Empty means unrestricted (no policy).
+	allowedHosts []string
+
+	cached []client.Object // memoized resolve() result
+}
+
+// parseManifestSource reads a component's properties strictly: exactly one of
+// inline/url must be set; unknown keys and recognized-but-unsupported sources
+// (chart, oci:// urls) get distinct errors.
+func parseManifestSource(props map[string]any) (*manifestSource, error) {
+	s := &manifestSource{}
+	count := 0
+	for k, v := range props {
+		switch k {
+		case "inline":
+			str, ok := v.(string)
+			if !ok {
+				return nil, errors.Errorf("manifest source: property %q must be a YAML string", k)
+			}
+			s.inline = str
+			count++
+		case "url":
+			str, ok := v.(string)
+			if !ok {
+				return nil, errors.Errorf("manifest source: property %q must be a string", k)
+			}
+			if err := validateURLScheme(str); err != nil {
+				return nil, err
+			}
+			s.url = str
+			count++
+		case "chart":
+			return nil, errors.Errorf("manifest source: %q source is not yet supported (designed, not implemented)", k)
+		default:
+			return nil, errors.Errorf("manifest source: unknown property %q", k)
+		}
+	}
+	if count != 1 {
+		return nil, errors.Errorf("manifest source: exactly one of inline/url is required (got %d)", count)
+	}
+	return s, nil
+}
+
+// validateURLScheme rejects non-http(s) schemes up front. oci:// gets a distinct
+// "not yet supported" message.
+func validateURLScheme(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return errors.Errorf("manifest source: invalid url %q: %w", rawURL, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+		return nil
+	case "oci":
+		return errors.Errorf("manifest source: oci:// urls are not yet supported (designed, not implemented)")
+	default:
+		return errors.Errorf("manifest source: unsupported url scheme %q (only http/https)", u.Scheme)
+	}
+}
+
+func (s *manifestSource) setAllowedHosts(hosts []string) { s.allowedHosts = hosts }
+
+// resolve parses inline YAML or fetches the URL (once, memoized) and returns
+// defensive copies of the resulting objects.
+func (s *manifestSource) resolve() ([]client.Object, error) {
+	if s.cached == nil {
+		var data []byte
+		var err error
+		switch {
+		case s.inline != "":
+			data = []byte(s.inline)
+		case s.url != "":
+			data, err = fetchURL(s.url, s.allowedHosts)
+			if err != nil {
+				return nil, err
+			}
+		default:
+			return nil, errors.Errorf("manifest source: no source configured")
+		}
+		objs, err := kureio.ParseYAMLWithOptions(data, kureio.ParseOptions{AllowUnstructured: true})
+		if err != nil {
+			return nil, errors.Errorf("manifest source: parse manifests: %w", err)
+		}
+		s.cached = objs
+	}
+	return copyObjects(s.cached), nil
+}
+
+func copyObjects(objs []client.Object) []client.Object {
+	out := make([]client.Object, len(objs))
+	for i, o := range objs {
+		out[i] = o.DeepCopyObject().(client.Object)
+	}
+	return out
+}
+
+// fetchURL retrieves raw manifest YAML over http(s), treating the URL as
+// untrusted: scheme allowlist (initial + every redirect hop), host allowlist
+// re-checked on each redirect, request timeout, non-2xx rejection, and a hard
+// response-size cap.
+func fetchURL(rawURL string, allowedHosts []string) ([]byte, error) {
+	if err := checkURL(rawURL, allowedHosts); err != nil {
+		return nil, err
+	}
+	httpClient := &http.Client{
+		Timeout: fetchTimeout,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return errors.Errorf("manifest source: too many redirects (>%d)", maxRedirects)
+			}
+			return checkURL(req.URL.String(), allowedHosts)
+		},
+	}
+	resp, err := httpClient.Get(rawURL)
+	if err != nil {
+		return nil, errors.Errorf("manifest source: fetch %q: %w", rawURL, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, errors.Errorf("manifest source: fetch %q: unexpected status %d", rawURL, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxManifestBytes+1))
+	if err != nil {
+		return nil, errors.Errorf("manifest source: read %q: %w", rawURL, err)
+	}
+	if int64(len(body)) > maxManifestBytes {
+		return nil, errors.Errorf("manifest source: %q response exceeds max size %d bytes", rawURL, maxManifestBytes)
+	}
+	return body, nil
+}
+
+// checkURL enforces the scheme allowlist and the policy host allowlist on a URL
+// (used for both the initial request and every redirect hop).
+func checkURL(rawURL string, allowedHosts []string) error {
+	if err := validateURLScheme(rawURL); err != nil {
+		return err
+	}
+	return enforceAllowedURLHosts(rawURL, allowedHosts)
+}
+
+// enforceAllowedURLHosts returns an error if the host extracted from a URL is
+// not in the allowed registries list. An empty allowed list means all hosts are
+// permitted. This is the URL-source counterpart to the image-reference allowlist
+// (registryHost / enforceAllowedRegistries) — kept separate because image refs
+// default to docker.io and strip tags/digests, which is wrong for fetch URLs.
+func enforceAllowedURLHosts(rawURL string, allowed []string) error {
+	if len(allowed) == 0 {
+		return nil
+	}
+	host := urlHost(rawURL)
+	for _, registry := range allowed {
+		if host == strings.TrimRight(registry, "/") {
+			return nil
+		}
+	}
+	return errors.Errorf("source registry %q is not in allowed registries %v", host, allowed)
+}
+
+// urlHost extracts the host from a URL with scheme (oci://, https://, http://).
+func urlHost(rawURL string) string {
+	for _, scheme := range []string{"oci://", "https://", "http://"} {
+		if after, ok := strings.CutPrefix(rawURL, scheme); ok {
+			rawURL = after
+			break
+		}
+	}
+	if before, _, ok := strings.Cut(rawURL, "/"); ok {
+		return before
+	}
+	return rawURL
+}
+
+// manifestConfig is the shared stack.ApplicationConfig behind the crd and
+// manifests components. It resolves a manifestSource and runs a per-type
+// `process` hook (CRD-only validation, or scope-aware namespace stamping).
+type manifestConfig struct {
+	name      string
+	namespace string
+	src       *manifestSource
+	process   func(namespace string, objs []client.Object) ([]client.Object, error)
+}
+
+// ApplyPolicy stores the policy registry allowlist on the source (so the URL
+// resolver's redirect check has policy context) and rejects a disallowed
+// configured-url host up front. It reads the allowlist through the oam.Policy
+// interface (AllowedRegistries) rather than type-asserting a concrete type, so
+// any policy implementation enforces correctly.
+func (c *manifestConfig) ApplyPolicy(p oam.Policy) error {
+	if p == nil || c.src.url == "" {
+		return nil
+	}
+	allowed := p.AllowedRegistries()
+	c.src.setAllowedHosts(allowed)
+	return enforceAllowedURLHosts(c.src.url, allowed)
+}
+
+// Generate resolves the source (cached) and applies the per-type process hook.
+func (c *manifestConfig) Generate(_ *stack.Application) ([]*client.Object, error) {
+	objs, err := c.src.resolve()
+	if err != nil {
+		return nil, err
+	}
+	if c.process != nil {
+		objs, err = c.process(c.namespace, objs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	out := make([]*client.Object, len(objs))
+	for i := range objs {
+		o := objs[i]
+		out[i] = &o
+	}
+	return out, nil
+}
+
+// validateInline runs resolve + process eagerly for inline sources so config
+// errors surface at ToApplicationConfig time (offline, fail fast). url sources
+// are validated at Generate time, after ApplyPolicy.
+func (c *manifestConfig) validateInline() error {
+	if c.src.inline == "" {
+		return nil
+	}
+	_, err := c.Generate(nil)
+	return err
+}

--- a/pkg/oam/builtin/components/manifestsource_test.go
+++ b/pkg/oam/builtin/components/manifestsource_test.go
@@ -1,0 +1,206 @@
+package components
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+)
+
+// fakePolicy implements oam.Policy via an embedded (nil) interface and overrides
+// only AllowedRegistries — proving ApplyPolicy reads the interface method, not a
+// concrete policy type.
+type fakePolicy struct {
+	oam.Policy
+	allowed []string
+}
+
+func (f fakePolicy) AllowedRegistries() []string { return f.allowed }
+
+func TestApplyPolicy_UsesInterfaceAndStoresAllowlist(t *testing.T) {
+	deny := &manifestConfig{src: &manifestSource{url: "https://evil.example.com/x.yaml"}}
+	if err := deny.ApplyPolicy(fakePolicy{allowed: []string{"trusted.example.com"}}); err == nil {
+		t.Error("want host denial through the Policy interface")
+	}
+
+	ok := &manifestConfig{src: &manifestSource{url: "https://trusted.example.com/x.yaml"}}
+	if err := ok.ApplyPolicy(fakePolicy{allowed: []string{"trusted.example.com"}}); err != nil {
+		t.Errorf("allowed host should pass: %v", err)
+	}
+	if len(ok.src.allowedHosts) != 1 {
+		t.Error("ApplyPolicy must store the allowlist for redirect revalidation")
+	}
+
+	if err := (&manifestConfig{src: &manifestSource{url: "https://x/y"}}).ApplyPolicy(nil); err != nil {
+		t.Errorf("nil policy must be a no-op, got %v", err)
+	}
+}
+
+const crdYAML = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: widgets.example.com
+spec:
+  group: example.com
+  names:
+    kind: Widget
+    plural: widgets
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+`
+
+// --- parseManifestSource ---
+
+func TestParseManifestSource_InlineOnly(t *testing.T) {
+	s, err := parseManifestSource(map[string]any{"inline": crdYAML})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.inline == "" || s.url != "" {
+		t.Errorf("want inline set, url empty; got inline=%q url=%q", s.inline, s.url)
+	}
+}
+
+func TestParseManifestSource_URLOnly(t *testing.T) {
+	s, err := parseManifestSource(map[string]any{"url": "https://example.com/crds.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if s.url == "" || s.inline != "" {
+		t.Error("want url set, inline empty")
+	}
+}
+
+func TestParseManifestSource_RejectsBothSources(t *testing.T) {
+	_, err := parseManifestSource(map[string]any{"inline": crdYAML, "url": "https://x/y.yaml"})
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Errorf("want 'exactly one' error, got %v", err)
+	}
+}
+
+func TestParseManifestSource_RejectsNoSource(t *testing.T) {
+	_, err := parseManifestSource(map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "exactly one") {
+		t.Errorf("want 'exactly one' error, got %v", err)
+	}
+}
+
+func TestParseManifestSource_UnknownPropertyDistinctFromUnsupportedSource(t *testing.T) {
+	_, err := parseManifestSource(map[string]any{"inline": crdYAML, "bogus": "x"})
+	if err == nil || !strings.Contains(err.Error(), "unknown property") {
+		t.Errorf("want 'unknown property' error, got %v", err)
+	}
+	_, err = parseManifestSource(map[string]any{"chart": map[string]any{"name": "x"}})
+	if err == nil || !strings.Contains(err.Error(), "not yet supported") {
+		t.Errorf("want 'not yet supported' for chart, got %v", err)
+	}
+}
+
+func TestParseManifestSource_RejectsOCIAndUnknownScheme(t *testing.T) {
+	if _, err := parseManifestSource(map[string]any{"url": "oci://r/x:1"}); err == nil || !strings.Contains(err.Error(), "not yet supported") {
+		t.Errorf("want 'not yet supported' for oci, got %v", err)
+	}
+	if _, err := parseManifestSource(map[string]any{"url": "file:///etc/passwd"}); err == nil || !strings.Contains(err.Error(), "scheme") {
+		t.Errorf("want scheme error for file://, got %v", err)
+	}
+}
+
+// --- resolve (inline + caching) ---
+
+func TestResolve_InlineParsesAndCachesDefensiveCopies(t *testing.T) {
+	s, err := parseManifestSource(map[string]any{"inline": crdYAML})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	a, err := s.resolve()
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(a) != 1 || a[0].GetObjectKind().GroupVersionKind().Kind != "CustomResourceDefinition" {
+		t.Fatalf("want one CRD, got %d", len(a))
+	}
+	// Mutate the first result; a second resolve must be unaffected (defensive copy).
+	a[0].SetName("mutated")
+	b, err := s.resolve()
+	if err != nil {
+		t.Fatalf("resolve#2: %v", err)
+	}
+	if b[0].GetName() != "widgets.example.com" {
+		t.Errorf("resolve must return defensive copies; got mutated name %q", b[0].GetName())
+	}
+}
+
+// --- url fetch safety ---
+
+func TestResolve_URLSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(crdYAML))
+	}))
+	defer srv.Close()
+	s := &manifestSource{url: srv.URL}
+	objs, err := s.resolve()
+	if err != nil {
+		t.Fatalf("resolve url: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Errorf("want 1 object, got %d", len(objs))
+	}
+}
+
+func TestResolve_URLRejectsNon2xx(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	s := &manifestSource{url: srv.URL}
+	if _, err := s.resolve(); err == nil || !strings.Contains(err.Error(), "status") {
+		t.Errorf("want status error, got %v", err)
+	}
+}
+
+func TestResolve_URLRejectsOversizedBody(t *testing.T) {
+	orig := maxManifestBytes
+	maxManifestBytes = 64
+	defer func() { maxManifestBytes = orig }()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(strings.Repeat("a", 1000)))
+	}))
+	defer srv.Close()
+	s := &manifestSource{url: srv.URL}
+	if _, err := s.resolve(); err == nil || !strings.Contains(err.Error(), "size") {
+		t.Errorf("want size error, got %v", err)
+	}
+}
+
+func TestResolve_URLRejectsRedirectToDisallowedHost(t *testing.T) {
+	dest := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(crdYAML))
+	}))
+	defer dest.Close()
+	redir := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, dest.URL, http.StatusFound)
+	}))
+	defer redir.Close()
+
+	// Allowlist only the redirecting host; the redirect target is disallowed.
+	s := &manifestSource{url: redir.URL}
+	s.setAllowedHosts([]string{hostOf(redir.URL)})
+	if _, err := s.resolve(); err == nil {
+		t.Error("want error when a redirect leaves the allowed host")
+	}
+}
+
+func hostOf(rawURL string) string {
+	if _, after, ok := strings.Cut(rawURL, "://"); ok {
+		return after
+	}
+	return rawURL
+}

--- a/pkg/oam/classify.go
+++ b/pkg/oam/classify.go
@@ -14,6 +14,8 @@ var defaultTierMap = map[string]Tier{
 	"helmchart":   TierApps,
 	"daemonset":   TierInfra,
 	"statefulset": TierApps,
+	"crd":         TierApps,
+	"manifests":   TierApps,
 }
 
 // validTiers is the set of valid tier values for annotation validation.

--- a/pkg/oam/classify_test.go
+++ b/pkg/oam/classify_test.go
@@ -41,6 +41,8 @@ func TestClassifyComponent_DefaultMap(t *testing.T) {
 		{"statefulset", TierApps},
 		{"postgresql", TierServices},
 		{"daemonset", TierInfra},
+		{"crd", TierApps},
+		{"manifests", TierApps},
 	}
 	for _, tc := range cases {
 		t.Run(tc.typ, func(t *testing.T) {

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -25,6 +25,8 @@ var validComponentTypes = map[string]bool{
 	"daemonset":   true,
 	"statefulset": true,
 	"passthrough": true,
+	"crd":         true,
+	"manifests":   true,
 }
 
 // validTraitTypes is the set of supported trait types from design-kurel-package.md §4.3.


### PR DESCRIPTION
## What

Adds the `crd` and `manifests` OAM component handlers to launcher's built-in set, so generic component handlers all live in one place (crane#216 / crane#237). `helmchart` stays in crane for now (feature divergence + crane-type coupling — separate follow-up).

Both handlers emit Kubernetes objects from a multi-doc YAML source — `inline:` (offline) or `url:` (http/https only; `oci://` returns the existing "not yet supported" error):

- **crd** — emits `CustomResourceDefinition`s, rejecting any non-CRD document.
- **manifests** — emits arbitrary manifests, resolving each object's scope (built-in kinds + any CRD in the same source) and stamping the build namespace on namespaced objects that omit one; cluster-scoped objects are untouched, and unknown-scope objects without a namespace fail closed.

## How

- Shared CRD/scope classifier comes from kure's new **`pkg/manifest`** (kure `v0.2.0-beta.5`), so the staging engine and these handlers classify identically — no divergent copies.
- URL fetching keeps the **5 MiB / 10-redirect / 30s** caps and a policy registry-allowlist check (`oam.Policy.AllowedRegistries`), enforced on the initial request and every redirect via a launcher-local URL-host helper. The existing image-ref helper (`registryHost`) is intentionally **not** reused — it defaults to docker.io and strips tags, wrong for fetch URLs.
- `manifestConfig` implements `oam.Enforceable`; the transformer already invokes `ApplyPolicy` (`pkg/oam/transform.go`), so the URL allowlist is enforced for real.
- Wired into launcher's own surfaces: registered in `newBuiltinTransformer`, added to the validation allowlist (`validComponentTypes`) and tier map (`defaultTierMap` → `TierApps`), documented in `docs/oam/design-kurel-package.md` + `docs/design.md`.

## Tests

- Ported unit tests: `crd_test.go`, `manifests_test.go`, `manifestsource_test.go` (CanHandle; inline CRD pass/reject; stamp-by-scope incl. CR-from-same-source-CRD; unknown-scope fail-closed; URL success / non-2xx / oversize / redirect-to-disallowed-host; oci + unknown scheme rejected; `ApplyPolicy` interface + allowlist stored + nil no-op).
- New kurel build smoke test proving a launcher-native app can use `crd`/`manifests`.
- `GOWORK=off go test ./...` green; `go vet` clean; gofmt clean.

## Cross-repo validation

Verified **golden-neutral**: with crane temporarily pointed at these launcher handlers (via the workspace replace), crane's full scenario goldens (incl. crd-staging, opsmaster) and transform suite are **byte-identical**. The port is behavior-preserving.

Part of crane#237 (Phase B). After merge, cut a release (e.g. `v0.1.0-alpha.4`) so crane (Phase C) can bump, register these, and delete its copies.