### PR TITLE
fix: build linux-only release artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,11 +540,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [linux, darwin, windows]
+        os: [linux]
         arch: [amd64, arm64]
-        exclude:
-          - os: windows
-            arch: arm64
 
     steps:
     - name: Checkout code

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,16 +18,13 @@ builds:
       - -X github.com/go-kure/launcher/pkg/cmd/shared.BuildDate={{.Date}}
     env:
       - CGO_ENABLED=0
-    goos: [linux, darwin, windows]
+    goos: [linux]
     goarch: [amd64, arm64]
 
 archives:
   - id: kurel-archive
     ids: [kurel]
     formats: [tar.gz]
-    format_overrides:
-      - goos: windows
-        formats: [zip]
     name_template: "kurel_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -168,7 +168,7 @@ The project uses GitHub Actions workflows:
 
 - **Triggers**: Version tags (`v*.*.*`)
 - **Jobs**: test, validate (tag + changelog), goreleaser, post-release (proxy refresh)
-- **Produces**: kurel binaries for linux/darwin/windows × amd64/arm64 + checksums + SBOM + cosign signature
+- **Produces**: kurel binaries for linux × amd64/arm64 + checksums + SBOM + cosign signature
 
 ### Creating a Release
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -73,7 +73,7 @@ concurrency:
                     │
                     ▼ (main / release/* only)
            ┌─────────────────┐
-           │ cross-platform  │  ← 5-platform matrix build
+           │ cross-platform  │  ← linux amd64/arm64 matrix build
            └─────────────────┘
 
 PR-only jobs (parallel, non-blocking):
@@ -97,7 +97,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 | `build-binaries` | `Build kurel` | 10 min | changes, test | Build `kurel` linux/amd64 binary; uploaded as artifact |
 | `docs-build` | `docs-build` | 15 min | changes | Hugo site build for docs; go + Hugo caches |
 | `build` | `build` | 1 min | validate, test, build-binaries, docs-build, coverage-check | Aggregation gate |
-| `cross-platform` | `Cross-Platform Build` | 15 min | build-binaries | Matrix: linux/darwin/windows × amd64/arm64 (main + release/* only) |
+| `cross-platform` | `Cross-Platform Build` | 15 min | build-binaries | Matrix: linux × amd64/arm64 (main + release/* only) |
 | `analyze-changes` | `Analyze Changes` | 5 min | — | Changed files summary, breaking change warning for pkg/ (PR only) |
 
 ### Cross-Platform Matrix
@@ -107,8 +107,6 @@ Runs on main and `release/*` branches only (not PRs):
 | OS | amd64 | arm64 |
 |----|-------|-------|
 | linux | ✅ | ✅ |
-| darwin | ✅ | ✅ |
-| windows | ✅ | — |
 
 ### Configuration
 


### PR DESCRIPTION
## Problem

`Release / Publish` has been failing — the last three runs (`v0.1.0-alpha.1/2/3`) were all **cancelled mid-build**, so no artifacts were ever published. Tracked in #128.

**Root cause (validated by timestamped logs + reading the shared workflow):** the shared `go-kure/.github` `release-publish.yml` `goreleaser` job has `timeout-minutes: 15`. A single GoReleaser job cross-compiled launcher's **6 targets** (`{linux,darwin,windows} × {amd64,arm64}`) in batches of ~2 concurrent targets on the `autops-kube-kure` runner. Under cold-cache conditions the build exceeds the 15-minute cap and is cancelled during the build phase — before signing/SBOM/publish are ever reached. (The one successful full run, 2026-05-22, ran the GoReleaser step in 12m15s with all six targets; cold-cache variance pushes it over.)

## Change

Reduce the published platform set to **`linux/amd64` + `linux/arm64`** — an intentional, permanent release policy change. Two targets build comfortably within the existing timeout, and **GoReleaser stays the build engine** so the shared workflow remains generic (kure, which builds no binaries, is unaffected — no shared-workflow change required for this fix).

- `.goreleaser.yml`: `goos` linux-only; remove the now-dead windows/zip archive override
- `.github/workflows/ci.yml`: `cross-platform` matrix → linux amd64/arm64 (5 legs → 2)
- `DEVELOPMENT.md`, `docs/github-workflows.md`: align platform docs

No Go source changed.

## Verification

- `goreleaser check` — config valid
- `goreleaser release --snapshot --clean --skip=sign` — succeeded in **1m40s**; produced exactly the 2 linux archives + SBOMs + `checksums.txt` (no darwin/windows)
- `go.mod`/`go.sum` clean after the `go mod tidy` hook
- `kurel version` reports the injected version/commit/build-date, `OS/Arch: linux/amd64`
- `go build ./...` / `go test ./...` green

## Notes

- **Drops macOS and Windows binaries** — intentional, not a temporary fallback.
- This fixes **future tags only**; the cancelled `.1/.2/.3` runs check out the old 6-target config and must not be rerun. First green release comes from the normal release flow producing a new tag after merge.
- Optional follow-up (separate repo/PR): bump the shared `goreleaser` job `timeout-minutes` as generic margin in `go-kure/.github`.

Refs #128