### PR TITLE
ci: speed up and stabilize the Security/govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
   security:
     name: Security
     runs-on: autops-kube-kure
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -245,8 +245,16 @@ jobs:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: false
 
+    - name: Cache Go modules
+      uses: actions/cache@v5
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-
+
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
     - name: Run govulncheck
       run: |


### PR DESCRIPTION
## Problem

The `Security` job's govulncheck regressed badly:
- 2026-06-02: ran in **2m31s** and **1m41s** (green)
- 2026-06-03: **>9–15 min**, getting cancelled (hit the 10-min job timeout / node instability)

Root cause: the `Security` job set up Go with **`cache: false`** (unlike `test`/`lint`/`build-binaries`, which cache `~/go/pkg/mod`). So every run cold-downloads the large k8s module graph before `govulncheck ./...` can scan it — and a runner **node reboot** wipes local caches, making it worse — all against a **10-minute** timeout. `Security` is not a required check, but its cancellation made the merge-queue run report `cancelled`.

## Change

- Add the same `Cache Go modules` step (`actions/cache` on `~/go/pkg/mod`, keyed on `go.sum`) used by `test`/`lint`/`build-binaries`, so govulncheck reuses the module cache.
- Pin govulncheck to **v1.3.0** (the version `@latest` currently resolves to) for reproducible, cache-friendly installs.
- Raise `timeout-minutes` **10 → 15** for margin on the slow self-hosted runner.

No change to what govulncheck scans or its pass/fail behavior.

## Verification

YAML validated. After merge, confirm the `Security` job completes well under 15 min (cache hit) on a subsequent run.