### PR TITLE
ci: cap govulncheck memory (GOMEMLIMIT + -scan package) to avoid runner OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,11 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
       (github.event_name != 'pull_request' || needs.changes.outputs.go == 'true')
 
+    # GOMEMLIMIT keeps Go's GC under the runner pod memory limit so govulncheck doesn't get
+    # OOMKilled on the in-cluster ARC runner. Pairs with the 6Gi ARC runner limit.
+    env:
+      GOMEMLIMIT: 5GiB
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -251,7 +256,7 @@ jobs:
     - name: Run govulncheck
       run: |
         set +e
-        OUTPUT=$(govulncheck ./... 2>&1)
+        OUTPUT=$(govulncheck -scan package ./... 2>&1)
         EXIT_CODE=$?
         echo "$OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,7 +219,7 @@ jobs:
   security:
     name: Security
     runs-on: autops-kube-kure
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: [changes]
     if: |
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
@@ -251,7 +251,7 @@ jobs:
         cache: false
 
     - name: Install govulncheck
-      run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
     - name: Run govulncheck
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kure/launcher
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/backube/volsync v0.15.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Use exact versions for reproducibility across environments
-go = "1.26.3"
+go = "1.26.4"
 golangci-lint = "2.10.1"
 git-cliff = "2.7.0"
 goreleaser = "2.14.3"


### PR DESCRIPTION
The `security` job runs `govulncheck` on the in-cluster ARC runner (`autops-kube-kure`). govulncheck can grow to ~3.8 GiB on large module graphs and OOMKill the runner pod (this happened on the sibling `kure` repo, exit 137).

Two changes:
- Add job-level `GOMEMLIMIT: 5GiB` so Go GC keeps govulncheck under the runner memory limit.
- Switch `govulncheck ./...` → `govulncheck -scan package ./...` (package-scan mode uses far less memory than the default symbol-scan), matching `go-kure/kure`.

Paired with the ARC runner memory limit being raised 4Gi→6Gi in the cluster config (opsmaster). `GOMEMLIMIT` is a soft cap; the runner limit bump is the hard safety net.
