### PR TITLE
docs: state mandatory documentation-sync rule (Part C cascade)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -48,6 +48,12 @@ return errors.New("description of error")
 return errors.Errorf("invalid value: %s", val)
 ```
 
+### Documentation Sync
+
+- Code and documentation changes must be in the same PR (mandatory; org standard in `go-kure/.github` → `docs/standards.md`, CI-enforced)
+- When you change a package, update its `README.md` and any affected `site/` docs in the same PR; repoint every reference when removing/renaming
+- Map-based enforcement (`docs-map.yaml` + `check-doc-sync.sh`/link-check/doc-gate, as in `go-kure/kure`) is being rolled out here — follow the rule manually until then
+
 ### Commits
 
 Follow conventional commits:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -214,6 +214,19 @@ func TestResolve(t *testing.T) {
 - Use GoDoc conventions for function comments
 - Include examples in function documentation
 
+### Documentation sync (mandatory)
+
+**Code and documentation changes must be in the same PR.** When you change a
+package, update its `README.md` and any affected guides/site docs in the same PR;
+removing or renaming a package or symbol must repoint every reference. This is the
+go-kure organization documentation-sync standard (`go-kure/.github` →
+`docs/standards.md`), which is CI-enforced.
+
+Map-based enforcement (`docs-map.yaml` as the single source of code→docs mapping,
+with `check-doc-sync.sh` / link checks / a docs-with-code gate, as already in
+`go-kure/kure`) is being rolled out to this repo; until then, follow the rule
+manually and keep package READMEs and `site/` in sync with code.
+
 ## Security Considerations
 
 ### Secret Management


### PR DESCRIPTION
## What

Cascades the go-kure organization documentation-sync standard into launcher's agentic files (Part C).

- `AGENTS.md` and `.claude/CLAUDE.md` now state the mandatory rule: code and documentation change in the **same PR**, pointing at the org canon (`go-kure/.github` → `docs/standards.md`, CI-enforced).
- Notes that map-based enforcement (`docs-map.yaml` + `check-doc-sync.sh` / link-check / docs-with-code gate, as already in `go-kure/kure`) is being rolled out to this repo; until then the rule is followed manually.

Companion work: go-kure/kure #596 (Layers 1 & 3 enforcement + kure cascade); the org standard landed in go-kure/.github #24.