### PR TITLE
docs(pr-review): correct backend to claude-max-proxy:3456

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -14,7 +14,7 @@ This document provides an overview of all GitHub Actions workflows used in the l
 | [Deploy Docs](#deploy-docs-workflow) | `deploy-docs.yml` | push to main (docs paths), `workflow_dispatch` | Multi-version docs deployment |
 | [Release](#release-workflow) | `release.yml` | version tags | Release with GoReleaser, SBOM, docs deploy |
 | [Create Release](#create-release-workflow) | `release-create.yml` | `workflow_dispatch` | Pre-release test gate + tag creation |
-| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via ccproxy |
+| [PR Review](#pr-review-workflow) | `pr-review.yml` | pull_request | Two-pass AI code review via claude-max-proxy |
 | [Claude](#claude-workflow) | `claude.yml` | PR/issue/comment events | @claude AI assistant |
 
 The last five workflows are thin callers that delegate to reusable workflows in
@@ -278,7 +278,7 @@ subsequent workflows — `GITHUB_TOKEN` pushes do not trigger workflows).
 
 ### How It Works
 
-Two-pass AI review via a cluster-local ccproxy sidecar:
+Two-pass AI review via the cluster-local claude-max-proxy sidecar:
 
 1. **Pass 1 — Review**: Sends PR diff + `AGENTS.md` + `.claude/CLAUDE.md` to the review model.
    Posts up to 3 findings in a structured table as a PR comment.


### PR DESCRIPTION
The ccproxy (OpenAI/Codex) sidecar was retired in opsmaster. The PR-review workflow already calls the claude-max-proxy sidecar at `http://openclaw-claude-proxy.openclaw.svc:3456`. This fixes the stale doc references to the cluster-local ccproxy sidecar.

Originally intended for #143, but that PR merged via the queue before this could be added, so it lands as a separate PR.