### PR TITLE
docs(content): full per-package API reference + getting-started narrative (PR-B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,9 @@ map and run `bash site/scripts/gen-docs-tables.sh`.
 | `pkg/cmd/kurel/` | `api-reference/kurel-cli` | — |
 | `pkg/errors/` | `api-reference/errors` | — |
 | `pkg/patch/` | `api-reference/patch` | — |
+| `pkg/oam/` | `api-reference/oam` | — |
+| `pkg/oam/builtin/components/` | `api-reference/oam-components` | — |
+| `pkg/oam/builtin/traits/` | `api-reference/oam-traits` | — |
 | `.github/workflows/` | — | `contributing/github-workflows` |
 <!-- END GENERATED: reverse-mapping -->
 

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -1,22 +1,64 @@
-# OAM Model & Parser
+# OAM Model, Parser & Transformer
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/launcher/pkg/oam.svg)](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
 
-Package `oam` provides the OAM data model, YAML parser, and semantic validator for
-launcher Application documents (`apiVersion: launcher.gokure.dev/v1alpha1`), plus the
-transform pipeline that turns an `Application` + `ClusterProfile` into Kubernetes
-manifests.
+Package `oam` is launcher's core: the OAM data model, YAML parser, semantic
+validator, and the transform pipeline that turns an `Application` + `ClusterProfile`
+into Kubernetes manifests. All documents use `apiVersion: launcher.gokure.dev/v1alpha1`.
 
-Core surface: the data model (`Application`, `Component`, `Trait`,
-`ApplicationPolicy`, `Package`, `ClusterProfile`, `CapabilityDefinition`), the
-parsers (`Parse`, `ParseMulti`, `ParsePackage`, `ParseClusterProfile`,
-`LoadCapabilityDefinitions`), the transformer (`NewTransformer`,
-`ResolveParameters`), and the extension interfaces (`ComponentHandler`,
-`TraitHandler`, `PolicyHandler`, `CapabilityAware`).
+## Document kinds
 
-This is launcher's largest package and an **internal builder surface** consumed by
-the `kurel` CLI rather than a stable external SDK. A full per-symbol API reference is
-intentionally deferred; see the design docs under `docs/oam/` and
-[pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam) for the complete
-exported API. Built-in handler implementations live in
-[`builtin/components`](builtin/components) and [`builtin/traits`](builtin/traits).
+| Kind | Type | Purpose |
+|------|------|---------|
+| `Application` | `Application` | The app: `components[]` (each with `type` + `properties`) and `traits[]`. |
+| `Package` | `Package` | A parameterized, distributable unit: `app.yaml` + a `kurel.yaml` parameter schema (`ParameterDecl`). |
+| `ClusterProfile` | `ClusterProfile` | Platform choices (trait implementations, capabilities) supplied at build time. |
+| `CapabilityDefinition` | `CapabilityDefinition` | Declares a capability's rendering/property schema for validation. |
+
+## Pipeline
+
+```
+parse → resolve parameters → transform (component + trait handlers) → manifests
+```
+
+1. **Parse** an Application/Package/ClusterProfile from YAML.
+2. **Resolve parameters** (`ResolveParameters`) — apply `kurel.yaml` declarations,
+   values files, and `--set` overrides via `${var}` substitution.
+3. **Transform** (`Transformer`) — dispatch each component to its
+   `ComponentHandler` and each trait to its `TraitHandler`, merging the
+   `ClusterProfile`'s capability choices.
+
+## Parsing
+
+| Function | Purpose |
+|----------|---------|
+| `Parse` / `ParseMulti` / `MustParse` | Parse one / many Application documents. |
+| `ParsePackage` | Parse a `Package` (app + parameter schema). |
+| `ParseClusterProfile` | Parse a `ClusterProfile`. |
+| `LoadCapabilityDefinitions` | Load `CapabilityDefinition`s for capability validation. |
+| `ParseWithExtraTraitTypes` | Parse allowing additional (custom) trait types. |
+
+## Transform & extension
+
+`NewTransformer(...)` builds a transformer from maps of component/trait handlers;
+`pkg/cmd/kurel` registers the built-ins. Extend the system by implementing:
+
+| Interface | Role |
+|-----------|------|
+| `ComponentHandler` | `CanHandle(type)` + `ToApplicationConfig(...)` — see [components](oam-components). |
+| `TraitHandler` | `CanHandle(type)` + `Apply(...)` — see [traits](oam-traits). |
+| `PolicyHandler` | Enforce/validate policies (`Enforceable`, `PolicyResult`). |
+| `CapabilityAware` | Mark a handler as requiring a `ClusterProfile` capability. |
+| `SourceDeduplicatable` | Collapse duplicate sources (e.g. shared OCI/Helm repos). |
+
+## Capability system
+
+Capability-aware traits (e.g. `expose`, `certificate`, `external-secret`) declare
+required platform inputs; the `ClusterProfile` provides them, and
+`CapabilityDefinition` rendering/property schemas validate custom capabilities
+(`--strict-capabilities` turns warnings into errors).
+
+This is a large internal builder surface; the tables above cover the entry points.
+See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam) for the full
+type reference, the design notes under the Concepts section, and `examples/` for
+runnable applications.

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -45,8 +45,8 @@ parse → resolve parameters → transform (component + trait handlers) → mani
 
 | Interface | Role |
 |-----------|------|
-| `ComponentHandler` | `CanHandle(type)` + `ToApplicationConfig(...)` — see [components](oam-components). |
-| `TraitHandler` | `CanHandle(type)` + `Apply(...)` — see [traits](oam-traits). |
+| `ComponentHandler` | `CanHandle(type)` + `ToApplicationConfig(...)` — see [components](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components). |
+| `TraitHandler` | `CanHandle(type)` + `Apply(...)` — see [traits](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits). |
 | `PolicyHandler` | Enforce/validate policies (`Enforceable`, `PolicyResult`). |
 | `CapabilityAware` | Mark a handler as requiring a `ClusterProfile` capability. |
 | `SourceDeduplicatable` | Collapse duplicate sources (e.g. shared OCI/Helm repos). |

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -2,14 +2,64 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/launcher/pkg/oam/builtin/components.svg)](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components)
 
-Package `components` implements `oam.ComponentHandler` for the built-in OAM component
-types — `webservice`, `worker`, `statefulset`, `daemonset`, `cronjob`, `helmchart`,
-`oci`, `postgresql`, `passthrough`, and CRD passthrough. Each handler parses its
-typed config (e.g. `WebserviceConfig`, `CronjobConfig`, `HelmchartConfig`) and
-produces the corresponding Kubernetes resources via kure's builders.
+Package `components` implements `oam.ComponentHandler` for the built-in component
+types. Each handler parses a typed config from a component's `properties` and
+produces the corresponding Kubernetes resources via kure's builders. Handlers are
+registered with the transformer in `pkg/cmd/kurel` (`newBuiltinTransformer`), each
+mapping a component `type` string to a handler implementing `CanHandle` +
+`ToApplicationConfig`.
 
-This is an **internal builder surface** for the `kurel` CLI and the primary extension
-point for custom component types (implement `oam.ComponentHandler`). A full
-per-symbol reference is deferred; see
-[pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components)
-and the examples in `examples/` for usage. (#145 PR-B will publish the full reference.)
+## Component types
+
+| `type` | Produces | Summary |
+|--------|----------|---------|
+| `webservice` | Deployment, Service, ServiceAccount (+PVC) | HTTP service with replicas, probes, env, volumes. |
+| `worker` | Deployment, ServiceAccount (+PVC) | Background workload (no Service/port). |
+| `statefulset` | StatefulSet, headless Service, SA | Stateful workload with `volumeClaimTemplates`. |
+| `daemonset` | DaemonSet, SA (+Service if `port`) | Per-node daemon; honors `tolerations`. |
+| `cronjob` | CronJob, SA | Scheduled job; cron `schedule` + history limits. |
+| `helmchart` | HelmRelease + Helm/OCIRepository, or rendered manifests | Helm via Flux (`native`) or client-side `template`. |
+| `oci` | OCIRepository, Kustomization | Sync manifests from an OCI artifact (Flux). |
+| `postgresql` | CNPG Cluster, Pooler, ObjectStore, Database | CloudNativePG database (backup/monitoring/pooling). |
+| `passthrough` | any (verbatim) | Emit an arbitrary object as-declared (`clusterScoped` opt). |
+| `crd` | CustomResourceDefinition(s) | CRDs from `inline`/`url`; rejects non-CRD docs. |
+| `manifests` | any | Raw manifests from `inline`/`url` with namespace stamping + `scopeOverrides`. |
+
+## Common config
+
+Most workload types (`webservice`, `worker`, `statefulset`, `daemonset`, `cronjob`)
+share these fields: `image` (validated — no untagged/`latest`), `env` (with
+`valueFrom` secret/configMap refs), `resources` (requests/limits, defaults
+100m/128Mi), `command`/`args`, `probes` (httpGet/tcpSocket/exec/grpc),
+`volumes`, `initContainers`, `sidecars`, and `affinity`.
+
+## Per-type highlights
+
+- **webservice / worker** — `image`, `replicas` (default 1), `port` (webservice).
+- **statefulset** — `volumeClaimTemplates` (`name`, `size`, `storageClass`,
+  `accessModes`, `mountPath`), `serviceName` (headless).
+- **daemonset** — `tolerations` (`key`/`operator`/`value`/`effect`); `port`
+  optionally adds a Service.
+- **cronjob** — `schedule` (5-field cron), `restartPolicy` (default `OnFailure`),
+  `successfulJobsHistoryLimit`/`failedJobsHistoryLimit`.
+- **helmchart** — `chart`, `version`, `delivery` (`native`|`template`), `source`
+  (inline `url` or `{name,kind}` ref), `values`/`valuesFrom`, `driftDetection`,
+  `install.crds`/`upgrade.crds`.
+- **oci** — `source.url` (`oci://…`), `version` (tag or `sha256:…`), `path`,
+  `prune`, `interval`, `targetNamespace`.
+- **postgresql** — `provider: cnpg`, `version` (default `16`), `storageSize`,
+  `replicas`, `backup.*`, `monitoring.enabled`, `pooler.enabled`, `managedRoles`,
+  `databases`.
+- **passthrough** — `object` (full apiVersion/kind/metadata/spec), `clusterScoped`.
+- **crd / manifests** — `inline` xor `url`; `manifests` adds `scopeOverrides`
+  (`apiVersion`/`kind`/`scope`) for unknown kinds.
+
+## Extending
+
+Custom component types implement `oam.ComponentHandler` (`CanHandle` +
+`ToApplicationConfig`) and are registered alongside the built-ins. Exported helpers:
+`ValidateImageRef` (image policy) and `BuildPVC` (PVC from a `PVCConfig`).
+
+See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components)
+for the full type/field reference, the [OAM model](oam) for the handler interfaces,
+and `examples/` for runnable applications.

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -61,5 +61,5 @@ Custom component types implement `oam.ComponentHandler` (`CanHandle` +
 `ValidateImageRef` (image policy) and `BuildPVC` (PVC from a `PVCConfig`).
 
 See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components)
-for the full type/field reference, the [OAM model](oam) for the handler interfaces,
-and `examples/` for runnable applications.
+for the full type/field reference, the [OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
+for the handler interfaces, and `examples/` for runnable applications.

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -67,5 +67,5 @@ Custom traits implement `oam.TraitHandler` (`CanHandle` + `Apply`), optionally
 `CapabilityAware` + `ValidateAndApplyDefaults` for capability validation.
 
 See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
-for the full config-field reference, the [OAM model](oam) for the interfaces, and
-`examples/` for runnable applications.
+for the full config-field reference, the [OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
+for the interfaces, and `examples/` for runnable applications.

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -2,16 +2,70 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/launcher/pkg/oam/builtin/traits.svg)](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
 
-Package `traits` implements `oam.TraitHandler` for the built-in OAM trait types,
-covering networking (`ingress`, `httproute`, `expose`, network policy / Cilium),
-security (`rbac`, `certificate`, `externalsecret`), storage (`pvc`, `volsync`),
-config (`configmap`), scaling (`scaler`), and operational concerns (FluxCD patches,
-prune protection, post-build). Each handler parses its typed config (e.g.
-`IngressConfig`, `HTTPRouteConfig`, `CertificateConfig`, `ScalerConfig`) and decorates
-or emits Kubernetes resources accordingly.
+Package `traits` implements `oam.TraitHandler` for the built-in trait types. A trait
+decorates or augments a component — adding networking, security, storage, scaling,
+or operational behavior. Handlers are registered with the transformer in
+`pkg/cmd/kurel` via `RegisterBuiltinTrait(type, handler)`; each implements
+`CanHandle` + `Apply`. Some traits are **capability-aware** (`CapabilityRequired`)
+and draw platform choices (issuer, gateway, secret store) from the `ClusterProfile`.
 
-This is an **internal builder surface** for the `kurel` CLI and the extension point
-for custom traits (implement `oam.TraitHandler`). A full per-symbol reference is
-deferred; see
-[pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
-and `examples/` for usage. (#145 PR-B will publish the full reference.)
+## Trait catalog
+
+### Networking
+| `type` | Produces | Key properties |
+|--------|----------|----------------|
+| `ingress` | Ingress | `rules[]` (`host`, `paths[]`), `ingressClassName`, `tls[]`, `annotations` |
+| `httproute` | Gateway API HTTPRoute | `parentRefs[]`, `rules[]` (`matches`/`backendRefs`/`filters`/`timeouts`), `hostnames[]` |
+| `expose` | Ingress **or** HTTPRoute | `rules[]`, `hostnames[]` — controller chosen by ClusterProfile (`controllerType`) |
+| `networkpolicy` | NetworkPolicy | `ingress[]`/`egress[]` (`from`/`to`, `ports`) |
+| `cilium-networkpolicy` | CiliumNetworkPolicy | `name`, `endpointSelector`, `ingress`/`egress` (raw Cilium rules) |
+
+### Security
+| `type` | Produces | Key properties |
+|--------|----------|----------------|
+| `certificate` | cert-manager Certificate | `secretName`, `dnsNames[]`, `duration`, `renewBefore` (issuer from ClusterProfile) |
+| `rbac` | Role/RoleBinding (+ClusterRole/Binding) | `rules[]` (`apiGroups`/`resources`/`verbs`), `clusterWide` |
+| `external-secret` | ESO ExternalSecret | `secretName`, `data[]`/`dataFrom[]`, `refreshInterval` (store from ClusterProfile or `provider`) |
+
+### Storage
+| `type` | Produces | Key properties |
+|--------|----------|----------------|
+| `pvc` | PersistentVolumeClaim | `name`, `size`, `storageClassName`, `accessModes[]` (policy: `maxStorageSize`) |
+| `volsync` | VolSync ReplicationSource | `sourcePVC`, `schedule`, `copyMethod`, `retain.{daily,weekly,monthly}` |
+
+### Configuration & scaling
+| `type` | Produces | Key properties |
+|--------|----------|----------------|
+| `configmap` | ConfigMap (+ optional volume mount) | `name`, `data`, `mountPath` |
+| `scaler` | HorizontalPodAutoscaler (+ optional PDB) | `minReplicas`, `maxReplicas`, `cpuUtilization`, `memoryUtilization`, `enablePDB` |
+
+### Operational (FluxCD)
+| `type` | Effect | Key properties |
+|--------|--------|----------------|
+| `fluxcd-patches` | Appends `Kustomization.spec.patches` | `patches[]` (`patch`, `target`) |
+| `fluxcd-postbuild` | Sets `Kustomization.spec.postBuild` | `substitute`, `substituteFrom[]` |
+| `prune-protection` | Adds `kustomize.toolkit.fluxcd.io/prune: disabled` | (no properties) |
+
+## Capability-aware traits
+
+These require (or optionally use) a `ClusterProfile` capability, so the platform —
+not the app — chooses the implementation:
+
+- **expose** → `controllerType` (ingress vs gateway) + gateway/ingress details.
+- **certificate** → `issuerRef` (cert-manager issuer/cluster-issuer).
+- **external-secret** → `secretStoreRef` (or the inline `provider` shorthand).
+
+## Auto-synthesized NetworkPolicy
+
+Routing traits (`ingress`/`httproute`/`expose`) can surface platform-reserved
+`networkPolicy.trafficSources`, which the OAM layer collects to synthesize a
+matching `NetworkPolicy` (see [`pkg/oam/netpol`](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/netpol)).
+
+## Extending
+
+Custom traits implement `oam.TraitHandler` (`CanHandle` + `Apply`), optionally
+`CapabilityAware` + `ValidateAndApplyDefaults` for capability validation.
+
+See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
+for the full config-field reference, the [OAM model](oam) for the interfaces, and
+`examples/` for runnable applications.

--- a/site/content/api-reference/_index.md
+++ b/site/content/api-reference/_index.md
@@ -18,6 +18,14 @@ For the full Go API, see
 |---------|-------------|-----------|
 | [kurel CLI](kurel-cli) | kurel command tree, flags, and usage | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/cmd/kurel) |
 
+## OAM
+
+| Package | Description | Reference |
+|---------|-------------|-----------|
+| [OAM Model](oam) | OAM data model, parser, and transform pipeline | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam) |
+| [Component Handlers](oam-components) | Built-in component types (webservice, worker, cronjob, helmchart, …) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components) |
+| [Trait Handlers](oam-traits) | Built-in traits (ingress, certificate, scaler, externalsecret, …) | [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits) |
+
 ## Libraries
 
 | Package | Description | Reference |

--- a/site/content/getting-started/examples.md
+++ b/site/content/getting-started/examples.md
@@ -1,0 +1,38 @@
+---
+title: "Examples"
+weight: 4
+---
+
+# Examples
+
+The [`examples/`](https://github.com/go-kure/launcher/tree/main/examples) directory
+contains runnable OAM Applications and cluster profiles. Build any of them with:
+
+```bash
+kurel build examples/01-webservice-minimal.yaml \
+  --profile examples/cluster-profiles/minimal.yaml
+```
+
+## Application examples
+
+| Example | Shows |
+|---------|-------|
+| `01-webservice-minimal` / `02-…-with-expose` / `03-…-with-tls` / `04-…-full` | webservice from minimal to full (expose, TLS, probes, volumes) |
+| `05-worker-minimal` / `06-worker-with-traits` | background workers |
+| `07-cronjob-minimal` / `08-cronjob-full` | scheduled jobs |
+| `09-postgresql-minimal` / `10-postgresql-ha` | CloudNativePG databases |
+| `11-helmchart` | Helm chart via Flux |
+| `12-daemonset` / `13-statefulset` | node daemons and stateful workloads |
+| `14-full-stack` | a multi-component application |
+| `15-passthrough-minimal` | emit an arbitrary object verbatim |
+
+## Cluster profiles & custom capabilities
+
+- [`cluster-profiles/`](https://github.com/go-kure/launcher/tree/main/examples/cluster-profiles)
+  — platform profiles (minimal, cert-manager + vault, gateway + AWS, …).
+- [`custom-capability/`](https://github.com/go-kure/launcher/tree/main/examples/custom-capability)
+  — extending kurel with a custom capability.
+
+See the [Component Handlers](../api-reference/oam-components/) and
+[Trait Handlers](../api-reference/oam-traits/) references for the full set of types
+and their properties.

--- a/site/content/getting-started/install.md
+++ b/site/content/getting-started/install.md
@@ -1,0 +1,35 @@
+---
+title: "Install"
+weight: 2
+---
+
+# Install
+
+> Tagged binary releases are not yet available. Until the first release, install
+> from source.
+
+## From source (Go)
+
+```bash
+go install github.com/go-kure/launcher/cmd/kurel@latest
+```
+
+This builds the `kurel` binary into `$(go env GOPATH)/bin`; make sure that
+directory is on your `PATH`.
+
+## Build a checkout
+
+```bash
+git clone https://github.com/go-kure/launcher
+cd launcher
+make build        # or: mise run build
+./bin/kurel version
+```
+
+## Verify
+
+```bash
+kurel version
+```
+
+Next: the [Quickstart](quickstart/).

--- a/site/content/getting-started/introduction.md
+++ b/site/content/getting-started/introduction.md
@@ -1,0 +1,33 @@
+---
+title: "Introduction"
+weight: 1
+---
+
+# Introduction
+
+**kurel** is an OAM-native package manager for Kubernetes. You describe an
+application with an OAM-style document (`app.yaml`) — a set of typed *components*
+(webservice, worker, cronjob, postgresql, …) decorated with *traits* (ingress,
+certificate, scaler, external-secret, …) — and `kurel build` resolves it into
+static, GitOps-ready Kubernetes manifests.
+
+## The two-config-set model
+
+kurel separates **what an application needs** from **how a cluster provides it**:
+
+- **Package config** — the application author's `app.yaml` (and an optional
+  `kurel.yaml` parameter schema for distributable, parameterized packages).
+- **Site config** — a platform `ClusterProfile` that supplies cluster-specific
+  choices (which ingress/gateway controller, which cert-manager issuer, which
+  secret store, …).
+
+At build time the two are resolved together, so the same package renders correctly
+on different clusters without edits.
+
+## Where to go next
+
+- [Install](install/) kurel.
+- Follow the [Quickstart](quickstart/) to build your first app.
+- Browse runnable [Examples](examples/).
+- Read the [Concepts](../concepts/) for the design and OAM model, and the
+  [API reference](../api-reference/) for packages and the CLI.

--- a/site/content/getting-started/quickstart.md
+++ b/site/content/getting-started/quickstart.md
@@ -1,0 +1,60 @@
+---
+title: "Quickstart"
+weight: 3
+---
+
+# Quickstart
+
+Build Kubernetes manifests from an OAM Application and a platform ClusterProfile.
+
+## 1. An application
+
+`app.yaml` — a single webservice component:
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: hello
+spec:
+  components:
+    - name: web
+      type: webservice
+      properties:
+        image: nginx:1.27
+        port: 80
+  traits: []
+```
+
+## 2. A cluster profile
+
+`profile.yaml` — minimal platform choices:
+
+```yaml
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: ClusterProfile
+metadata:
+  name: minimal
+spec: {}
+```
+
+## 3. Build
+
+```bash
+# Render to stdout
+kurel build app.yaml --profile profile.yaml
+
+# …or write manifests to a directory
+kurel build app.yaml --profile profile.yaml -o out/
+```
+
+`kurel` resolves the application against the profile and emits ready-to-apply
+Kubernetes manifests (here a Deployment, Service, and ServiceAccount).
+
+## Next steps
+
+- Add traits (ingress, certificate, scaler) — see the [Trait Handlers](../api-reference/oam-traits/).
+- Explore component types — see the [Component Handlers](../api-reference/oam-components/).
+- Parameterize a reusable package (`kurel.yaml`, `--values`, `--set`) — see the
+  full [kurel CLI reference](../api-reference/kurel-cli/).
+- Browse runnable [Examples](examples/).

--- a/site/docs-map.yaml
+++ b/site/docs-map.yaml
@@ -28,23 +28,22 @@ packages:
     readme: pkg/patch/README.md
     mount: {target: api-reference/patch.md, title: Patch Engine, weight: 40, group: Libraries, desc: "Declarative JSONPath patching (TOML/YAML, strategic merge)"}
 
-  # ─── Unmounted: internal builder surface; full reference deferred (PR-B / #145) ───
+  # ─── Published (OAM model + handler catalogs) ───
   - path: pkg/oam
     readme: pkg/oam/README.md
-    mounted: false
-    reason: "Large internal builder surface (OAM model/parser/transformer); full per-package reference deferred to the content PR."
+    mount: {target: api-reference/oam.md, title: OAM Model, weight: 20, group: OAM, desc: "OAM data model, parser, and transform pipeline"}
+  - path: pkg/oam/builtin/components
+    readme: pkg/oam/builtin/components/README.md
+    mount: {target: api-reference/oam-components.md, title: Component Handlers, weight: 22, group: OAM, desc: "Built-in component types (webservice, worker, cronjob, helmchart, …)"}
+  - path: pkg/oam/builtin/traits
+    readme: pkg/oam/builtin/traits/README.md
+    mount: {target: api-reference/oam-traits.md, title: Trait Handlers, weight: 24, group: OAM, desc: "Built-in traits (ingress, certificate, scaler, externalsecret, …)"}
+
+  # ─── Unmounted: internal support; not a user-facing API ───
   - path: pkg/oam/builtin
     readme: pkg/oam/builtin/README.md
     mounted: false
-    reason: "Internal capability rendering schemas; not a user-facing API."
-  - path: pkg/oam/builtin/components
-    readme: pkg/oam/builtin/components/README.md
-    mounted: false
-    reason: "Internal component handlers; full reference deferred to the content PR."
-  - path: pkg/oam/builtin/traits
-    readme: pkg/oam/builtin/traits/README.md
-    mounted: false
-    reason: "Internal trait handlers; full reference deferred to the content PR."
+    reason: "Internal capability rendering schemas used by the component/trait handlers."
   - path: pkg/oam/netpol
     readme: pkg/oam/netpol/README.md
     mounted: false

--- a/site/docs-map.yaml
+++ b/site/docs-map.yaml
@@ -72,6 +72,7 @@ extra_mounts:
   - {source: docs/oam/options-param-syntax.md, target: concepts/oam-param-syntax.md, title: Parameter Syntax, weight: 50}
   - {source: docs/oam/options-policy-interface.md, target: concepts/oam-policy-interface.md, title: Policy Interface, weight: 60}
   - {source: docs/oam/options-package-composition.md, target: concepts/oam-package-composition.md, title: Package Composition, weight: 70}
+  - {source: docs/oam/design-capability-schema.md, target: concepts/oam-capability-schema.md, title: Capability Schema, weight: 55}
   - {source: DEVELOPMENT.md, target: contributing/guide.md, title: Development Guide, weight: 10}
   - {source: docs/github-workflows.md, target: contributing/github-workflows.md, title: GitHub Workflows, weight: 20}
   - {source: CHANGELOG.md, target: changelog/releases.md, title: Releases, weight: 10}


### PR DESCRIPTION
**PR-B** of the launcher docs split — the content layer. Stacked on #146 (PR-A: enforcement + mount-existing); GitHub will retarget this to `main` once #146 merges.

Completes the full, per-package documentation site for #2.

## Commits
1. **Per-package API references** — expand the `pkg/oam`, `pkg/oam/builtin/components`, and `pkg/oam/builtin/traits` overview READMEs into full reference pages and **publish** them under a new "OAM" api-reference group:
   - `oam` — data model, document kinds, parse→resolve→transform pipeline, extension interfaces, capability system.
   - `components` — catalog of the 11 component types with produced resources + key config.
   - `traits` — catalog of the 15 traits grouped (networking/security/storage/config/scaling/operational) with key config + capability notes.
   These packages are now mounted, so the doc-gate covers them.
2. **Getting-started narrative + capability schema** — site-native `introduction`, `install`, `quickstart`, and `examples` pages (authored rather than mounting the repo README/examples, whose repo-relative links don't resolve on the site), and mount the link-clean `design-capability-schema` doc into Concepts.

## Scope notes
- README/examples are represented by purpose-built site pages (link-safe across baseURL) instead of raw mounts.
- Discoverability (a launcher link on `go-kure/go-kure.github.io` `index.html`) is a separate repo/PR.

## Verification (local)
- `check-doc-sync`: OK (11 packages mapped; oam/components/traits now mounted).
- Hugo build renders the new OAM api-reference pages, the getting-started pages, and the capability-schema concept page.
- `check-links` (offline, rendered): 0 internal-link errors.

Closes #2.
