### PR TITLE
fix(oam): use k8s.io/api constants for well-known K8s values

### DIFF
--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -63,3 +63,9 @@ Custom component types implement `oam.ComponentHandler` (`CanHandle` +
 See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/components)
 for the full type/field reference, the [OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
 for the handler interfaces, and `examples/` for runnable applications.
+
+## Conventions
+
+Handlers use `k8s.io/api` constants for well-known Kubernetes enum values (access
+modes, restart policies, etc.) rather than string literals — never re-define values
+that already exist upstream.

--- a/pkg/oam/builtin/components/common.go
+++ b/pkg/oam/builtin/components/common.go
@@ -632,7 +632,7 @@ func parseAccessModes(m map[string]any) ([]string, error) {
 			return result, nil
 		}
 	}
-	return []string{"ReadWriteOnce"}, nil
+	return []string{string(corev1.ReadWriteOnce)}, nil
 }
 
 func parseInitContainers(props map[string]any) ([]InitContainerConfig, error) {

--- a/pkg/oam/builtin/components/cronjob.go
+++ b/pkg/oam/builtin/components/cronjob.go
@@ -54,9 +54,9 @@ func (h *CronjobHandler) ToApplicationConfig(component *oam.Component, namespace
 	config.RestartPolicy = corev1.RestartPolicyOnFailure
 	if rp, ok := props["restartPolicy"].(string); ok {
 		switch rp {
-		case "Never":
+		case string(corev1.RestartPolicyNever):
 			config.RestartPolicy = corev1.RestartPolicyNever
-		case "OnFailure":
+		case string(corev1.RestartPolicyOnFailure):
 			config.RestartPolicy = corev1.RestartPolicyOnFailure
 		default:
 			return nil, errors.Errorf("invalid restartPolicy %q, must be 'Never' or 'OnFailure'", rp)

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -70,3 +70,9 @@ Custom traits implement `oam.TraitHandler` (`CanHandle` + `Apply`), optionally
 See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
 for the full config-field reference, the [OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
 for the interfaces, and `examples/` for runnable applications.
+
+## Conventions
+
+Handlers use `k8s.io/api` constants for well-known Kubernetes enum values (access
+modes, restart policies, etc.) rather than string literals — never re-define values
+that already exist upstream.

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -2,6 +2,7 @@ package traits
 
 import (
 	"github.com/go-kure/kure/pkg/stack"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -11,10 +12,10 @@ import (
 )
 
 var validPVCAccessModes = map[string]bool{
-	"ReadWriteOnce":    true,
-	"ReadOnlyMany":     true,
-	"ReadWriteMany":    true,
-	"ReadWriteOncePod": true,
+	string(corev1.ReadWriteOnce):    true,
+	string(corev1.ReadOnlyMany):     true,
+	string(corev1.ReadWriteMany):    true,
+	string(corev1.ReadWriteOncePod): true,
 }
 
 // PVCHandler handles OAM pvc traits, generating a standalone PersistentVolumeClaim.
@@ -60,7 +61,7 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 		storageClass = s
 	}
 
-	accessModes := []string{"ReadWriteOnce"}
+	accessModes := []string{string(corev1.ReadWriteOnce)}
 	if rawModes, ok := props["accessModes"].([]any); ok {
 		if len(rawModes) == 0 {
 			return nil, errors.New("accessModes must not be empty when specified")


### PR DESCRIPTION
## Summary

Replace hard-coded Kubernetes enum string literals with their `k8s.io/api` constants, per launcher standards (do not re-define well-known values that exist upstream). Issue #164.

Closes #164.

## Changes

- `pkg/oam/builtin/traits/pvc.go`: `validPVCAccessModes` keys + default access mode → `corev1.ReadWriteOnce`/`ReadOnlyMany`/`ReadWriteMany`/`ReadWriteOncePod`.
- `pkg/oam/builtin/components/common.go`: default access-mode return → `corev1.ReadWriteOnce`.
- `pkg/oam/builtin/components/cronjob.go`: `restartPolicy` switch cases → `corev1.RestartPolicyNever`/`OnFailure`.

## No behavior change

The emitted string values are identical; existing `pvc`/`cronjob` tests pass unchanged. Requesting `docs-skip` — this is a literal→constant refactor with nothing user-facing to document.

## Verification (`GOWORK=off`)

- `go build ./...` clean; `go test ./pkg/oam/builtin/...` green.