### PR TITLE
feat(oam): property-schema vocabulary + handler-schema interface

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -49,7 +49,19 @@ parse → resolve parameters → transform (component + trait handlers) → mani
 | `TraitHandler` | `CanHandle(type)` + `Apply(...)` — see [traits](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits). |
 | `PolicyHandler` | Enforce/validate policies (`Enforceable`, `PolicyResult`). |
 | `CapabilityAware` | Mark a handler as requiring a `ClusterProfile` capability. |
+| `PropertySchemaProvider` | Declare a `PropertySchema` for the handler's user-facing properties (see below). |
 | `SourceDeduplicatable` | Collapse duplicate sources (e.g. shared OCI/Helm repos). |
+
+## Property schemas
+
+Handlers may implement `PropertySchemaProvider` (`PropertySchema() map[string]PropertySchema`)
+to declare a constrained schema for their user-facing properties. `PropertySchema` is the
+richer sibling of `CapabilityPropertySchema`: `Type` (string/integer/boolean/number/array/object),
+`Required`, `Default`, `Enum`, nested `Properties`, `Items`, and `AdditionalProperties` (default
+false; escape-hatch fields set it true). `Transformer.HandlerSchemas()` returns a
+`HandlerSchemaSet{ Components, Traits }` of every registered handler that declares one, so crane's
+validator can check a component/trait's properties before the handler is invoked. Built-in
+examples: the `configmap` trait and the `passthrough` component.
 
 ## Capability system
 

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -7,7 +7,9 @@ types. Each handler parses a typed config from a component's `properties` and
 produces the corresponding Kubernetes resources via kure's builders. Handlers are
 registered with the transformer in `pkg/cmd/kurel` (`newBuiltinTransformer`), each
 mapping a component `type` string to a handler implementing `CanHandle` +
-`ToApplicationConfig`.
+`ToApplicationConfig`. Handlers may also implement `oam.PropertySchemaProvider`
+(`PropertySchema()`) to declare a constrained schema for their properties so crane can
+validate them before invocation — the `passthrough` handler is a worked example.
 
 ## Component types
 

--- a/pkg/oam/builtin/components/passthrough.go
+++ b/pkg/oam/builtin/components/passthrough.go
@@ -28,6 +28,15 @@ func (h *PassthroughHandler) CanHandle(componentType string) bool {
 	return componentType == "passthrough"
 }
 
+// PropertySchema declares the passthrough component's properties. `object` is the
+// escape-hatch body emitted verbatim, so it is an open object (additionalProperties).
+func (h *PassthroughHandler) PropertySchema() map[string]oam.PropertySchema {
+	return map[string]oam.PropertySchema{
+		"object":        {Type: oam.PropertyTypeObject, Required: true, AdditionalProperties: true},
+		"clusterScoped": {Type: oam.PropertyTypeBoolean, Default: false},
+	}
+}
+
 // ToApplicationConfig validates the passthrough properties and returns a PassthroughConfig.
 func (h *PassthroughHandler) ToApplicationConfig(component *oam.Component, namespace string) (stack.ApplicationConfig, error) {
 	props := component.Properties

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -8,6 +8,9 @@ or operational behavior. Handlers are registered with the transformer in
 `pkg/cmd/kurel` via `RegisterBuiltinTrait(type, handler)`; each implements
 `CanHandle` + `Apply`. Some traits are **capability-aware** (`CapabilityRequired`)
 and draw platform choices (issuer, gateway, secret store) from the `ClusterProfile`.
+Handlers may also implement `oam.PropertySchemaProvider` (`PropertySchema()`) to declare a
+constrained schema for their properties so crane can validate them before invocation — the
+`configmap` handler is a worked example.
 
 ## Trait catalog
 

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -36,6 +36,16 @@ func (h *ConfigMapHandler) CanHandle(traitType string) bool {
 	return traitType == "configmap"
 }
 
+// PropertySchema declares the configmap trait's user-facing properties so crane
+// can validate them before invocation. `data` is an open map (escape hatch).
+func (h *ConfigMapHandler) PropertySchema() map[string]oam.PropertySchema {
+	return map[string]oam.PropertySchema{
+		"name":      {Type: oam.PropertyTypeString, Required: true},
+		"mountPath": {Type: oam.PropertyTypeString},
+		"data":      {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+	}
+}
+
 // ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
 func (h *ConfigMapHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
 	if _, err := builtin.DecodeStrict[builtin.ConfigmapRendering](rendering); err != nil {

--- a/pkg/oam/handler.go
+++ b/pkg/oam/handler.go
@@ -24,6 +24,15 @@ type CapabilityAware interface {
 	CapabilityRequired() bool
 }
 
+// PropertySchemaProvider is an optional interface implemented by component and
+// trait handlers that declare a schema for their user-facing properties. crane's
+// validator consumes these schemas (via Transformer.HandlerSchemas) to validate a
+// component/trait's properties before the handler is invoked. Handlers that accept
+// arbitrary keys declare an open field with PropertySchema.AdditionalProperties.
+type PropertySchemaProvider interface {
+	PropertySchema() map[string]PropertySchema
+}
+
 // SourceDeduplicatable is an optional interface for ApplicationConfig types
 // that generate source CRDs (e.g. HelmRepository). The runtime uses it to
 // suppress duplicate source generation when multiple components share the

--- a/pkg/oam/schema.go
+++ b/pkg/oam/schema.go
@@ -1,0 +1,42 @@
+package oam
+
+// PropertyType is the constrained set of value types a handler property may
+// declare. It mirrors the JSON-schema scalar/compound vocabulary that crane's
+// validator understands.
+type PropertyType string
+
+const (
+	PropertyTypeString  PropertyType = "string"
+	PropertyTypeInteger PropertyType = "integer"
+	PropertyTypeBoolean PropertyType = "boolean"
+	PropertyTypeNumber  PropertyType = "number"
+	PropertyTypeArray   PropertyType = "array"
+	PropertyTypeObject  PropertyType = "object"
+)
+
+// PropertySchema is the constrained schema vocabulary describing one handler
+// property. It is the richer sibling of CapabilityPropertySchema (types.go),
+// which models only the custom-trait YAML rendering fields (type/required/
+// default/description). Launcher-origin handlers expose PropertySchema via the
+// PropertySchemaProvider interface (handler.go) so crane can validate a
+// component/trait's user-facing properties before invoking the handler.
+//
+// AdditionalProperties defaults to false: a handler that accepts arbitrary keys
+// (an escape hatch, e.g. the passthrough component's `object`) sets it true.
+type PropertySchema struct {
+	// Type is the value type. Required.
+	Type PropertyType `json:"type"`
+	// Required marks the property as mandatory.
+	Required bool `json:"required,omitempty"`
+	// Default is the value applied when the property is absent.
+	Default any `json:"default,omitempty"`
+	// Enum, when non-empty, constrains the value to this set.
+	Enum []any `json:"enum,omitempty"`
+	// Properties describes the fields of a Type==object value.
+	Properties map[string]PropertySchema `json:"properties,omitempty"`
+	// Items describes the element schema of a Type==array value.
+	Items *PropertySchema `json:"items,omitempty"`
+	// AdditionalProperties allows keys beyond those in Properties (object types).
+	// Defaults to false.
+	AdditionalProperties bool `json:"additionalProperties,omitempty"`
+}

--- a/pkg/oam/schema_test.go
+++ b/pkg/oam/schema_test.go
@@ -1,0 +1,76 @@
+package oam
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+)
+
+// schemaComponent is a stub ComponentHandler that declares a property schema.
+type schemaComponent struct{ typ string }
+
+func (h schemaComponent) CanHandle(t string) bool { return t == h.typ }
+func (h schemaComponent) ToApplicationConfig(*Component, string) (stack.ApplicationConfig, error) {
+	return nil, nil
+}
+func (h schemaComponent) PropertySchema() map[string]PropertySchema {
+	return map[string]PropertySchema{"image": {Type: PropertyTypeString, Required: true}}
+}
+
+// plainComponent is a stub ComponentHandler with no schema.
+type plainComponent struct{ typ string }
+
+func (h plainComponent) CanHandle(t string) bool { return t == h.typ }
+func (h plainComponent) ToApplicationConfig(*Component, string) (stack.ApplicationConfig, error) {
+	return nil, nil
+}
+
+// schemaTrait is a stub TraitHandler that declares a property schema.
+type schemaTrait struct{ typ string }
+
+func (h schemaTrait) CanHandle(t string) bool                               { return t == h.typ }
+func (h schemaTrait) Apply(*Trait, *stack.Application, *stack.Bundle) error { return nil }
+func (h schemaTrait) PropertySchema() map[string]PropertySchema {
+	return map[string]PropertySchema{
+		"size":        {Type: PropertyTypeString, Required: true},
+		"accessModes": {Type: PropertyTypeArray, Items: &PropertySchema{Type: PropertyTypeString}},
+	}
+}
+
+func TestHandlerSchemas(t *testing.T) {
+	tr := NewTransformer(
+		map[string]ComponentHandler{
+			"webservice": schemaComponent{typ: "webservice"},
+			"plain":      plainComponent{typ: "plain"},
+		},
+		map[string]TraitHandler{
+			"pvc": schemaTrait{typ: "pvc"},
+		},
+	)
+
+	set := tr.HandlerSchemas()
+
+	// Providers are included, split by kind; non-providers are omitted.
+	if _, ok := set.Components["webservice"]; !ok {
+		t.Errorf("expected component 'webservice' schema, got %v", set.Components)
+	}
+	if _, ok := set.Components["plain"]; ok {
+		t.Error("plain component has no schema and must be omitted")
+	}
+	if _, ok := set.Traits["pvc"]; !ok {
+		t.Errorf("expected trait 'pvc' schema, got %v", set.Traits)
+	}
+
+	// Component and trait maps are distinct (no cross-registry collision).
+	if _, ok := set.Traits["webservice"]; ok {
+		t.Error("component schema leaked into Traits map")
+	}
+
+	// Schema content round-trips.
+	if got := set.Components["webservice"]["image"]; got.Type != PropertyTypeString || !got.Required {
+		t.Errorf("webservice.image schema = %+v", got)
+	}
+	if got := set.Traits["pvc"]["accessModes"]; got.Type != PropertyTypeArray || got.Items == nil || got.Items.Type != PropertyTypeString {
+		t.Errorf("pvc.accessModes schema = %+v", got)
+	}
+}

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -121,6 +121,36 @@ func (t *Transformer) RegisterTrait(typeName string, h TraitHandler) {
 	t.traitHandlers[typeName] = h
 }
 
+// HandlerSchemaSet is the set of property schemas declared by registered handlers,
+// keyed by handler type name. Component and trait schemas are kept separate so a
+// component and a trait that share a type name do not collide, and so consumers
+// (crane's validator) know which registry a schema came from.
+type HandlerSchemaSet struct {
+	Components map[string]map[string]PropertySchema
+	Traits     map[string]map[string]PropertySchema
+}
+
+// HandlerSchemas returns the property schemas of every registered component and
+// trait handler that implements PropertySchemaProvider. Handlers that do not
+// implement it are omitted. The maps are always non-nil.
+func (t *Transformer) HandlerSchemas() HandlerSchemaSet {
+	set := HandlerSchemaSet{
+		Components: make(map[string]map[string]PropertySchema),
+		Traits:     make(map[string]map[string]PropertySchema),
+	}
+	for name, h := range t.componentHandlers {
+		if p, ok := h.(PropertySchemaProvider); ok {
+			set.Components[name] = p.PropertySchema()
+		}
+	}
+	for name, h := range t.traitHandlers {
+		if p, ok := h.(PropertySchemaProvider); ok {
+			set.Traits[name] = p.PropertySchema()
+		}
+	}
+	return set
+}
+
 // RegisterPolicy registers a policy handler under the given type name.
 // Panics if typeName is already registered or if h.CanHandle(typeName) returns false.
 func (t *Transformer) RegisterPolicy(typeName string, h PolicyHandler) {


### PR DESCRIPTION
## Summary

Defines the constrained property-schema vocabulary and the handler-schema contract so launcher handlers can describe their properties and crane's validator can check them before invocation (crane#235 D7b, launcher side). **Contract only** — per-handler adoption across all handlers is a follow-up.

Closes #163.

## What's added

- **`pkg/oam/schema.go`** — `PropertySchema` (`Type`, `Required`, `Default`, `Enum`, nested `Properties`, `Items`, `AdditionalProperties` [default false]) + `PropertyType` consts (string/integer/boolean/number/array/object). It's the richer sibling of the existing `CapabilityPropertySchema` (custom-trait YAML), which is left unchanged.
- **`pkg/oam/handler.go`** — `PropertySchemaProvider` optional interface (`PropertySchema() map[string]PropertySchema`), implementable by both `ComponentHandler` and `TraitHandler`.
- **`pkg/oam/transform.go`** — `Transformer.HandlerSchemas()` returns `HandlerSchemaSet{Components, Traits}`, split by handler kind to avoid cross-registry name collisions.
- **Proof handlers** — the `configmap` trait and `passthrough` component implement `PropertySchema()` (both demonstrate the escape-hatch open field via `AdditionalProperties`).
- **Tests** — enumeration: providers included and split correctly, non-providers omitted, schema content round-trips.

## Verification (`GOWORK=off`)

- `go build ./...`, `go test ./...` green; gofmt clean; `go mod tidy` noop; **doc-gate OK** (READMEs updated).

## Notes

- Depends on nothing; needed by crane #304 (D7b engine).
- `CapabilityPropertySchema` intentionally not churned in this PR.