### PR TITLE
feat(oam/expose): platform-managed TLS + hostname validation

### DIFF
--- a/pkg/oam/builtin/README.md
+++ b/pkg/oam/builtin/README.md
@@ -7,6 +7,9 @@ handlers (e.g. `CertificateRendering`, `ExposeRendering`, `ExternalSecretRenderi
 `NetworkPolicyRendering`, `ConfigmapRendering`, `VolSyncRendering`) and the
 `DecodeStrict[T]` helper used by handlers to decode capability properties.
 
+`ExposeRendering` additionally carries `certManagerClusterIssuer` (platform-managed TLS on
+the ingress path) and `allowedHostnameWildcard` (hostname constraint for both paths).
+
 These are internal schema types used by [`builtin/components`](components) and
 [`builtin/traits`](traits); they are not a user-facing API. See
 [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin) for the

--- a/pkg/oam/builtin/expose.go
+++ b/pkg/oam/builtin/expose.go
@@ -19,4 +19,15 @@ type ExposeRendering struct {
 	// GatewayNamespace is the namespace of the Gateway resource.
 	// Optional when ControllerType is "gateway"; defaults to "gateway-system".
 	GatewayNamespace string `yaml:"gatewayNamespace,omitempty" json:"gatewayNamespace,omitempty"`
+
+	// CertManagerClusterIssuer, when set, enables platform-managed TLS on the
+	// ingress path: expose emits the cert-manager.io/cluster-issuer annotation and
+	// a synthesized spec.tls[] entry derived from the rule hosts. Empty disables
+	// managed TLS (plain HTTP). Ingress-only.
+	CertManagerClusterIssuer string `yaml:"certManagerClusterIssuer,omitempty" json:"certManagerClusterIssuer,omitempty"`
+
+	// AllowedHostnameWildcard, when set (e.g. "*.apps.example.com"), constrains the
+	// user-supplied hostnames on both the ingress and gateway paths. Empty skips
+	// hostname validation.
+	AllowedHostnameWildcard string `yaml:"allowedHostnameWildcard,omitempty" json:"allowedHostnameWildcard,omitempty"`
 }

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -53,6 +53,13 @@ These require (or optionally use) a `ClusterProfile` capability, so the platform
 not the app — chooses the implementation:
 
 - **expose** → `controllerType` (ingress vs gateway) + gateway/ingress details.
+  On the **ingress** path, expose is platform-managed for TLS: it derives `spec.tls[]`
+  from the rule hosts under a deterministic `<component>-tls` secret and emits the
+  `cert-manager.io/cluster-issuer` annotation from the `certManagerClusterIssuer`
+  capability field (empty ⇒ managed TLS disabled). Users do **not** author TLS on the
+  expose trait (use the low-level `ingress` trait for full TLS control). Both paths
+  validate user hostnames against the `allowedHostnameWildcard` capability field (empty ⇒
+  no validation); a violation is a `ValidationError`.
 - **certificate** → `issuerRef` (cert-manager issuer/cluster-issuer).
 - **external-secret** → `secretStoreRef` (or the inline `provider` shorthand).
 

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -47,6 +47,9 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 		if r.IngressClassName != "" {
 			return nil, errors.New("expose rendering: ingressClassName is only valid when controllerType is \"ingress\"")
 		}
+		if r.CertManagerClusterIssuer != "" {
+			return nil, errors.New("expose rendering: certManagerClusterIssuer is only valid when controllerType is \"ingress\"")
+		}
 		if r.GatewayNamespace == "" {
 			rendering["gatewayNamespace"] = "gateway-system"
 		}
@@ -57,15 +60,41 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 }
 
 // Apply dispatches to IngressHandler or HTTPRouteHandler based on controllerType.
+// It also implements platform-managed TLS (ingress path) and hostname validation
+// (both paths), consuming the certManagerClusterIssuer/allowedHostnameWildcard
+// capability keys so they never leak into the low-level handlers.
 func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *stack.Bundle) error {
 	controllerType, _ := trait.Properties["controllerType"].(string)
 	props := maps.Clone(trait.Properties)
 	delete(props, "controllerType")
-	modified := &oam.Trait{Type: "expose", Properties: props}
+
+	// Consume the platform capability keys; they are handled here, not downstream.
+	issuer, _ := props["certManagerClusterIssuer"].(string)
+	wildcard, _ := props["allowedHostnameWildcard"].(string)
+	delete(props, "certManagerClusterIssuer")
+	delete(props, "allowedHostnameWildcard")
+
 	switch controllerType {
 	case "ingress":
-		return (&IngressHandler{}).Apply(modified, app, bundle)
+		hosts := uniqueStrings(ruleHosts(props))
+		if err := validateHostnames(hosts, wildcard, app.Name); err != nil {
+			return err
+		}
+		// expose is platform-managed: the user does not author TLS.
+		delete(props, "tls")
+		if issuer != "" {
+			if err := setClusterIssuerAnnotation(props, issuer, app.Name); err != nil {
+				return err
+			}
+			if len(hosts) > 0 {
+				props["tls"] = synthesizedIngressTLS(hosts, app.Name)
+			}
+		}
+		return (&IngressHandler{}).Apply(&oam.Trait{Type: "expose", Properties: props}, app, bundle)
 	case "gateway":
+		if err := validateHostnames(hostnameList(props), wildcard, app.Name); err != nil {
+			return err
+		}
 		gatewayName, _ := props["gatewayName"].(string)
 		gatewayNamespace, _ := props["gatewayNamespace"].(string)
 		if gatewayNamespace == "" {
@@ -78,9 +107,71 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 			ref["namespace"] = gatewayNamespace
 		}
 		props["parentRefs"] = []any{ref}
-		modified = &oam.Trait{Type: "expose", Properties: props}
-		return (&HTTPRouteHandler{}).Apply(modified, app, bundle)
+		return (&HTTPRouteHandler{}).Apply(&oam.Trait{Type: "expose", Properties: props}, app, bundle)
 	default:
 		return errors.Errorf("expose trait: unsupported controllerType %q", controllerType)
 	}
+}
+
+// ruleHosts extracts the host of every entry in the ingress-style rules[] property.
+func ruleHosts(props map[string]any) []string {
+	var hosts []string
+	if rawRules, ok := props["rules"].([]any); ok {
+		for _, r := range rawRules {
+			if rm, ok := r.(map[string]any); ok {
+				if host, ok := rm["host"].(string); ok && host != "" {
+					hosts = append(hosts, host)
+				}
+			}
+		}
+	}
+	return hosts
+}
+
+// hostnameList extracts the gateway-style hostnames[] property.
+func hostnameList(props map[string]any) []string {
+	var hosts []string
+	if raw, ok := props["hostnames"].([]any); ok {
+		for _, h := range raw {
+			if s, ok := h.(string); ok && s != "" {
+				hosts = append(hosts, s)
+			}
+		}
+	}
+	return hosts
+}
+
+// setClusterIssuerAnnotation adds the platform cert-manager cluster-issuer
+// annotation. The platform value is authoritative: a conflicting user-supplied
+// value is rejected as a ValidationError.
+func setClusterIssuerAnnotation(props map[string]any, issuer, component string) error {
+	anns, _ := props["annotations"].(map[string]any)
+	if anns == nil {
+		anns = map[string]any{}
+	}
+	if existing, ok := anns[clusterIssuerAnnotation].(string); ok && existing != issuer {
+		return &errors.ValidationError{
+			Field:     "annotations." + clusterIssuerAnnotation,
+			Value:     existing,
+			Component: component,
+			Message: "annotation " + clusterIssuerAnnotation +
+				" is platform-managed by the expose trait and cannot be overridden",
+		}
+	}
+	anns[clusterIssuerAnnotation] = issuer
+	props["annotations"] = anns
+	return nil
+}
+
+// synthesizedIngressTLS builds the single managed TLS entry: all hosts under one
+// deterministic secretName (<component>-tls), for cert-manager's ingress-shim.
+func synthesizedIngressTLS(hosts []string, component string) []any {
+	anyHosts := make([]any, len(hosts))
+	for i, h := range hosts {
+		anyHosts[i] = h
+	}
+	return []any{map[string]any{
+		"hosts":      anyHosts,
+		"secretName": component + "-tls",
+	}}
 }

--- a/pkg/oam/builtin/traits/expose_managed_tls_test.go
+++ b/pkg/oam/builtin/traits/expose_managed_tls_test.go
@@ -1,0 +1,197 @@
+package traits_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	networkingv1 "k8s.io/api/networking/v1"
+
+	pkgerrors "github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// ingressFromBundle generates the first sub-application and returns it as an Ingress.
+func ingressFromBundle(t *testing.T, bundle *stack.Bundle) *networkingv1.Ingress {
+	t.Helper()
+	if len(bundle.Applications) == 0 {
+		t.Fatal("no sub-application in bundle")
+	}
+	objs, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	for _, o := range objs {
+		if ing, ok := (*o).(*networkingv1.Ingress); ok {
+			return ing
+		}
+	}
+	t.Fatal("no Ingress object generated")
+	return nil
+}
+
+func exposeIngressTrait(issuer, wildcard string, hosts ...string) *oam.Trait {
+	rules := make([]any, 0, len(hosts))
+	for _, h := range hosts {
+		rules = append(rules, map[string]any{
+			"host":  h,
+			"paths": []any{map[string]any{"path": "/"}},
+		})
+	}
+	props := map[string]any{
+		"controllerType":   "ingress",
+		"ingressClassName": "nginx",
+		"rules":            rules,
+	}
+	if issuer != "" {
+		props["certManagerClusterIssuer"] = issuer
+	}
+	if wildcard != "" {
+		props["allowedHostnameWildcard"] = wildcard
+	}
+	return &oam.Trait{Type: "expose", Properties: props}
+}
+
+func TestExposeHandler_Apply_IngressManagedTLS(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	// Two rules, one duplicate host — synthesized TLS must dedupe.
+	trait := exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com", "a.apps.example.com", "b.apps.example.com")
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+
+	if got := ing.Annotations["cert-manager.io/cluster-issuer"]; got != "letsencrypt-prod" {
+		t.Errorf("cluster-issuer annotation = %q, want letsencrypt-prod", got)
+	}
+	if len(ing.Spec.TLS) != 1 {
+		t.Fatalf("expected 1 TLS entry, got %d", len(ing.Spec.TLS))
+	}
+	tls := ing.Spec.TLS[0]
+	if tls.SecretName != "my-app-tls" {
+		t.Errorf("secretName = %q, want my-app-tls", tls.SecretName)
+	}
+	if len(tls.Hosts) != 2 || tls.Hosts[0] != "a.apps.example.com" || tls.Hosts[1] != "b.apps.example.com" {
+		t.Errorf("TLS hosts = %v, want [a.apps.example.com b.apps.example.com]", tls.Hosts)
+	}
+}
+
+func TestExposeHandler_Apply_IngressNoIssuer_NoTLS(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	if err := h.Apply(exposeIngressTrait("", "", "a.apps.example.com"), app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.TLS) != 0 {
+		t.Errorf("expected no TLS, got %v", ing.Spec.TLS)
+	}
+	if _, ok := ing.Annotations["cert-manager.io/cluster-issuer"]; ok {
+		t.Error("expected no cluster-issuer annotation")
+	}
+}
+
+func TestExposeHandler_Apply_IngressUserTLSIgnored(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com")
+	// User attempts to author TLS directly — expose must ignore it.
+	trait.Properties["tls"] = []any{map[string]any{
+		"hosts": []any{"evil.example.com"}, "secretName": "user-secret",
+	}}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.TLS) != 1 || ing.Spec.TLS[0].SecretName != "my-app-tls" {
+		t.Errorf("user TLS not overridden: %+v", ing.Spec.TLS)
+	}
+}
+
+func TestExposeHandler_Apply_IngressHostnameRejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("", "*.apps.example.com", "not-allowed.example.com")
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError, got %v", err)
+	}
+}
+
+func TestExposeHandler_Apply_IngressHostnameAllowed(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("", "*.apps.example.com", "foo.apps.example.com")
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+}
+
+func TestExposeHandler_Apply_ClusterIssuerCollision(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com")
+	trait.Properties["annotations"] = map[string]any{
+		"cert-manager.io/cluster-issuer": "self-signed", // conflicts with platform
+	}
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError for annotation collision, got %v", err)
+	}
+}
+
+func TestExposeHandler_Apply_GatewayHostnameRejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{Type: "expose", Properties: map[string]any{
+		"controllerType":          "gateway",
+		"gatewayName":             "public",
+		"allowedHostnameWildcard": "*.apps.example.com",
+		"hostnames":               []any{"bad.example.com"},
+		"rules":                   []any{map[string]any{}},
+	}}
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError for gateway hostname, got %v", err)
+	}
+}
+
+func TestExposeHandler_Apply_GatewayNoTLS(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{Type: "expose", Properties: map[string]any{
+		"controllerType":          "gateway",
+		"gatewayName":             "public",
+		"allowedHostnameWildcard": "*.apps.example.com",
+		"hostnames":               []any{"ok.apps.example.com"},
+		"rules": []any{map[string]any{
+			"matches": []any{map[string]any{"path": map[string]any{"type": "PathPrefix", "value": "/"}}},
+		}},
+	}}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	// Gateway path emits an HTTPRoute, never an Ingress.
+	objs, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	for _, o := range objs {
+		if _, ok := (*o).(*networkingv1.Ingress); ok {
+			t.Error("gateway path must not emit an Ingress")
+		}
+	}
+}

--- a/pkg/oam/builtin/traits/hostname.go
+++ b/pkg/oam/builtin/traits/hostname.go
@@ -1,0 +1,66 @@
+package traits
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+// clusterIssuerAnnotation is the cert-manager ingress-shim annotation that names
+// the ClusterIssuer used to provision the ingress TLS certificate.
+const clusterIssuerAnnotation = "cert-manager.io/cluster-issuer"
+
+// matchHostnameWildcard reports whether host is permitted by pattern. An empty
+// pattern permits everything. A pattern without a leading "*." must match host
+// exactly. A "*.suffix" pattern matches exactly one DNS label in place of the
+// star: "*.apps.example.com" matches "foo.apps.example.com" but not
+// "a.b.apps.example.com" or "apps.example.com".
+func matchHostnameWildcard(pattern, host string) bool {
+	if pattern == "" {
+		return true
+	}
+	if !strings.HasPrefix(pattern, "*.") {
+		return host == pattern
+	}
+	suffix := pattern[1:] // ".apps.example.com"
+	if !strings.HasSuffix(host, suffix) {
+		return false
+	}
+	label := host[:len(host)-len(suffix)]
+	return label != "" && !strings.Contains(label, ".")
+}
+
+// validateHostnames returns a *errors.ValidationError for the first host not
+// permitted by wildcard. An empty wildcard skips validation.
+func validateHostnames(hosts []string, wildcard, component string) error {
+	if wildcard == "" {
+		return nil
+	}
+	for _, h := range hosts {
+		if !matchHostnameWildcard(wildcard, h) {
+			return &errors.ValidationError{
+				Field:     "hostname",
+				Value:     h,
+				Component: component,
+				Message: fmt.Sprintf("hostname %q is not permitted by allowedHostnameWildcard %q",
+					h, wildcard),
+			}
+		}
+	}
+	return nil
+}
+
+// uniqueStrings returns s with duplicates removed, preserving first-seen order.
+func uniqueStrings(s []string) []string {
+	seen := make(map[string]struct{}, len(s))
+	out := make([]string, 0, len(s))
+	for _, v := range s {
+		if _, ok := seen[v]; ok {
+			continue
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	return out
+}

--- a/pkg/oam/builtin/traits/hostname_internal_test.go
+++ b/pkg/oam/builtin/traits/hostname_internal_test.go
@@ -1,0 +1,43 @@
+package traits
+
+import (
+	stderrors "errors"
+	"testing"
+
+	pkgerrors "github.com/go-kure/launcher/pkg/errors"
+)
+
+func TestMatchHostnameWildcard(t *testing.T) {
+	cases := []struct {
+		pattern, host string
+		want          bool
+	}{
+		{"", "anything.example.com", true},                    // empty pattern permits all
+		{"*.apps.example.com", "foo.apps.example.com", true},  // one label
+		{"*.apps.example.com", "a.b.apps.example.com", false}, // two labels
+		{"*.apps.example.com", "apps.example.com", false},     // no label
+		{"*.apps.example.com", "foo.apps.example.org", false}, // wrong suffix
+		{"*.apps.example.com", "foo.apps.example.com.evil.com", false},
+		{"exact.example.com", "exact.example.com", true},  // exact match
+		{"exact.example.com", "other.example.com", false}, // exact mismatch
+	}
+	for _, c := range cases {
+		if got := matchHostnameWildcard(c.pattern, c.host); got != c.want {
+			t.Errorf("matchHostnameWildcard(%q, %q) = %v, want %v", c.pattern, c.host, got, c.want)
+		}
+	}
+}
+
+func TestValidateHostnames(t *testing.T) {
+	if err := validateHostnames([]string{"anything.com"}, "", "c"); err != nil {
+		t.Errorf("empty wildcard should skip validation, got %v", err)
+	}
+	if err := validateHostnames([]string{"a.apps.example.com"}, "*.apps.example.com", "c"); err != nil {
+		t.Errorf("valid host rejected: %v", err)
+	}
+	err := validateHostnames([]string{"a.apps.example.com", "bad.other.com"}, "*.apps.example.com", "c")
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError, got %v", err)
+	}
+}

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -242,6 +242,18 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 		config.Rules = append(config.Rules, rule)
 	}
 
+	// Optional platform constraint (from capability rendering when used directly;
+	// the expose trait validates and strips this before delegating here).
+	if wildcard, ok := props["allowedHostnameWildcard"].(string); ok && wildcard != "" {
+		hosts := make([]string, 0, len(config.Rules))
+		for _, r := range config.Rules {
+			hosts = append(hosts, r.Host)
+		}
+		if err := validateHostnames(hosts, wildcard, app.Name); err != nil {
+			return nil, err
+		}
+	}
+
 	if rawTLS, ok := props["tls"].([]any); ok {
 		for i, rawEntry := range rawTLS {
 			entry, ok := rawEntry.(map[string]any)


### PR DESCRIPTION
## Summary

crane#235 D5 (launcher side). The `expose` trait now owns TLS and hostname policy on the ingress path, so apps don't hand-author them.

Closes #161.

## Behavior

- **`ExposeRendering`** gains `certManagerClusterIssuer` and `allowedHostnameWildcard`.
- **Ingress path** — expose derives `spec.tls[]` from the rule hosts as a **single** entry under a deterministic `<component>-tls` secret, and emits the `cert-manager.io/cluster-issuer` annotation from `certManagerClusterIssuer`. **Empty issuer ⇒ managed TLS disabled** (plain HTTP). User-authored TLS on the expose trait is ignored; a *conflicting* user `cert-manager.io/cluster-issuer` annotation is rejected. The low-level `ingress` trait keeps full user TLS control (unchanged).
- **Hostname validation (both paths)** — user hostnames (`rules[].host` for ingress, `hostnames[]` for gateway) are validated against `allowedHostnameWildcard` (empty ⇒ skip). Violations return `*pkg/errors.ValidationError` (propagates via `errors.As`, so crane classifies as a compile error). `*.suffix` matches exactly one DNS label.
- **Property flow** — expose consumes and strips `certManagerClusterIssuer`/`allowedHostnameWildcard` before delegating, so they never leak into the low-level handlers. The low-level `IngressHandler` independently honors `allowedHostnameWildcard` when present in its own props (standalone use).

## Tests

`matchHostnameWildcard`/`validateHostnames` unit tests; ingress managed-TLS synthesis (dedupe + `<component>-tls`), no-issuer ⇒ no TLS, user-TLS ignored, cluster-issuer collision, ingress + gateway hostname pass/fail, gateway emits no Ingress.

## Verification (`GOWORK=off`)

- `go build`/`go vet`/`go test ./...` green; gofmt clean; tidy noop; **doc-gate OK**.