### PR TITLE
feat(oam/httproute): synthesise parentRefs from capability

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -18,7 +18,7 @@ constrained schema for their properties so crane can validate them before invoca
 | `type` | Produces | Key properties |
 |--------|----------|----------------|
 | `ingress` | Ingress | `rules[]` (`host`, `paths[]`), `ingressClassName`, `tls[]`, `annotations` |
-| `httproute` | Gateway API HTTPRoute | `parentRefs[]`, `rules[]` (`matches`/`backendRefs`/`filters`/`timeouts`), `hostnames[]` |
+| `httproute` | Gateway API HTTPRoute | `rules[]` (`matches`/`backendRefs`/`filters`/`timeouts`), `hostnames[]`; `parentRefs[]` optional — synthesized from the `gatewayName`/`gatewayNamespace` capability when omitted |
 | `expose` | Ingress **or** HTTPRoute | `rules[]`, `hostnames[]` — controller chosen by ClusterProfile (`controllerType`) |
 | `networkpolicy` | NetworkPolicy | `ingress[]`/`egress[]` (`from`/`to`, `ports`) |
 | `cilium-networkpolicy` | CiliumNetworkPolicy | `name`, `endpointSelector`, `ingress`/`egress` (raw Cilium rules) |

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -97,16 +97,9 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 		}
 		gatewayName, _ := props["gatewayName"].(string)
 		gatewayNamespace, _ := props["gatewayNamespace"].(string)
-		if gatewayNamespace == "" {
-			gatewayNamespace = "gateway-system"
-		}
 		delete(props, "gatewayName")
 		delete(props, "gatewayNamespace")
-		ref := map[string]any{"name": gatewayName}
-		if gatewayNamespace != "" {
-			ref["namespace"] = gatewayNamespace
-		}
-		props["parentRefs"] = []any{ref}
+		props["parentRefs"] = []any{synthesizeParentRef(gatewayName, gatewayNamespace)}
 		return (&HTTPRouteHandler{}).Apply(&oam.Trait{Type: "expose", Properties: props}, app, bundle)
 	default:
 		return errors.Errorf("expose trait: unsupported controllerType %q", controllerType)

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -47,6 +47,16 @@ func (h *HTTPRouteHandler) Apply(trait *oam.Trait, app *stack.Application, bundl
 	return nil
 }
 
+// synthesizeParentRef builds a Gateway API parentRef map from a gateway name and
+// (optional) namespace, applying the "gateway-system" default. Shared by the
+// httproute trait's capability synthesis and the expose trait's gateway path.
+func synthesizeParentRef(name, namespace string) map[string]any {
+	if namespace == "" {
+		namespace = "gateway-system"
+	}
+	return map[string]any{"name": name, "namespace": namespace}
+}
+
 func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Application) (*HTTPRouteConfig, error) {
 	defaultPort := resolveDefaultPort(app)
 	config := &HTTPRouteConfig{
@@ -89,10 +99,18 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 		config.Scope = scope
 	}
 
-	// Required: parentRefs
+	// parentRefs: user-authored take precedence; otherwise synthesize a single ref
+	// from the gatewayName/gatewayNamespace capability fields (crane#235 D4). This
+	// is optional-capability: a plain httproute with an explicit parentRefs still
+	// works with no capability.
 	rawParentRefs, ok := props["parentRefs"].([]any)
 	if !ok || len(rawParentRefs) == 0 {
-		return nil, errors.New("required property 'parentRefs' missing or empty")
+		gatewayName, _ := props["gatewayName"].(string)
+		if gatewayName == "" {
+			return nil, errors.New("required property 'parentRefs' missing or empty (and no gatewayName capability to synthesize from)")
+		}
+		gatewayNamespace, _ := props["gatewayNamespace"].(string)
+		rawParentRefs = []any{synthesizeParentRef(gatewayName, gatewayNamespace)}
 	}
 	for i, rawRef := range rawParentRefs {
 		refMap, ok := rawRef.(map[string]any)

--- a/pkg/oam/builtin/traits/httproute_parentrefs_test.go
+++ b/pkg/oam/builtin/traits/httproute_parentrefs_test.go
@@ -1,0 +1,106 @@
+package traits_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+func httprouteFromBundle(t *testing.T, bundle *stack.Bundle) *gatewayv1.HTTPRoute {
+	t.Helper()
+	if len(bundle.Applications) == 0 {
+		t.Fatal("no sub-application in bundle")
+	}
+	objs, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	for _, o := range objs {
+		if r, ok := (*o).(*gatewayv1.HTTPRoute); ok {
+			return r
+		}
+	}
+	t.Fatal("no HTTPRoute object generated")
+	return nil
+}
+
+func httprouteTrait(extra map[string]any) *oam.Trait {
+	props := map[string]any{
+		"rules": []any{map[string]any{
+			"matches": []any{map[string]any{
+				"path": map[string]any{"type": "PathPrefix", "value": "/"},
+			}},
+		}},
+	}
+	for k, v := range extra {
+		props[k] = v
+	}
+	return &oam.Trait{Type: "httproute", Properties: props}
+}
+
+func TestHTTPRoute_SynthParentRefFromGateway(t *testing.T) {
+	h := &traits.HTTPRouteHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	if err := h.Apply(httprouteTrait(map[string]any{"gatewayName": "public"}), app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	route := httprouteFromBundle(t, bundle)
+	if len(route.Spec.ParentRefs) != 1 {
+		t.Fatalf("expected 1 parentRef, got %d", len(route.Spec.ParentRefs))
+	}
+	pr := route.Spec.ParentRefs[0]
+	if string(pr.Name) != "public" {
+		t.Errorf("parentRef name = %q, want public", pr.Name)
+	}
+	if pr.Namespace == nil || string(*pr.Namespace) != "gateway-system" {
+		t.Errorf("parentRef namespace = %v, want gateway-system", pr.Namespace)
+	}
+}
+
+func TestHTTPRoute_SynthParentRefRespectsNamespace(t *testing.T) {
+	h := &traits.HTTPRouteHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	err := h.Apply(httprouteTrait(map[string]any{
+		"gatewayName":      "public",
+		"gatewayNamespace": "infra",
+	}), app, bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	route := httprouteFromBundle(t, bundle)
+	if pr := route.Spec.ParentRefs[0]; pr.Namespace == nil || string(*pr.Namespace) != "infra" {
+		t.Errorf("parentRef namespace = %v, want infra", pr.Namespace)
+	}
+}
+
+func TestHTTPRoute_UserParentRefsWin(t *testing.T) {
+	h := &traits.HTTPRouteHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	err := h.Apply(httprouteTrait(map[string]any{
+		"gatewayName": "public", // present, but user parentRefs take precedence
+		"parentRefs":  []any{map[string]any{"name": "custom", "namespace": "other"}},
+	}), app, bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	route := httprouteFromBundle(t, bundle)
+	if string(route.Spec.ParentRefs[0].Name) != "custom" {
+		t.Errorf("user parentRef should win, got %q", route.Spec.ParentRefs[0].Name)
+	}
+}
+
+func TestHTTPRoute_NoParentRefsNoGateway(t *testing.T) {
+	h := &traits.HTTPRouteHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	if err := h.Apply(httprouteTrait(map[string]any{}), app, bundle); err == nil {
+		t.Fatal("expected error when neither parentRefs nor gatewayName is present")
+	}
+}

--- a/pkg/oam/builtin/traits/httproute_synth_internal_test.go
+++ b/pkg/oam/builtin/traits/httproute_synth_internal_test.go
@@ -1,0 +1,14 @@
+package traits
+
+import "testing"
+
+func TestSynthesizeParentRef(t *testing.T) {
+	got := synthesizeParentRef("gw", "")
+	if got["name"] != "gw" || got["namespace"] != "gateway-system" {
+		t.Errorf("synthesizeParentRef(gw, \"\") = %v, want name=gw namespace=gateway-system", got)
+	}
+	got = synthesizeParentRef("gw", "infra")
+	if got["namespace"] != "infra" {
+		t.Errorf("explicit namespace not respected: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary

crane#235 D4 (launcher side). The `httproute` trait no longer requires user-authored `parentRefs`: when omitted, a single `parentRef` is synthesized from the `gatewayName`/`gatewayNamespace` capability fields (namespace defaults to `gateway-system`).

Closes #162.

> **Stacked on #175 (#161).** Base is `feat/expose-managed-tls` because this PR refactors the shared gateway helper that #161 introduced in `expose.go`. GitHub will retarget this PR to `main` once #175 merges.

## Behavior

- `parentRefs` is now **optional**. User-authored `parentRefs` take precedence; a plain `httproute` with explicit `parentRefs` still works with **no** capability.
- **Optional-capability** (per review): `HTTPRouteHandler` is *not* marked `CapabilityRequired` — the transformer would otherwise reject a missing-capability trait before renderings merge, breaking explicit-`parentRefs` use. The handler reads `gatewayName`/`gatewayNamespace` from merged renderings and only synthesizes when `parentRefs` is absent.
- Factored the gateway parentRef construction into a shared `synthesizeParentRef` helper; the `expose` trait's gateway path now uses it too (one pattern for both).

## Tests

Synthesis from `gatewayName` (+ default and explicit namespace), user `parentRefs` win, neither present ⇒ error; `synthesizeParentRef` unit test.

## Verification (`GOWORK=off`)

- `go build`/`go test ./...` green; gofmt clean; **doc-gate OK**.