### PR TITLE
ci(probe): cache-scope probe (Step 0A, temporary)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,54 @@ jobs:
             - '.github/workflows/ci.yml'
 
   # =============================================================================
+  # TEMPORARY — cache-scope probe (Step 0A). REVERT after reading results.
+  # Question: can a merge_group (queue) run restore a cache saved by the
+  # pull_request run? Uses a fixed key so every event references the same string.
+  # Expected: PR run saves (scoped to refs/pull/N/merge); merge_group MISSES
+  # (queue ref can only read its own ref + base + default branch main, never the
+  # PR ref). Not a required check; not in the build gate — does not block merges.
+  # =============================================================================
+
+  cache-scope-probe:
+    name: cache-scope-probe
+    runs-on: autops-kube-kure
+    timeout-minutes: 3
+    steps:
+    - name: Prepare probe payload dir
+      run: mkdir -p /tmp/cache-probe
+
+    - name: Restore probe cache
+      id: probe
+      uses: actions/cache/restore@v6
+      with:
+        path: /tmp/cache-probe
+        key: cache-scope-probe-v1
+
+    - name: Report probe result
+      run: |
+        echo "event=${{ github.event_name }}"
+        echo "ref=${{ github.ref }}"
+        echo "cache-hit=${{ steps.probe.outputs.cache-hit }}"
+        echo "matched-key=${{ steps.probe.outputs.cache-matched-key }}"
+        if [ -f /tmp/cache-probe/saved-by.txt ]; then
+          echo "RESTORED payload — originally saved by:"
+          cat /tmp/cache-probe/saved-by.txt
+        else
+          echo "NO payload restored (cache miss)"
+        fi
+
+    - name: Write payload (only on miss)
+      if: steps.probe.outputs.cache-hit != 'true'
+      run: echo "event=${{ github.event_name }} ref=${{ github.ref }} sha=${{ github.sha }} run=${{ github.run_id }}" > /tmp/cache-probe/saved-by.txt
+
+    - name: Save probe cache (only on miss)
+      if: success() && steps.probe.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: /tmp/cache-probe
+        key: cache-scope-probe-v1
+
+  # =============================================================================
   # Stage 1: Fast Validation
   # =============================================================================
 


### PR DESCRIPTION
## What

Temporary throwaway probe to answer one architectural question before investing in a Go build-cache re-key:

**Can a `merge_group` (merge-queue) run restore a cache that the `pull_request` run saved?**

Adds a non-required `cache-scope-probe` job that restores/saves a fixed cache key (`cache-scope-probe-v1`) on every event and logs `cache-hit` + which event/ref originally saved the entry.

## Expected result

GitHub caches are ref-scoped. A `pull_request` cache lives on `refs/pull/N/merge`; a `merge_group` run can restore only its own ref, its base, and the default branch (`main`) — never the PR ref. So:

- **PR run** → cache miss → saves `cache-scope-probe-v1` (scoped to the PR merge ref).
- **merge_group run** (after this PR enters the queue) → **expected MISS** — proving the queue run cannot reuse the PR run's cache.

If the merge_group run instead reports `cache-hit=true`, PR→queue cache reuse unexpectedly works and the optimization can be stronger.

## How to read it

1. This is not a required check and is excluded from the `build` gate, so it does not block the queue.
2. Review + **Merge when ready** to send it through the queue.
3. Open the `cache-scope-probe` job in both the PR run and the merge_group run; compare `cache-hit`.
4. **Revert** this PR afterward (throwaway).