### PR TITLE
perf(ci): source-aware Go build cache, split by job purpose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,24 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
+    # Source-aware Go build cache (distinct job prefix so lint and test don't overwrite
+    # each other's entry). See the test job for the design rationale.
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-validate-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
+
     - name: Install dependencies
       run: make deps
 
@@ -151,6 +169,13 @@ jobs:
           make lint
         fi
 
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
+
   # =============================================================================
   # Stage 2: Tests and Security (parallel with lint)
   # =============================================================================
@@ -192,6 +217,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
+    # Source-aware Go build cache. Warmed on push-to-main (main-scoped, restorable by both
+    # PR and merge_group runs); restore-keys fall back deps-first then job-prefix. Split
+    # restore/save so we can log exact vs fallback via cache-matched-key.
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-test-race-cover-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
+
     - name: Install dependencies
       run: make deps
 
@@ -200,6 +244,15 @@ jobs:
         set -euo pipefail
         mkdir -p coverage
         go test -v -race -coverprofile=coverage/coverage.out -covermode=atomic -timeout 5m ./... 2>&1 | tee /tmp/gotest.log
+
+    # Save only on non-exact restore (fallback/miss) and only if the run succeeded, so a
+    # broken build never publishes a cache. Refreshes the per-tree entry for main-warming.
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Upload test log
       uses: actions/upload-artifact@v7
@@ -251,6 +304,32 @@ jobs:
       with:
         go-version: ${{ steps.go-version.outputs.version }}
         cache: false
+
+    - name: Cache Go modules
+      uses: actions/cache@v6
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-gomod-
+
+    # Source-aware Go build cache. govulncheck's symbol scan compiles the whole program,
+    # so a warm build cache cuts this job materially (it had no caching before).
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-security-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
 
     - name: Install scan tools
       run: |
@@ -324,6 +403,13 @@ jobs:
           exit 1
         fi
         echo "No unallowed reachable vulnerabilities (allowed: ${allowed_hit:-none})."
+
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Check for outdated dependencies
       run: make outdated
@@ -453,11 +539,35 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
+    # Source-aware Go build cache (build prefix, shared with cross-platform per-arch).
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
+
     - name: Install dependencies
       run: make deps
 
     - name: Build kurel
       run: make build-kurel
+
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v7
@@ -706,6 +816,25 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gomod-
 
+    # Source-aware Go build cache, scoped per target arch (cross-compiled arm64 artifacts
+    # differ from amd64, so matrix.arch is part of the key — runner.arch is the host arch
+    # and is identical across legs).
+    - name: Restore Go build cache
+      id: gocache
+      uses: actions/cache/restore@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-${{ matrix.os }}-${{ matrix.arch }}-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-${{ hashFiles('**/*.go', 'go.mod', 'go.sum', 'Makefile', '**/testdata/**') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-${{ matrix.os }}-${{ matrix.arch }}-deps-${{ hashFiles('go.mod', 'go.sum') }}-src-
+          ${{ runner.os }}-${{ runner.arch }}-go-${{ steps.go-version.outputs.version }}-gocache-build-${{ matrix.os }}-${{ matrix.arch }}-
+
+    - name: Log Go build cache restore
+      run: |
+        echo "cache-hit=${{ steps.gocache.outputs.cache-hit }}"
+        echo "primary-key=${{ steps.gocache.outputs.cache-primary-key }}"
+        echo "matched-key=${{ steps.gocache.outputs.cache-matched-key }}"
+
     - name: Install dependencies
       run: make deps
 
@@ -727,6 +856,13 @@ jobs:
         mkdir -p bin
         go build -ldflags="-s -w -X main.Version=${VERSION} -X main.GitCommit=${GIT_COMMIT} -X main.BuildTime=${BUILD_TIME}" \
           -o bin/kurel-${{ matrix.os }}-${{ matrix.arch }}${EXT} ./cmd/kurel
+
+    - name: Save Go build cache
+      if: success() && steps.gocache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ~/.cache/go-build
+        key: ${{ steps.gocache.outputs.cache-primary-key }}
 
     - name: Upload cross-platform artifacts
       uses: actions/upload-artifact@v7

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -345,17 +345,60 @@ GO_VER=$(grep '^go = ' mise.toml | sed 's/go = "\(.*\)"/\1/')
 
 ### Caching
 
-Module and build caches use explicit `actions/cache@v5` steps with `cache: false` on `setup-go`:
+`setup-go` runs with `cache: false`; caching is done with explicit `actions/cache` steps.
+The runners are ephemeral ARC pods, so nothing on disk survives between jobs — everything
+useful must round-trip through the cache server.
+
+**Module cache** (dependency-only, one combined step per Go job):
 
 ```yaml
 - name: Cache Go modules
-  uses: actions/cache@v5
+  uses: actions/cache@v6
   with:
     path: ~/go/pkg/mod
     key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
     restore-keys: |
       ${{ runner.os }}-gomod-
 ```
+
+**Go build cache** (`~/.cache/go-build`) uses split `actions/cache/restore` + `actions/cache/save`
+so the log can show exact vs fallback restore (`cache-matched-key`). The key is **source-aware**
+and **split by job purpose** so `validate` (non-race) and `test` (race+coverage) never overwrite
+each other's entry:
+
+```yaml
+- name: Restore Go build cache
+  id: gocache
+  uses: actions/cache/restore@v6
+  with:
+    path: ~/.cache/go-build
+    key: ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-deps-<go.sum hash>-src-<source hash>
+    restore-keys: |
+      ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-deps-<go.sum hash>-src-
+      ${{ runner.os }}-${{ runner.arch }}-go-<GOVER>-gocache-<purpose>-
+# ... compile / test ...
+- name: Save Go build cache
+  if: success() && steps.gocache.outputs.cache-hit != 'true'
+  uses: actions/cache/save@v6
+  with:
+    path: ~/.cache/go-build
+    key: ${{ steps.gocache.outputs.cache-primary-key }}
+```
+
+Purpose prefixes: `gocache-validate-`, `gocache-test-race-cover-`, `gocache-security-`,
+`gocache-build-` (the `cross-platform` job adds `<os>-<arch>` because cross-compiled artifacts
+differ per target). The source hash covers `**/*.go`, `go.mod`, `go.sum`, `Makefile`, and
+`**/testdata/**`. The save runs only on a non-exact (fallback/miss) restore and only when the
+run succeeded, so a broken build never publishes a cache.
+
+**Cross-ref scoping caveat.** GitHub caches are ref-scoped: a `pull_request` cache lives on
+`refs/pull/N/merge` and is **not** visible to the `merge_group` (merge-queue) run — verified
+empirically. The only scope both PR and queue runs can read is the default branch (`main`).
+So these caches are warmed by push-to-main runs; a code-changing PR and its queue run restore
+main's cache via **restore-key fallback** (not an exact hit) and Go reuses unchanged package
+entries internally. This lowers the absolute cost of both runs but does **not** deduplicate the
+PR↔queue build — that duplication is inherent to the merge queue and cannot be removed with
+GitHub-scoped caches.
 
 Cache and artifact traffic routes through an in-cluster cache server. Setting
 `ACTIONS_RESULTS_URL` in the workflow `env:` block ensures upload/download-artifact and


### PR DESCRIPTION
## What

Repairs and extends Go build caching across the CI workflow so PR and merge-queue runs
recompile less. launcher had **no** `~/.cache/go-build` cache in any job — every job
cold-compiled dependencies + race-instrumented code from scratch.

Changes to `.github/workflows/ci.yml` (5 Go-compiling jobs: `test`, `validate`, `security`,
`build-binaries`, `cross-platform`):

- **Add `~/.cache/go-build` caching** to all five jobs.
- **Source-aware keys** (were dependency-only via `go.sum`, which froze the cache at an old
  snapshot and never refreshed as source changed) — key now includes a source hash over
  `**/*.go, go.mod, go.sum, Makefile, **/testdata/**`.
- **Split by job purpose** (`gocache-validate-` / `-test-race-cover-` / `-security-` /
  `-build-`; `cross-platform` adds `-<os>-<arch>`) so lint (non-race) and test (race+coverage)
  no longer overwrite each other's entry.
- Split `actions/cache/restore` + `actions/cache/save` with matched-key logging; save guarded
  by `success() && cache-hit != 'true'` so a broken/cancelled run never publishes a cache.
- Module cache (`~/go/pkg/mod`) stays `go.sum`-keyed; added to `security` (which had none).

Docs: `docs/github-workflows.md` Caching section updated in the same commit.

## Scope / expectations (important)

Verified via a throwaway probe: a `merge_group` run **cannot** restore a `pull_request` run's
cache (GitHub caches are ref-scoped; the queue ref can't read `refs/pull/N/merge`). So these
caches are warmed by **push-to-main** and restored by PR + queue via **restore-key fallback**.
This lowers both runs' absolute cost; it does **not** dedupe the PR↔queue build (inherent to
the merge queue).

**This PR's own cycle is cold** — no main-warmed cache exists yet under the new keys, so its PR
and queue runs will MISS and save. It validates *mechanics* (caches save under distinct
prefixes, logs show primary/matched keys, guards work, no regression), not speed. The speed
benefit appears on the **next** PR after this merges and the push-to-main run warms main.

kure gets the same pattern in a separate MR only after this produces real numbers.