### PR TITLE
test(ci): R3 warm-cache probe (throwaway — do not merge)

### DIFF
--- a/cmd/kurel/main.go
+++ b/cmd/kurel/main.go
@@ -1,5 +1,7 @@
 package main
 
+// R3 warm-cache probe: trivial one-package change to measure fallback restore. Revert.
+
 import (
 	"github.com/go-kure/launcher/pkg/cmd/kurel"
 )


### PR DESCRIPTION
Throwaway measurement PR for the source-aware build-cache work (#179). A trivial one-package change; its **PR run** should fallback-restore main's warm build cache and show `(cached)` for unchanged packages + lower lint/test durations. **Do not merge** — will be closed after reading the run logs.