### PR TITLE
docs: refresh github-workflows.md Last Updated date

### DIFF
--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -2,7 +2,7 @@
 
 This document provides an overview of all GitHub Actions workflows used in the launcher project.
 
-**Last Updated:** 2026-06-02
+**Last Updated:** 2026-07-02
 
 ---
 


### PR DESCRIPTION
Small real docs fix: the Caching section was updated 2026-07-02 (source-aware build cache, #179); refresh the stale header date to match.

Also serves as the R3b queue-side cache measurement — on merge_group the go jobs run against the warmed main cache, closing the last measurement gap from #179.