### PR TITLE
fix(oam): don't mark capability-injected fields as user-required in schemas

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -16,6 +16,13 @@ handler reads from merged properties (e.g. `networkPolicy`, `allowedHostnameWild
 (`additionalProperties`) rather than modeled field-by-field; `prune-protection` accepts no
 properties and so declares an empty schema.
 
+Capability-injected fields are **not** marked `Required` in a handler's schema, because
+they are supplied by capability rendering (validated in `ValidateAndApplyDefaults`), not by
+the OAM author — e.g. `expose.controllerType` and the parent `certificate.issuerRef` are
+optional in the user-facing schema (though `issuerRef.name` stays required when `issuerRef`
+is present). Marking a capability-injected field user-required would make a consumer's schema
+preflight reject every valid use of the trait.
+
 ## Trait catalog
 
 ### Networking

--- a/pkg/oam/builtin/traits/capability_schema_test.go
+++ b/pkg/oam/builtin/traits/capability_schema_test.go
@@ -1,0 +1,33 @@
+package traits
+
+import "testing"
+
+// Capability-injected fields must NOT be marked user-required in a handler's
+// PropertySchema: they are supplied by capability rendering (CapabilityRequired),
+// not by the OAM author, and are validated in ValidateAndApplyDefaults. Marking
+// them required makes a consumer's schema preflight reject every valid use of the
+// trait (regression guard for the expose.controllerType / certificate.issuerRef
+// bug shipped in v0.1.0-alpha.9).
+func TestCapabilityInjectedFieldsNotUserRequired(t *testing.T) {
+	exposeSchema := (&ExposeHandler{}).PropertySchema()
+	if exposeSchema["controllerType"].Required {
+		t.Error("expose: controllerType is capability-injected and must not be user-required")
+	}
+
+	certSchema := (&CertificateHandler{}).PropertySchema()
+	issuerRef := certSchema["issuerRef"]
+	if issuerRef.Required {
+		t.Error("certificate: issuerRef is capability-injected and must not be user-required")
+	}
+	// If a user does supply issuerRef, its name stays required so `issuerRef: {}`
+	// fails in preflight rather than later in parseProperties.
+	if !issuerRef.Properties["name"].Required {
+		t.Error("certificate: issuerRef.name must remain required when issuerRef is supplied")
+	}
+	// Genuinely user-facing fields stay required.
+	for _, k := range []string{"secretName", "dnsNames"} {
+		if !certSchema[k].Required {
+			t.Errorf("certificate: %s is user-facing and must stay required", k)
+		}
+	}
+}

--- a/pkg/oam/builtin/traits/certificate.go
+++ b/pkg/oam/builtin/traits/certificate.go
@@ -48,9 +48,12 @@ func (h *CertificateHandler) ValidateAndApplyDefaults(rendering map[string]any) 
 func (h *CertificateHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"secretName": {Type: oam.PropertyTypeString, Required: true},
+		// issuerRef is capability-injected (CapabilityRequired; validated in
+		// ValidateAndApplyDefaults), so the parent is NOT user-required. If a user does
+		// supply issuerRef, its name is still required so `issuerRef: {}` fails in schema
+		// preflight rather than later in parseProperties.
 		"issuerRef": {
-			Type:     oam.PropertyTypeObject,
-			Required: true,
+			Type: oam.PropertyTypeObject,
 			Properties: map[string]oam.PropertySchema{
 				"name": {Type: oam.PropertyTypeString, Required: true},
 				"kind": {Type: oam.PropertyTypeString, Default: "ClusterIssuer"},

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -66,7 +66,10 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 // by capability rendering.
 func (h *ExposeHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"controllerType":           {Type: oam.PropertyTypeString, Required: true, Enum: []any{"ingress", "gateway"}},
+		// controllerType is capability-injected, not user-set (see doc above), so it is
+		// NOT user-required here; it is validated in ValidateAndApplyDefaults. Kept in the
+		// schema as an optional enum so a value, if present, is type/enum-checked.
+		"controllerType":           {Type: oam.PropertyTypeString, Enum: []any{"ingress", "gateway"}},
 		"certManagerClusterIssuer": {Type: oam.PropertyTypeString},
 		"allowedHostnameWildcard":  {Type: oam.PropertyTypeString},
 		"gatewayName":              {Type: oam.PropertyTypeString},


### PR DESCRIPTION
## Problem

`expose.controllerType` and `certificate.issuerRef` are supplied by **capability rendering** (`CapabilityRequired() == true`; validated in `ValidateAndApplyDefaults`; `expose.Apply` reads then `delete`s `controllerType`), not by the OAM author. But the `PropertySchema()` added in v0.1.0-alpha.9 (#182) marks them `Required: true`.

That makes a consumer's schema preflight reject **every valid use** of those traits. crane injects `controllerType` from ClusterProfile and even forbids the OAM author from setting it (`reservedTraitKeys`), so with alpha.9 crane cannot compile any `expose` or `certificate` trait — preflight fails with `"controllerType": is required` / `"issuerRef": is required` before capability resolution runs.

This contradicts the schema principle from #182/#163: schemas describe **user-facing** properties, not capability-rendering fields.

## Fix

- `expose.go`: de-require `controllerType` (kept as an optional enum for type-checking).
- `certificate.go`: de-require the parent `issuerRef`, but **keep `issuerRef.name` required** so `issuerRef: {}` still fails in preflight rather than later in `parseProperties`. Keep the genuinely user-facing `secretName` and `dnsNames` required.
- Runtime validation via `ValidateAndApplyDefaults` is unchanged.
- Adds `TestCapabilityInjectedFieldsNotUserRequired` as a regression guard.

Scope is exactly the two `CapabilityRequired` traits; `ingress`/`httproute` list `networkPolicy` optional-only and don't require `controllerType`, so they're unaffected.

Needs a `v0.1.0-alpha.10` release so crane can bump and proceed with crane#305.

Refs #182