### PR TITLE
feat(oam): support privateKey in certificate trait

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -37,7 +37,7 @@ preflight reject every valid use of the trait.
 ### Security
 | `type` | Produces | Key properties |
 |--------|----------|----------------|
-| `certificate` | cert-manager Certificate | `secretName`, `dnsNames[]`, `duration`, `renewBefore` (issuer from ClusterProfile) |
+| `certificate` | cert-manager Certificate | `secretName`, `dnsNames[]`, `duration`, `renewBefore`, `privateKey` (`algorithm`/`size`/`encoding`/`rotationPolicy`) (issuer from ClusterProfile) |
 | `rbac` | Role/RoleBinding (+ClusterRole/Binding) | `rules[]` (`apiGroups`/`resources`/`verbs`), `clusterWide` |
 | `external-secret` | ESO ExternalSecret | `secretName`, `data[]`/`dataFrom[]`, `refreshInterval` (store from ClusterProfile or `provider`) |
 | `security-context` | (modifies PodSpec) | `psaLevel` (`restricted`\|`baseline`\|`privileged`), optional: `runAsNonRoot`, `allowPrivilegeEscalation`, `readOnlyRootFilesystem`, `runAsUser`, `runAsGroup`, `fsGroup` |

--- a/pkg/oam/builtin/traits/certificate.go
+++ b/pkg/oam/builtin/traits/certificate.go
@@ -3,6 +3,7 @@ package traits
 import (
 	"time"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-kure/kure/pkg/kubernetes/certmanager"
 	"github.com/go-kure/kure/pkg/stack"
@@ -62,6 +63,18 @@ func (h *CertificateHandler) PropertySchema() map[string]oam.PropertySchema {
 		"dnsNames":    {Type: oam.PropertyTypeArray, Required: true, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
 		"duration":    {Type: oam.PropertyTypeString, Default: "2160h"},
 		"renewBefore": {Type: oam.PropertyTypeString, Default: "360h"},
+		// privateKey is user-authored (not capability-injected) and optional; when
+		// omitted cert-manager applies its own defaults (RSA 2048). algorithm-specific
+		// size validation is enforced in parseProperties, not the schema.
+		"privateKey": {
+			Type: oam.PropertyTypeObject,
+			Properties: map[string]oam.PropertySchema{
+				"algorithm":      {Type: oam.PropertyTypeString, Enum: []any{"RSA", "ECDSA", "Ed25519"}},
+				"size":           {Type: oam.PropertyTypeInteger},
+				"encoding":       {Type: oam.PropertyTypeString, Enum: []any{"PKCS1", "PKCS8"}},
+				"rotationPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Never", "Always"}},
+			},
+		},
 	}
 }
 
@@ -130,7 +143,82 @@ func (h *CertificateHandler) parseProperties(props map[string]any, app *stack.Ap
 		config.RenewBefore = renew
 	}
 
+	if err := parsePrivateKey(props, config); err != nil {
+		return nil, err
+	}
+
 	return config, nil
+}
+
+// parsePrivateKey reads the optional privateKey block into config, validating
+// algorithm-specific size constraints so launcher rejects shapes cert-manager
+// would later reject. The block and every field are optional; omitted fields
+// leave cert-manager's own defaults in place.
+func parsePrivateKey(props map[string]any, config *CertificateConfig) error {
+	pk, ok := props["privateKey"].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	if alg, ok := pk["algorithm"].(string); ok && alg != "" {
+		if alg != "RSA" && alg != "ECDSA" && alg != "Ed25519" {
+			return errors.Errorf("privateKey.algorithm %q is invalid (allowed: RSA, ECDSA, Ed25519)", alg)
+		}
+		config.PKAlgorithm = alg
+	}
+	if enc, ok := pk["encoding"].(string); ok && enc != "" {
+		if enc != "PKCS1" && enc != "PKCS8" {
+			return errors.Errorf("privateKey.encoding %q is invalid (allowed: PKCS1, PKCS8)", enc)
+		}
+		config.PKEncoding = enc
+	}
+	if rot, ok := pk["rotationPolicy"].(string); ok && rot != "" {
+		if rot != "Never" && rot != "Always" {
+			return errors.Errorf("privateKey.rotationPolicy %q is invalid (allowed: Never, Always)", rot)
+		}
+		config.PKRotationPolicy = rot
+	}
+
+	if raw, exists := pk["size"]; exists {
+		size, ok := toInt32ForScaler(raw)
+		if !ok {
+			return errors.New("privateKey.size must be a whole number")
+		}
+		if size <= 0 {
+			return errors.Errorf("privateKey.size must be positive, got %d", size)
+		}
+		config.PKSize = int(size)
+	}
+
+	if config.PKSize != 0 {
+		// A bare size (no algorithm) is ambiguous: cert-manager would default to
+		// RSA, where ECDSA sizes are invalid. Require an explicit algorithm.
+		if config.PKAlgorithm == "" {
+			return errors.New("privateKey.size requires privateKey.algorithm to be set")
+		}
+		if err := validatePrivateKeySize(config.PKAlgorithm, config.PKSize); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// validatePrivateKeySize enforces cert-manager's per-algorithm key sizes.
+func validatePrivateKeySize(algorithm string, size int) error {
+	switch algorithm {
+	case "RSA":
+		if size != 2048 && size != 4096 && size != 8192 {
+			return errors.Errorf("privateKey.size %d is invalid for RSA (allowed: 2048, 4096, 8192)", size)
+		}
+	case "ECDSA":
+		if size != 256 && size != 384 && size != 521 {
+			return errors.Errorf("privateKey.size %d is invalid for ECDSA (allowed: 256, 384, 521)", size)
+		}
+	case "Ed25519":
+		return errors.New("privateKey.size must not be set for Ed25519 (key size is fixed)")
+	}
+	return nil
 }
 
 // CertificateConfig implements stack.ApplicationConfig for certificate traits.
@@ -142,6 +230,12 @@ type CertificateConfig struct {
 	DNSNames      []string
 	Duration      string
 	RenewBefore   string
+
+	// PrivateKey options; zero values leave cert-manager's defaults in place.
+	PKAlgorithm      string
+	PKSize           int
+	PKEncoding       string
+	PKRotationPolicy string
 }
 
 // ApplyPolicy is a no-op: certificates have no enforceable policy fields.
@@ -170,6 +264,17 @@ func (c *CertificateConfig) Generate(app *stack.Application) ([]*client.Object, 
 		Duration:    &metav1.Duration{Duration: dur},
 		RenewBefore: &metav1.Duration{Duration: renewBefore},
 	})
+
+	// The kure helper cannot carry privateKey; set it directly. Only populate the
+	// sub-fields the user authored so cert-manager defaults the rest.
+	if c.PKAlgorithm != "" || c.PKSize != 0 || c.PKEncoding != "" || c.PKRotationPolicy != "" {
+		cert.Spec.PrivateKey = &certv1.CertificatePrivateKey{
+			Algorithm:      certv1.PrivateKeyAlgorithm(c.PKAlgorithm),
+			Size:           c.PKSize,
+			Encoding:       certv1.PrivateKeyEncoding(c.PKEncoding),
+			RotationPolicy: certv1.PrivateKeyRotationPolicy(c.PKRotationPolicy),
+		}
+	}
 
 	obj := client.Object(cert)
 	return []*client.Object{&obj}, nil

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	certv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-kure/kure/pkg/stack"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -546,6 +547,102 @@ func TestCertificateConfig_Generate_OK(t *testing.T) {
 	}
 	if len(objects) != 1 {
 		t.Errorf("expected 1 Certificate object, got %d", len(objects))
+	}
+}
+
+func TestCertificateConfig_Generate_PrivateKey(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"secretName": "my-tls",
+			"issuerRef":  map[string]any{"name": "letsencrypt-prod", "kind": "ClusterIssuer"},
+			"dnsNames":   []any{"example.com"},
+			"privateKey": map[string]any{
+				"algorithm":      "ECDSA",
+				"size":           256,
+				"rotationPolicy": "Always",
+			},
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	cert, ok := (*objects[0]).(*certv1.Certificate)
+	if !ok {
+		t.Fatalf("expected *certv1.Certificate, got %T", *objects[0])
+	}
+	if cert.Spec.PrivateKey == nil {
+		t.Fatal("expected spec.privateKey to be set, got nil")
+	}
+	if cert.Spec.PrivateKey.Algorithm != certv1.ECDSAKeyAlgorithm {
+		t.Errorf("algorithm = %q, want ECDSA", cert.Spec.PrivateKey.Algorithm)
+	}
+	if cert.Spec.PrivateKey.Size != 256 {
+		t.Errorf("size = %d, want 256", cert.Spec.PrivateKey.Size)
+	}
+	if cert.Spec.PrivateKey.RotationPolicy != certv1.RotationPolicyAlways {
+		t.Errorf("rotationPolicy = %q, want Always", cert.Spec.PrivateKey.RotationPolicy)
+	}
+}
+
+func TestCertificateConfig_Generate_NoPrivateKey(t *testing.T) {
+	h := &traits.CertificateHandler{}
+	trait := &oam.Trait{
+		Type: "certificate",
+		Properties: map[string]any{
+			"secretName": "my-tls",
+			"issuerRef":  map[string]any{"name": "letsencrypt-prod"},
+			"dnsNames":   []any{"example.com"},
+		},
+	}
+	app := newApp("frontend", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objects, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	cert := (*objects[0]).(*certv1.Certificate)
+	if cert.Spec.PrivateKey != nil {
+		t.Errorf("expected spec.privateKey to be nil when unset, got %+v", cert.Spec.PrivateKey)
+	}
+}
+
+func TestCertificateHandler_Apply_PrivateKeyInvalid(t *testing.T) {
+	cases := map[string]map[string]any{
+		"unknown algorithm":      {"algorithm": "DSA"},
+		"unknown encoding":       {"algorithm": "RSA", "size": 2048, "encoding": "DER"},
+		"size without algorithm": {"size": 2048},
+		"non-positive size":      {"algorithm": "RSA", "size": 0},
+		"RSA size mismatch":      {"algorithm": "RSA", "size": 256},
+		"ECDSA size mismatch":    {"algorithm": "ECDSA", "size": 2048},
+		"Ed25519 with size":      {"algorithm": "Ed25519", "size": 256},
+	}
+	for name, pk := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := &traits.CertificateHandler{}
+			trait := &oam.Trait{
+				Type: "certificate",
+				Properties: map[string]any{
+					"secretName": "my-tls",
+					"issuerRef":  map[string]any{"name": "letsencrypt-prod"},
+					"dnsNames":   []any{"example.com"},
+					"privateKey": pk,
+				},
+			}
+			if err := h.Apply(trait, newApp("frontend", "default"), newBundle()); err == nil {
+				t.Fatalf("expected error for %s", name)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #185

The certificate trait read only `secretName`, `issuerRef`, `dnsNames`, `duration` and `renewBefore`, so cert-manager's `Certificate.spec.privateKey` was silently dropped and keys fell back to cert-manager defaults (RSA 2048). Surfaced by crane#305 dropping `privateKey: {algorithm: ECDSA, size: 256}` from its `nats-tls` fixture to unblock the alpha.10 bump.

## Changes
- Parse an optional `privateKey` block (`algorithm`/`size`/`encoding`/`rotationPolicy`) in `parseProperties`.
- Validate enums and cert-manager's per-algorithm key sizes (RSA 2048/4096/8192, ECDSA 256/384/521, Ed25519 rejects size); a bare `size` without `algorithm` is rejected as ambiguous.
- Set `Certificate.spec.privateKey` directly on the generated object (the kure helper cannot carry it).
- Add the nested `privateKey` property to `PropertySchema()` and document it in the traits README.

## Tests
- `TestCertificateConfig_Generate_PrivateKey` casts the generated object to `*certv1.Certificate` and asserts `spec.privateKey`.
- `TestCertificateConfig_Generate_NoPrivateKey` confirms nil when unset.
- `TestCertificateHandler_Apply_PrivateKeyInvalid` covers invalid enums, size-without-algorithm, non-positive size, and RSA/ECDSA/Ed25519 size mismatches.
