### PR TITLE
feat(oam): consume EnvironmentPolicy storage/scaler defaults in scaler/pvc/postgresql

### DIFF
--- a/docs/oam/options-policy-interface.md
+++ b/docs/oam/options-policy-interface.md
@@ -7,7 +7,7 @@
 | 1.1 | 2026-05-14 | Record decision (Option A); add framing section; rename options A/B; remove Option B |
 | 1.0 | 2026-04-19 | Initial draft — compared typed accessor (Option A) and opaque marker (Option B) |
 
-**Decision:** `oam.Policy` is a typed accessor interface with 18 methods. Reason:
+**Decision:** `oam.Policy` is a typed accessor interface with 21 methods. Reason:
 compile-time verification, no type assertions in handler code, and explicit `NoopPolicy`
 behaviour (no limits, no defaults, security-sensitive bools default-deny) are more important
 than the flexibility of a marker interface for future policy types.
@@ -82,7 +82,7 @@ policy from the request.
 // crane/pkg/api/types.go (abbreviated)
 type EnvironmentPolicy struct {
     Enforced     EnforcedLimits         // MaxReplicas, MaxCPU, MaxMemory, MaxStorageSize, AllowedRegistries
-    Defaults     DefaultValues          // Replicas, CPURequest, MemoryRequest, CPULimit, MemoryLimit
+    Defaults     DefaultValues          // Replicas, CPURequest, MemoryRequest, CPULimit, MemoryLimit, StorageSize, ScalerMinReplicas, ScalerMaxReplicas
     Security     SecurityPolicy         // AllowHostNetwork, AllowPrivileged, AllowHostPID, AllowHostIPC, AllowHostPathVolumes
     Placement    *PlacementRules        // optional
     Capabilities *CapabilityConstraints // Allowed, Forbidden, Required
@@ -135,6 +135,9 @@ type Policy interface {
     DefaultMemoryRequest() string
     DefaultCPULimit() string
     DefaultMemoryLimit() string
+    DefaultStorageSize() string
+    DefaultScalerMinReplicas() *int32
+    DefaultScalerMaxReplicas() *int32
 
     // Security flags — false is the zero value (default-deny)
     AllowHostNetwork() bool
@@ -173,6 +176,9 @@ func (*NoopPolicy) DefaultCPURequest() string    { return "" }
 func (*NoopPolicy) DefaultMemoryRequest() string { return "" }
 func (*NoopPolicy) DefaultCPULimit() string      { return "" }
 func (*NoopPolicy) DefaultMemoryLimit() string   { return "" }
+func (*NoopPolicy) DefaultStorageSize() string       { return "" }
+func (*NoopPolicy) DefaultScalerMinReplicas() *int32 { return nil }
+func (*NoopPolicy) DefaultScalerMaxReplicas() *int32 { return nil }
 func (*NoopPolicy) AllowHostNetwork() bool       { return false }
 func (*NoopPolicy) AllowPrivileged() bool        { return false }
 func (*NoopPolicy) AllowHostPID() bool           { return false }
@@ -207,6 +213,9 @@ func (p *EnvironmentPolicy) DefaultCPURequest() string    { return p.Defaults.CP
 func (p *EnvironmentPolicy) DefaultMemoryRequest() string { return p.Defaults.MemoryRequest }
 func (p *EnvironmentPolicy) DefaultCPULimit() string      { return p.Defaults.CPULimit }
 func (p *EnvironmentPolicy) DefaultMemoryLimit() string   { return p.Defaults.MemoryLimit }
+func (p *EnvironmentPolicy) DefaultStorageSize() string        { return p.Defaults.StorageSize }
+func (p *EnvironmentPolicy) DefaultScalerMinReplicas() *int32  { return p.Defaults.ScalerMinReplicas }
+func (p *EnvironmentPolicy) DefaultScalerMaxReplicas() *int32  { return p.Defaults.ScalerMaxReplicas }
 func (p *EnvironmentPolicy) AllowHostNetwork() bool       { return p.Security.AllowHostNetwork }
 func (p *EnvironmentPolicy) AllowPrivileged() bool        { return p.Security.AllowPrivileged }
 func (p *EnvironmentPolicy) AllowHostPID() bool           { return p.Security.AllowHostPID }

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -63,6 +63,23 @@ false; escape-hatch fields set it true). `Transformer.HandlerSchemas()` returns 
 validator can check a component/trait's properties before the handler is invoked. Built-in
 examples: the `configmap` trait and the `passthrough` component.
 
+## Policy defaults & enforcement
+
+`Policy` is a typed accessor interface (no type assertions in handlers) that carries
+per-environment **enforced limits** (`MaxReplicas`, `MaxCPU`, `MaxMemory`, `MaxStorageSize`,
+`AllowedRegistries`), **defaults** (`DefaultReplicas`, the CPU/memory request/limit defaults,
+and the workload-shape defaults `DefaultStorageSize`, `DefaultScalerMinReplicas`,
+`DefaultScalerMaxReplicas`), security flags, and capability constraints. Handlers that
+implement `Enforceable` receive it via `ApplyPolicy`; `NoopPolicy` supplies zero values when
+no policy is set (so `ApplyPolicy` is always called with a non-nil value at runtime).
+
+Handlers apply values with the precedence **authored > policy default > handler default**,
+then enforce the limits on the resulting effective value. For example the `scaler` trait fills
+`minReplicas`/`maxReplicas` from the scaler defaults when omitted (erroring if neither the trait
+nor a policy default supplies them), and the `pvc`/`postgresql` handlers default the storage
+size from `DefaultStorageSize`. See the Policy Interface design note under the Concepts
+section for the full accessor list and rationale.
+
 ## Capability system
 
 Capability-aware traits (e.g. `expose`, `certificate`, `external-secret`) declare

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -52,9 +52,9 @@ share these fields: `image` (validated — no untagged/`latest`), `env` (with
   `install.crds`/`upgrade.crds`.
 - **oci** — `source.url` (`oci://…`), `version` (tag or `sha256:…`), `path`,
   `prune`, `interval`, `targetNamespace`.
-- **postgresql** — `provider: cnpg`, `version` (default `16`), `storageSize`,
-  `replicas`, `backup.*`, `monitoring.enabled`, `pooler.enabled`, `managedRoles`,
-  `databases`.
+- **postgresql** — `provider: cnpg`, `version` (default `16`), `storageSize`
+  (precedence: authored > policy default `storageSize` > `1Gi`), `replicas`,
+  `backup.*`, `monitoring.enabled`, `pooler.enabled`, `managedRoles`, `databases`.
 - **passthrough** — `object` (full apiVersion/kind/metadata/spec), `clusterScoped`.
 - **crd / manifests** — `inline` xor `url`; `manifests` adds `scopeOverrides`
   (`apiVersion`/`kind`/`scope`) for unknown kinds.

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -545,6 +545,12 @@ func (c *PostgresqlConfig) ApplyPolicy(p oam.Policy) error {
 	if !c.explicitResources.memoryLimit {
 		c.Resources.MemoryLimit = applyDefaultResource(c.Resources.MemoryLimit, p.DefaultMemoryLimit())
 	}
+	// StorageSize precedence: authored > policy default > "1Gi" handler default.
+	// The parse-time fallback is already "1Gi", so let a policy default override it
+	// only when the user did not author a value.
+	if !c.explicitStorageSize && p.DefaultStorageSize() != "" {
+		c.StorageSize = p.DefaultStorageSize()
+	}
 
 	if err := enforceMaxReplicas(c.Replicas, p.MaxReplicas()); err != nil {
 		return err

--- a/pkg/oam/builtin/components/postgresql_test.go
+++ b/pkg/oam/builtin/components/postgresql_test.go
@@ -779,6 +779,36 @@ func TestPostgresqlConfig_ApplyPolicy_DefaultsReplicas(t *testing.T) {
 	}
 }
 
+func TestPostgresqlConfig_ApplyPolicy_DefaultsStorageSize(t *testing.T) {
+	// Omitted storageSize takes the policy default over the "1Gi" handler default.
+	pc := newPostgresqlApp(t, map[string]any{})
+	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)
+	if err := enforceable.ApplyPolicy(&stubPolicy{defaultStorageSize: "20Gi"}); err != nil {
+		t.Fatalf("ApplyPolicy: %v", err)
+	}
+	if pc.StorageSize != "20Gi" {
+		t.Errorf("StorageSize after defaulting: got %q, want 20Gi", pc.StorageSize)
+	}
+
+	// Authored storageSize wins over the policy default.
+	authored := newPostgresqlApp(t, map[string]any{"storageSize": "50Gi"})
+	if err := stack.ApplicationConfig(authored).(oam.Enforceable).ApplyPolicy(&stubPolicy{defaultStorageSize: "20Gi"}); err != nil {
+		t.Fatalf("ApplyPolicy: %v", err)
+	}
+	if authored.StorageSize != "50Gi" {
+		t.Errorf("authored StorageSize: got %q, want 50Gi", authored.StorageSize)
+	}
+
+	// NoopPolicy (no default) falls back to the "1Gi" handler default.
+	fallback := newPostgresqlApp(t, map[string]any{})
+	if err := stack.ApplicationConfig(fallback).(oam.Enforceable).ApplyPolicy(&oam.NoopPolicy{}); err != nil {
+		t.Fatalf("ApplyPolicy: %v", err)
+	}
+	if fallback.StorageSize != "1Gi" {
+		t.Errorf("fallback StorageSize: got %q, want 1Gi", fallback.StorageSize)
+	}
+}
+
 func TestPostgresqlConfig_ApplyPolicy_NilPolicy(t *testing.T) {
 	pc := newPostgresqlApp(t, map[string]any{})
 	enforceable := stack.ApplicationConfig(pc).(oam.Enforceable)

--- a/pkg/oam/builtin/components/webservice_test.go
+++ b/pkg/oam/builtin/components/webservice_test.go
@@ -13,33 +13,37 @@ import (
 
 // stubPolicy implements oam.Policy for testing.
 type stubPolicy struct {
-	maxReplicas       *int32
-	defaultReplicas   *int32
-	allowedRegistries []string
-	maxCPU            string
-	maxMemory         string
-	maxStorageSize    string
-	defaultCPURequest string
+	maxReplicas        *int32
+	defaultReplicas    *int32
+	allowedRegistries  []string
+	maxCPU             string
+	maxMemory          string
+	maxStorageSize     string
+	defaultCPURequest  string
+	defaultStorageSize string
 }
 
-func (s *stubPolicy) MaxReplicas() *int32             { return s.maxReplicas }
-func (s *stubPolicy) MaxCPU() string                  { return s.maxCPU }
-func (s *stubPolicy) MaxMemory() string               { return s.maxMemory }
-func (s *stubPolicy) MaxStorageSize() string          { return s.maxStorageSize }
-func (s *stubPolicy) AllowedRegistries() []string     { return s.allowedRegistries }
-func (s *stubPolicy) DefaultReplicas() *int32         { return s.defaultReplicas }
-func (s *stubPolicy) DefaultCPURequest() string       { return s.defaultCPURequest }
-func (s *stubPolicy) DefaultMemoryRequest() string    { return "" }
-func (s *stubPolicy) DefaultCPULimit() string         { return "" }
-func (s *stubPolicy) DefaultMemoryLimit() string      { return "" }
-func (s *stubPolicy) AllowHostNetwork() bool          { return false }
-func (s *stubPolicy) AllowPrivileged() bool           { return false }
-func (s *stubPolicy) AllowHostPID() bool              { return false }
-func (s *stubPolicy) AllowHostIPC() bool              { return false }
-func (s *stubPolicy) AllowHostPathVolumes() bool      { return false }
-func (s *stubPolicy) AllowedCapabilities() []string   { return nil }
-func (s *stubPolicy) ForbiddenCapabilities() []string { return nil }
-func (s *stubPolicy) RequiredCapabilities() []string  { return nil }
+func (s *stubPolicy) MaxReplicas() *int32              { return s.maxReplicas }
+func (s *stubPolicy) MaxCPU() string                   { return s.maxCPU }
+func (s *stubPolicy) MaxMemory() string                { return s.maxMemory }
+func (s *stubPolicy) MaxStorageSize() string           { return s.maxStorageSize }
+func (s *stubPolicy) AllowedRegistries() []string      { return s.allowedRegistries }
+func (s *stubPolicy) DefaultReplicas() *int32          { return s.defaultReplicas }
+func (s *stubPolicy) DefaultCPURequest() string        { return s.defaultCPURequest }
+func (s *stubPolicy) DefaultMemoryRequest() string     { return "" }
+func (s *stubPolicy) DefaultCPULimit() string          { return "" }
+func (s *stubPolicy) DefaultMemoryLimit() string       { return "" }
+func (s *stubPolicy) DefaultStorageSize() string       { return s.defaultStorageSize }
+func (s *stubPolicy) DefaultScalerMinReplicas() *int32 { return nil }
+func (s *stubPolicy) DefaultScalerMaxReplicas() *int32 { return nil }
+func (s *stubPolicy) AllowHostNetwork() bool           { return false }
+func (s *stubPolicy) AllowPrivileged() bool            { return false }
+func (s *stubPolicy) AllowHostPID() bool               { return false }
+func (s *stubPolicy) AllowHostIPC() bool               { return false }
+func (s *stubPolicy) AllowHostPathVolumes() bool       { return false }
+func (s *stubPolicy) AllowedCapabilities() []string    { return nil }
+func (s *stubPolicy) ForbiddenCapabilities() []string  { return nil }
+func (s *stubPolicy) RequiredCapabilities() []string   { return nil }
 
 var _ oam.Policy = (*stubPolicy)(nil)
 

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -45,14 +45,14 @@ preflight reject every valid use of the trait.
 ### Storage
 | `type` | Produces | Key properties |
 |--------|----------|----------------|
-| `pvc` | PersistentVolumeClaim | `name`, `size`, `storageClassName`, `accessModes[]` (policy: `maxStorageSize`) |
+| `pvc` | PersistentVolumeClaim | `name`, `size` (optional; policy default `storageSize`), `storageClassName`, `accessModes[]` (policy: `maxStorageSize`) |
 | `volsync` | VolSync ReplicationSource | `sourcePVC`, `schedule`, `copyMethod`, `retain.{daily,weekly,monthly}` |
 
 ### Configuration & scaling
 | `type` | Produces | Key properties |
 |--------|----------|----------------|
 | `configmap` | ConfigMap (+ optional volume mount) | `name`, `data`, `mountPath` |
-| `scaler` | HorizontalPodAutoscaler (+ optional PDB) | `minReplicas`, `maxReplicas`, `cpuUtilization`, `memoryUtilization`, `enablePDB` |
+| `scaler` | HorizontalPodAutoscaler (+ optional PDB) | `minReplicas`, `maxReplicas` (both optional; policy defaults `scalerMinReplicas`/`scalerMaxReplicas`, policy cap `maxReplicas`), `cpuUtilization`, `memoryUtilization`, `enablePDB` |
 
 ### Operational (FluxCD)
 | `type` | Effect | Key properties |

--- a/pkg/oam/builtin/traits/enforce.go
+++ b/pkg/oam/builtin/traits/enforce.go
@@ -1,0 +1,56 @@
+package traits
+
+import (
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+// applyDefaultReplicas returns dflt when the value was not user-authored and a
+// policy default is set; otherwise it leaves current unchanged. Mirrors the
+// component-side helper of the same name (kept trait-local to avoid coupling
+// the traits and components packages).
+func applyDefaultReplicas(current int32, explicit bool, dflt *int32) int32 {
+	if explicit || dflt == nil {
+		return current
+	}
+	return *dflt
+}
+
+// applyDefaultResource returns dflt when current is unset (empty string).
+func applyDefaultResource(current, dflt string) string {
+	if current != "" {
+		return current
+	}
+	return dflt
+}
+
+// enforceMaxReplicas errors when current exceeds a set maximum (nil = no limit).
+func enforceMaxReplicas(current int32, max *int32) error {
+	if max == nil {
+		return nil
+	}
+	if current > *max {
+		return errors.Errorf("replicas %d exceeds enforced maximum %d", current, *max)
+	}
+	return nil
+}
+
+// enforceMaxStorageSize errors when current exceeds a set maximum ("" = no limit).
+func enforceMaxStorageSize(current, max string) error {
+	if max == "" || current == "" {
+		return nil
+	}
+	currentQty, err := resource.ParseQuantity(current)
+	if err != nil {
+		return errors.Wrapf(err, "invalid storageSize value %q", current)
+	}
+	maxQty, err := resource.ParseQuantity(max)
+	if err != nil {
+		return errors.Wrapf(err, "invalid enforced max storageSize value %q", max)
+	}
+	if currentQty.Cmp(maxQty) > 0 {
+		return errors.Errorf("storageSize %q exceeds enforced maximum %q", current, max)
+	}
+	return nil
+}

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -29,8 +29,11 @@ func (h *PVCHandler) CanHandle(traitType string) bool {
 // PropertySchema declares the pvc trait's user-facing properties.
 func (h *PVCHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"name":             {Type: oam.PropertyTypeString, Required: true},
-		"size":             {Type: oam.PropertyTypeString, Required: true},
+		"name": {Type: oam.PropertyTypeString, Required: true},
+		// size is not schema-required: an EnvironmentPolicy may supply it via
+		// DefaultStorageSize. When neither the trait nor a policy default provides a
+		// value, ApplyPolicy errors (pvc has no last-resort handler default).
+		"size":             {Type: oam.PropertyTypeString},
 		"storageClassName": {Type: oam.PropertyTypeString},
 		"accessModes": {
 			Type:    oam.PropertyTypeArray,
@@ -62,12 +65,14 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 		return nil, errors.New("required property 'name' missing or not a string")
 	}
 
+	// size is optional at parse time: a policy default may supply it. When present
+	// it must be a valid quantity; the "must be set" check runs in validateEffective
+	// after ApplyPolicy has had a chance to apply the policy default.
 	size, _ := props["size"].(string)
-	if size == "" {
-		return nil, errors.New("required property 'size' missing or not a string")
-	}
-	if _, err := resource.ParseQuantity(size); err != nil {
-		return nil, errors.Errorf("invalid PVC size %q: %w", size, err)
+	if size != "" {
+		if _, err := resource.ParseQuantity(size); err != nil {
+			return nil, errors.Errorf("invalid PVC size %q: %w", size, err)
+		}
 	}
 
 	var storageClass string
@@ -111,27 +116,45 @@ type PVCTraitConfig struct {
 	AccessModes   []string
 }
 
-// ApplyPolicy enforces the policy storage-size limit against the requested PVC size.
+// ApplyPolicy defaults the PVC size from the policy when the trait omitted it,
+// validates the effective size, and enforces the policy storage-size limit.
+// Precedence: authored > policy default > (error, no handler default). A nil
+// policy means no default and no cap.
 func (c *PVCTraitConfig) ApplyPolicy(p oam.Policy) error {
-	if p == nil || p.MaxStorageSize() == "" {
-		return nil
+	if p != nil {
+		c.Size = applyDefaultResource(c.Size, p.DefaultStorageSize())
 	}
-	current, err := resource.ParseQuantity(c.Size)
-	if err != nil {
+	if err := c.validateEffective(); err != nil {
+		return err
+	}
+	if p != nil {
+		if err := enforceMaxStorageSize(c.Size, p.MaxStorageSize()); err != nil {
+			return errors.Errorf("PVC %q %w", c.Name, err)
+		}
+	}
+	return nil
+}
+
+// validateEffective owns the effective-size validation for the PVC: it runs
+// after the policy default is applied (from ApplyPolicy) and defensively from
+// Generate so a config built without ApplyPolicy cannot emit an empty size.
+func (c *PVCTraitConfig) validateEffective() error {
+	if c.Size == "" {
+		return errors.Errorf("PVC %q size is required (set it on the trait or via an EnvironmentPolicy storage default)", c.Name)
+	}
+	if _, err := resource.ParseQuantity(c.Size); err != nil {
 		return errors.Errorf("invalid PVC size %q: %w", c.Size, err)
-	}
-	max, err := resource.ParseQuantity(p.MaxStorageSize())
-	if err != nil {
-		return errors.Errorf("invalid maxStorageSize %q in policy: %w", p.MaxStorageSize(), err)
-	}
-	if current.Cmp(max) > 0 {
-		return errors.Errorf("PVC %q size %q exceeds maximum storage size %q", c.Name, c.Size, p.MaxStorageSize())
 	}
 	return nil
 }
 
 // Generate delegates to components.BuildPVC so the trait shares the same PVC construction path.
 func (c *PVCTraitConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	// Defensive: reject an unset/invalid size even if ApplyPolicy was bypassed.
+	if err := c.validateEffective(); err != nil {
+		return nil, err
+	}
+
 	labels := map[string]string{"app": c.ComponentName}
 	pvc, err := components.BuildPVC(components.PVCConfig{
 		Name:         c.Name,

--- a/pkg/oam/builtin/traits/scaler.go
+++ b/pkg/oam/builtin/traits/scaler.go
@@ -26,8 +26,11 @@ func (h *ScalerHandler) CanHandle(traitType string) bool {
 // PropertySchema declares the scaler trait's user-facing properties.
 func (h *ScalerHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"minReplicas":       {Type: oam.PropertyTypeInteger, Required: true},
-		"maxReplicas":       {Type: oam.PropertyTypeInteger, Required: true},
+		// minReplicas/maxReplicas are not schema-required: an EnvironmentPolicy may
+		// supply them via DefaultScalerMinReplicas/DefaultScalerMaxReplicas. When
+		// neither the trait nor a policy default provides a value, ApplyPolicy errors.
+		"minReplicas":       {Type: oam.PropertyTypeInteger},
+		"maxReplicas":       {Type: oam.PropertyTypeInteger},
 		"cpuUtilization":    {Type: oam.PropertyTypeInteger, Default: 80},
 		"memoryUtilization": {Type: oam.PropertyTypeInteger},
 		"enablePDB":         {Type: oam.PropertyTypeBoolean, Default: false},
@@ -55,23 +58,25 @@ func (h *ScalerHandler) parseProperties(props map[string]any, app *stack.Applica
 		ComponentName: app.Name,
 	}
 
-	minReplicas, ok := toInt32ForScaler(props["minReplicas"])
-	if !ok {
-		return nil, errors.New("required property 'minReplicas' missing or not a number")
+	// minReplicas/maxReplicas are optional at parse time: a policy default may
+	// supply them. When present they must be whole numbers; the effective-value
+	// checks (>=1, max>=min, PDB) run in validateEffective after ApplyPolicy.
+	if _, exists := props["minReplicas"]; exists {
+		minReplicas, ok := toInt32ForScaler(props["minReplicas"])
+		if !ok {
+			return nil, errors.New("minReplicas must be a whole number")
+		}
+		config.MinReplicas = minReplicas
+		config.explicitMinReplicas = true
 	}
-	config.MinReplicas = minReplicas
 
-	maxReplicas, ok := toInt32ForScaler(props["maxReplicas"])
-	if !ok {
-		return nil, errors.New("required property 'maxReplicas' missing or not a number")
-	}
-	config.MaxReplicas = maxReplicas
-
-	if config.MinReplicas < 1 {
-		return nil, errors.Errorf("minReplicas must be >= 1, got %d", config.MinReplicas)
-	}
-	if config.MaxReplicas < config.MinReplicas {
-		return nil, errors.Errorf("maxReplicas (%d) must be >= minReplicas (%d)", config.MaxReplicas, config.MinReplicas)
+	if _, exists := props["maxReplicas"]; exists {
+		maxReplicas, ok := toInt32ForScaler(props["maxReplicas"])
+		if !ok {
+			return nil, errors.New("maxReplicas must be a whole number")
+		}
+		config.MaxReplicas = maxReplicas
+		config.explicitMaxReplicas = true
 	}
 
 	if _, exists := props["cpuUtilization"]; exists {
@@ -104,9 +109,8 @@ func (h *ScalerHandler) parseProperties(props map[string]any, app *stack.Applica
 	if pdb, ok := props["enablePDB"].(bool); ok {
 		config.EnablePDB = pdb
 	}
-	if config.EnablePDB && config.MinReplicas < 2 {
-		return nil, errors.Errorf("enablePDB requires minReplicas >= 2 (got %d); with 1 replica PDB blocks all voluntary disruptions", config.MinReplicas)
-	}
+	// The enablePDB/minReplicas cross-check runs in validateEffective, since
+	// minReplicas may still be filled by a policy default.
 
 	return config, nil
 }
@@ -147,13 +151,54 @@ type ScalerConfig struct {
 	CPUUtilization    *int32
 	MemoryUtilization *int32
 	EnablePDB         bool
+
+	explicitMinReplicas bool
+	explicitMaxReplicas bool
 }
 
-// ApplyPolicy is a no-op: the scaler trait has no enforceable policy fields.
-func (c *ScalerConfig) ApplyPolicy(_ oam.Policy) error { return nil }
+// ApplyPolicy fills minReplicas/maxReplicas from the policy defaults when the
+// trait omitted them, validates the effective values, and enforces the policy
+// replica ceiling. Precedence: authored > policy default > (error, no handler
+// default for scaler bounds). A nil policy means no defaults and no caps.
+func (c *ScalerConfig) ApplyPolicy(p oam.Policy) error {
+	if p != nil {
+		c.MinReplicas = applyDefaultReplicas(c.MinReplicas, c.explicitMinReplicas, p.DefaultScalerMinReplicas())
+		c.MaxReplicas = applyDefaultReplicas(c.MaxReplicas, c.explicitMaxReplicas, p.DefaultScalerMaxReplicas())
+	}
+	if err := c.validateEffective(); err != nil {
+		return err
+	}
+	if p != nil {
+		if err := enforceMaxReplicas(c.MaxReplicas, p.MaxReplicas()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateEffective owns all effective-value validation for the scaler: it runs
+// after defaults are applied (from ApplyPolicy) and defensively from Generate so
+// a config built without ApplyPolicy cannot emit invalid HPA bounds.
+func (c *ScalerConfig) validateEffective() error {
+	if c.MinReplicas < 1 {
+		return errors.Errorf("minReplicas must be >= 1, got %d (set it on the trait or via an EnvironmentPolicy scaler default)", c.MinReplicas)
+	}
+	if c.MaxReplicas < c.MinReplicas {
+		return errors.Errorf("maxReplicas (%d) must be >= minReplicas (%d)", c.MaxReplicas, c.MinReplicas)
+	}
+	if c.EnablePDB && c.MinReplicas < 2 {
+		return errors.Errorf("enablePDB requires minReplicas >= 2 (got %d); with 1 replica PDB blocks all voluntary disruptions", c.MinReplicas)
+	}
+	return nil
+}
 
 // Generate creates HPA and optionally PDB Kubernetes resources.
 func (c *ScalerConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	// Defensive: reject invalid effective bounds even if ApplyPolicy was bypassed.
+	if err := c.validateEffective(); err != nil {
+		return nil, err
+	}
+
 	labels := map[string]string{"app": c.ComponentName}
 
 	var resources []*client.Object

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -580,44 +580,73 @@ func TestScalerHandler_Apply_OK(t *testing.T) {
 	}
 }
 
-func TestScalerHandler_Apply_MissingMinReplicas(t *testing.T) {
+// applyScalerPolicy applies the trait then runs ApplyPolicy, returning the
+// ApplyPolicy error. minReplicas/maxReplicas are optional at parse time (a policy
+// default may supply them), so effective-value violations surface here, not in Apply.
+func applyScalerPolicy(t *testing.T, trait *oam.Trait, p oam.Policy) error {
+	t.Helper()
 	h := &traits.ScalerHandler{}
-	trait := &oam.Trait{
-		Type: "scaler",
-		Properties: map[string]any{
-			"maxReplicas": 10,
-		},
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
 	}
-	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
-		t.Fatal("expected error for missing minReplicas")
+	return bundle.Applications[0].Config.(oam.Enforceable).ApplyPolicy(p)
+}
+
+func TestScalerConfig_ApplyPolicy_MissingMinReplicas(t *testing.T) {
+	trait := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"maxReplicas": 10},
+	}
+	// Omitted min with no policy default is rejected by ApplyPolicy...
+	if err := applyScalerPolicy(t, trait, &oam.NoopPolicy{}); err == nil {
+		t.Fatal("expected error for missing minReplicas with no policy default")
+	}
+	// ...but a policy default fills it.
+	p := &stubScalerPolicy{defaultScalerMin: int32ptr32(2)}
+	if err := applyScalerPolicy(t, trait, p); err != nil {
+		t.Fatalf("expected policy default to fill minReplicas, got: %v", err)
 	}
 }
 
-func TestScalerHandler_Apply_MinReplicasLessThanOne(t *testing.T) {
-	h := &traits.ScalerHandler{}
+func TestScalerConfig_ApplyPolicy_MinReplicasLessThanOne(t *testing.T) {
 	trait := &oam.Trait{
-		Type: "scaler",
-		Properties: map[string]any{
-			"minReplicas": 0,
-			"maxReplicas": 10,
-		},
+		Type:       "scaler",
+		Properties: map[string]any{"minReplicas": 0, "maxReplicas": 10},
 	}
-	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+	if err := applyScalerPolicy(t, trait, &oam.NoopPolicy{}); err == nil {
 		t.Fatal("expected error for minReplicas < 1")
 	}
 }
 
-func TestScalerHandler_Apply_MaxLessThanMin(t *testing.T) {
-	h := &traits.ScalerHandler{}
+func TestScalerConfig_ApplyPolicy_MaxLessThanMin(t *testing.T) {
 	trait := &oam.Trait{
-		Type: "scaler",
-		Properties: map[string]any{
-			"minReplicas": 5,
-			"maxReplicas": 3,
-		},
+		Type:       "scaler",
+		Properties: map[string]any{"minReplicas": 5, "maxReplicas": 3},
 	}
-	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+	if err := applyScalerPolicy(t, trait, &oam.NoopPolicy{}); err == nil {
 		t.Fatal("expected error for maxReplicas < minReplicas")
+	}
+}
+
+func TestScalerConfig_ApplyPolicy_DefaultsAndCeiling(t *testing.T) {
+	// Authored value wins over the policy default.
+	authored := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"minReplicas": 3, "maxReplicas": 9},
+	}
+	p := &stubScalerPolicy{defaultScalerMin: int32ptr32(1), defaultScalerMax: int32ptr32(4)}
+	if err := applyScalerPolicy(t, authored, p); err != nil {
+		t.Fatalf("authored values with policy defaults: %v", err)
+	}
+	// Effective maxReplicas above the policy ceiling is rejected.
+	omitted := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"minReplicas": 2},
+	}
+	ceiling := &stubScalerPolicy{maxReplicas: int32ptr32(5), defaultScalerMax: int32ptr32(10)}
+	if err := applyScalerPolicy(t, omitted, ceiling); err == nil {
+		t.Fatal("expected error when effective maxReplicas exceeds MaxReplicas ceiling")
 	}
 }
 
@@ -645,8 +674,7 @@ func TestScalerHandler_Apply_WithPDB(t *testing.T) {
 	}
 }
 
-func TestScalerHandler_Apply_PDB_RequiresMinReplicas2(t *testing.T) {
-	h := &traits.ScalerHandler{}
+func TestScalerConfig_ApplyPolicy_PDB_RequiresMinReplicas2(t *testing.T) {
 	trait := &oam.Trait{
 		Type: "scaler",
 		Properties: map[string]any{
@@ -655,7 +683,7 @@ func TestScalerHandler_Apply_PDB_RequiresMinReplicas2(t *testing.T) {
 			"enablePDB":   true,
 		},
 	}
-	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
+	if err := applyScalerPolicy(t, trait, &oam.NoopPolicy{}); err == nil {
 		t.Fatal("expected error: enablePDB requires minReplicas >= 2")
 	}
 }
@@ -672,6 +700,42 @@ func TestScalerHandler_Apply_CPUUtilizationOutOfRange(t *testing.T) {
 	}
 	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
 		t.Fatal("expected error for cpuUtilization > 100")
+	}
+}
+
+func TestScalerConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	// Authored values + nil policy: valid, no defaults/caps applied.
+	authored := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"minReplicas": 2, "maxReplicas": 6},
+	}
+	if err := applyScalerPolicy(t, authored, nil); err != nil {
+		t.Errorf("authored values with nil policy should be valid, got: %v", err)
+	}
+	// Omitted min + nil policy: no default to fill it → validateEffective errors.
+	omitted := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"maxReplicas": 6},
+	}
+	if err := applyScalerPolicy(t, omitted, nil); err == nil {
+		t.Fatal("expected error for omitted minReplicas with nil policy")
+	}
+}
+
+func TestScalerConfig_Generate_RejectsInvalidBounds(t *testing.T) {
+	// Bypass safety: a config built without ApplyPolicy must not emit invalid HPA
+	// bounds. Apply leaves minReplicas at 0 when omitted; Generate must reject it.
+	h := &traits.ScalerHandler{}
+	trait := &oam.Trait{
+		Type:       "scaler",
+		Properties: map[string]any{"maxReplicas": 5},
+	}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if _, err := bundle.Applications[0].Generate(); err == nil {
+		t.Fatal("expected Generate to reject minReplicas < 1 when ApplyPolicy was bypassed")
 	}
 }
 
@@ -743,7 +807,7 @@ func TestPVCHandler_Apply_MissingName(t *testing.T) {
 	}
 }
 
-func TestPVCHandler_Apply_MissingSize(t *testing.T) {
+func TestPVCConfig_ApplyPolicy_MissingSize(t *testing.T) {
 	h := &traits.PVCHandler{}
 	trait := &oam.Trait{
 		Type: "pvc",
@@ -751,8 +815,19 @@ func TestPVCHandler_Apply_MissingSize(t *testing.T) {
 			"name": "data",
 		},
 	}
-	if err := h.Apply(trait, newApp("api", "default"), newBundle()); err == nil {
-		t.Fatal("expected error for missing size")
+	// size is optional at parse time; the "required" check moves to ApplyPolicy.
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	enforceable := bundle.Applications[0].Config.(oam.Enforceable)
+	// No policy default → error.
+	if err := enforceable.ApplyPolicy(&oam.NoopPolicy{}); err == nil {
+		t.Fatal("expected error for missing size with no policy default")
+	}
+	// Policy default fills it.
+	if err := enforceable.ApplyPolicy(&stubPVCPolicy{defaultStorageSize: "3Gi"}); err != nil {
+		t.Fatalf("expected policy default to fill size, got: %v", err)
 	}
 }
 
@@ -840,29 +915,116 @@ func TestPVCTraitConfig_ApplyPolicy_WithinMax(t *testing.T) {
 	}
 }
 
-// stubPVCPolicy implements oam.Policy for PVC trait tests.
-type stubPVCPolicy struct {
-	maxStorageSize string
+// pvcSizeAfterPolicy applies the pvc trait, runs ApplyPolicy, and returns the
+// effective size rendered onto the generated PersistentVolumeClaim.
+func pvcSizeAfterPolicy(t *testing.T, props map[string]any, p oam.Policy) string {
+	t.Helper()
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{Type: "pvc", Properties: props}
+	app := newApp("api", "default")
+	bundle := newBundle()
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := bundle.Applications[0].Config.(oam.Enforceable).ApplyPolicy(p); err != nil {
+		t.Fatalf("ApplyPolicy: %v", err)
+	}
+	objs, err := bundle.Applications[0].Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	pvc := (*objs[0]).(*corev1.PersistentVolumeClaim)
+	return pvc.Spec.Resources.Requests.Storage().String()
 }
 
-func (p *stubPVCPolicy) MaxReplicas() *int32             { return nil }
-func (p *stubPVCPolicy) MaxCPU() string                  { return "" }
-func (p *stubPVCPolicy) MaxMemory() string               { return "" }
-func (p *stubPVCPolicy) MaxStorageSize() string          { return p.maxStorageSize }
-func (p *stubPVCPolicy) AllowedRegistries() []string     { return nil }
-func (p *stubPVCPolicy) DefaultReplicas() *int32         { return nil }
-func (p *stubPVCPolicy) DefaultCPURequest() string       { return "" }
-func (p *stubPVCPolicy) DefaultMemoryRequest() string    { return "" }
-func (p *stubPVCPolicy) DefaultCPULimit() string         { return "" }
-func (p *stubPVCPolicy) DefaultMemoryLimit() string      { return "" }
-func (p *stubPVCPolicy) AllowHostNetwork() bool          { return false }
-func (p *stubPVCPolicy) AllowPrivileged() bool           { return false }
-func (p *stubPVCPolicy) AllowHostPID() bool              { return false }
-func (p *stubPVCPolicy) AllowHostIPC() bool              { return false }
-func (p *stubPVCPolicy) AllowHostPathVolumes() bool      { return false }
-func (p *stubPVCPolicy) AllowedCapabilities() []string   { return nil }
-func (p *stubPVCPolicy) ForbiddenCapabilities() []string { return nil }
-func (p *stubPVCPolicy) RequiredCapabilities() []string  { return nil }
+func TestPVCTraitConfig_ApplyPolicy_NilPolicy(t *testing.T) {
+	h := &traits.PVCHandler{}
+	// Authored size + nil policy: valid.
+	authored := &oam.Trait{Type: "pvc", Properties: map[string]any{"name": "data", "size": "5Gi"}}
+	bundle := newBundle()
+	if err := h.Apply(authored, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := bundle.Applications[0].Config.(oam.Enforceable).ApplyPolicy(nil); err != nil {
+		t.Errorf("authored size with nil policy should be valid, got: %v", err)
+	}
+	// Omitted size + nil policy: no default → error.
+	omitted := &oam.Trait{Type: "pvc", Properties: map[string]any{"name": "data"}}
+	bundle2 := newBundle()
+	if err := h.Apply(omitted, newApp("api", "default"), bundle2); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if err := bundle2.Applications[0].Config.(oam.Enforceable).ApplyPolicy(nil); err == nil {
+		t.Fatal("expected error for omitted size with nil policy")
+	}
+}
+
+func TestPVCTraitConfig_Generate_RejectsEmptySize(t *testing.T) {
+	// Bypass safety: Generate must reject an unset size even without ApplyPolicy.
+	h := &traits.PVCHandler{}
+	trait := &oam.Trait{Type: "pvc", Properties: map[string]any{"name": "data"}}
+	bundle := newBundle()
+	if err := h.Apply(trait, newApp("api", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if _, err := bundle.Applications[0].Generate(); err == nil {
+		t.Fatal("expected Generate to reject empty size when ApplyPolicy was bypassed")
+	}
+}
+
+func TestPVCTraitConfig_ApplyPolicy_DefaultStorageSize(t *testing.T) {
+	// Omitted size takes the policy default.
+	if got := pvcSizeAfterPolicy(t, map[string]any{"name": "data"}, &stubPVCPolicy{defaultStorageSize: "7Gi"}); got != "7Gi" {
+		t.Errorf("defaulted size = %q, want 7Gi", got)
+	}
+	// Authored size wins over the policy default.
+	if got := pvcSizeAfterPolicy(t, map[string]any{"name": "data", "size": "5Gi"}, &stubPVCPolicy{defaultStorageSize: "7Gi"}); got != "5Gi" {
+		t.Errorf("authored size = %q, want 5Gi", got)
+	}
+}
+
+// stubPVCPolicy implements oam.Policy for PVC trait tests.
+type stubPVCPolicy struct {
+	maxStorageSize     string
+	defaultStorageSize string
+}
+
+func (p *stubPVCPolicy) MaxReplicas() *int32              { return nil }
+func (p *stubPVCPolicy) MaxCPU() string                   { return "" }
+func (p *stubPVCPolicy) MaxMemory() string                { return "" }
+func (p *stubPVCPolicy) MaxStorageSize() string           { return p.maxStorageSize }
+func (p *stubPVCPolicy) AllowedRegistries() []string      { return nil }
+func (p *stubPVCPolicy) DefaultReplicas() *int32          { return nil }
+func (p *stubPVCPolicy) DefaultCPURequest() string        { return "" }
+func (p *stubPVCPolicy) DefaultMemoryRequest() string     { return "" }
+func (p *stubPVCPolicy) DefaultCPULimit() string          { return "" }
+func (p *stubPVCPolicy) DefaultMemoryLimit() string       { return "" }
+func (p *stubPVCPolicy) DefaultStorageSize() string       { return p.defaultStorageSize }
+func (p *stubPVCPolicy) DefaultScalerMinReplicas() *int32 { return nil }
+func (p *stubPVCPolicy) DefaultScalerMaxReplicas() *int32 { return nil }
+func (p *stubPVCPolicy) AllowHostNetwork() bool           { return false }
+func (p *stubPVCPolicy) AllowPrivileged() bool            { return false }
+func (p *stubPVCPolicy) AllowHostPID() bool               { return false }
+func (p *stubPVCPolicy) AllowHostIPC() bool               { return false }
+func (p *stubPVCPolicy) AllowHostPathVolumes() bool       { return false }
+func (p *stubPVCPolicy) AllowedCapabilities() []string    { return nil }
+func (p *stubPVCPolicy) ForbiddenCapabilities() []string  { return nil }
+func (p *stubPVCPolicy) RequiredCapabilities() []string   { return nil }
+
+// stubScalerPolicy implements oam.Policy for scaler trait tests, embedding
+// NoopPolicy so only the scaler-relevant accessors need overriding.
+type stubScalerPolicy struct {
+	oam.NoopPolicy
+	maxReplicas      *int32
+	defaultScalerMin *int32
+	defaultScalerMax *int32
+}
+
+func (p *stubScalerPolicy) MaxReplicas() *int32              { return p.maxReplicas }
+func (p *stubScalerPolicy) DefaultScalerMinReplicas() *int32 { return p.defaultScalerMin }
+func (p *stubScalerPolicy) DefaultScalerMaxReplicas() *int32 { return p.defaultScalerMax }
+
+func int32ptr32(v int32) *int32 { return &v }
 
 // --- ExternalSecretHandler ---
 

--- a/pkg/oam/policy.go
+++ b/pkg/oam/policy.go
@@ -3,7 +3,7 @@ package oam
 // Policy provides environment-level constraints and defaults for OAM component
 // and trait handlers. Handlers call its methods; they must not type-assert.
 //
-// The 18 typed accessor methods correspond to every piece of data that handlers
+// The 21 typed accessor methods correspond to every piece of data that handlers
 // currently access via crane's *api.EnvironmentPolicy. See the finalized design
 // in docs/oam/options-policy-interface.md (Option A).
 //
@@ -23,6 +23,11 @@ type Policy interface {
 	DefaultMemoryRequest() string
 	DefaultCPULimit() string
 	DefaultMemoryLimit() string
+
+	// Workload-shape defaults — nil or empty string means leave the OAM value as-is.
+	DefaultStorageSize() string
+	DefaultScalerMinReplicas() *int32
+	DefaultScalerMaxReplicas() *int32
 
 	// Security flags — false is the zero value (default-deny).
 	AllowHostNetwork() bool
@@ -54,21 +59,24 @@ type NoopPolicy struct{}
 // compile-time interface check
 var _ Policy = (*NoopPolicy)(nil)
 
-func (*NoopPolicy) MaxReplicas() *int32             { return nil }
-func (*NoopPolicy) MaxCPU() string                  { return "" }
-func (*NoopPolicy) MaxMemory() string               { return "" }
-func (*NoopPolicy) MaxStorageSize() string          { return "" }
-func (*NoopPolicy) AllowedRegistries() []string     { return nil }
-func (*NoopPolicy) DefaultReplicas() *int32         { return nil }
-func (*NoopPolicy) DefaultCPURequest() string       { return "" }
-func (*NoopPolicy) DefaultMemoryRequest() string    { return "" }
-func (*NoopPolicy) DefaultCPULimit() string         { return "" }
-func (*NoopPolicy) DefaultMemoryLimit() string      { return "" }
-func (*NoopPolicy) AllowHostNetwork() bool          { return false }
-func (*NoopPolicy) AllowPrivileged() bool           { return false }
-func (*NoopPolicy) AllowHostPID() bool              { return false }
-func (*NoopPolicy) AllowHostIPC() bool              { return false }
-func (*NoopPolicy) AllowHostPathVolumes() bool      { return false }
-func (*NoopPolicy) AllowedCapabilities() []string   { return nil }
-func (*NoopPolicy) ForbiddenCapabilities() []string { return nil }
-func (*NoopPolicy) RequiredCapabilities() []string  { return nil }
+func (*NoopPolicy) MaxReplicas() *int32              { return nil }
+func (*NoopPolicy) MaxCPU() string                   { return "" }
+func (*NoopPolicy) MaxMemory() string                { return "" }
+func (*NoopPolicy) MaxStorageSize() string           { return "" }
+func (*NoopPolicy) AllowedRegistries() []string      { return nil }
+func (*NoopPolicy) DefaultReplicas() *int32          { return nil }
+func (*NoopPolicy) DefaultCPURequest() string        { return "" }
+func (*NoopPolicy) DefaultMemoryRequest() string     { return "" }
+func (*NoopPolicy) DefaultCPULimit() string          { return "" }
+func (*NoopPolicy) DefaultMemoryLimit() string       { return "" }
+func (*NoopPolicy) DefaultStorageSize() string       { return "" }
+func (*NoopPolicy) DefaultScalerMinReplicas() *int32 { return nil }
+func (*NoopPolicy) DefaultScalerMaxReplicas() *int32 { return nil }
+func (*NoopPolicy) AllowHostNetwork() bool           { return false }
+func (*NoopPolicy) AllowPrivileged() bool            { return false }
+func (*NoopPolicy) AllowHostPID() bool               { return false }
+func (*NoopPolicy) AllowHostIPC() bool               { return false }
+func (*NoopPolicy) AllowHostPathVolumes() bool       { return false }
+func (*NoopPolicy) AllowedCapabilities() []string    { return nil }
+func (*NoopPolicy) ForbiddenCapabilities() []string  { return nil }
+func (*NoopPolicy) RequiredCapabilities() []string   { return nil }

--- a/pkg/oam/policy_test.go
+++ b/pkg/oam/policy_test.go
@@ -38,6 +38,15 @@ func TestNoopPolicy_ZeroValues(t *testing.T) {
 	if got := p.DefaultMemoryLimit(); got != "" {
 		t.Errorf("DefaultMemoryLimit() = %q, want empty", got)
 	}
+	if got := p.DefaultStorageSize(); got != "" {
+		t.Errorf("DefaultStorageSize() = %q, want empty", got)
+	}
+	if got := p.DefaultScalerMinReplicas(); got != nil {
+		t.Errorf("DefaultScalerMinReplicas() = %v, want nil", got)
+	}
+	if got := p.DefaultScalerMaxReplicas(); got != nil {
+		t.Errorf("DefaultScalerMaxReplicas() = %v, want nil", got)
+	}
 	if got := p.AllowHostNetwork(); got {
 		t.Error("AllowHostNetwork() = true, want false (default-deny)")
 	}


### PR DESCRIPTION
Closes #186

crane#318 added workload-shape defaults to `EnvironmentPolicy` (`storageSize`, `scalerMinReplicas`, `scalerMaxReplicas`) but nothing consumed them because the launcher `Policy` interface and handlers didn't read them.

## Changes
- Add `DefaultStorageSize()`, `DefaultScalerMinReplicas()`, `DefaultScalerMaxReplicas()` to the `oam.Policy` interface (18 → 21 methods) and `NoopPolicy`.
- Wire consumption honoring precedence **authored > policy default > handler default**, with `MaxReplicas`/`MaxStorageSize` still enforced on the effective values:
  - **scaler**: `minReplicas`/`maxReplicas` become parse-optional; a policy default fills them when omitted. Effective-value validation (`>=1`, `max>=min`, PDB requires `min>=2`, and the `MaxReplicas` ceiling) moves into `ApplyPolicy` via a `validateEffective()` helper that is also called defensively from `Generate()`. Omitted with no policy default → error (no arbitrary handler default for scaler bounds).
  - **pvc**: `size` becomes parse-optional and is defaulted from the policy, with the same `validateEffective()`/`Generate()` bypass-safety guard; `MaxStorageSize` still enforced.
  - **postgresql**: a policy `storageSize` default overrides the hardcoded `"1Gi"` when the user did not author a value (authored > policy default > `"1Gi"`).
- `ApplyPolicy(nil)` treated as "no defaults, no caps" but still validates effective values (guards direct-`ApplyPolicy(nil)` test paths).
- Trait-local `enforce.go` helpers (`applyDefaultReplicas`/`applyDefaultResource`/`enforceMaxReplicas`/`enforceMaxStorageSize`) to avoid coupling `traits` to `components`.

## Tests / docs
- Extended every `oam.Policy` test stub; reclassified the scaler/pvc validation tests to assert failures at `ApplyPolicy`/`Generate` (not `Apply`); added default/authored/ceiling/nil-policy/bypass-safety cases and a postgresql storage-default-override test.
- Updated the traits & components READMEs and `docs/oam/options-policy-interface.md` (method count 18 → 21, new accessors).

## Downstream (separate crane MR, gated on this release)
crane bumps the launcher pin and adds the matching accessors on `*api.EnvironmentPolicy` (binding asserted in `internal/transform/policy_check.go`).
