### PR TITLE
feat(oam/expose): hostnames shorthand + platform-default ssl-redirect

### DIFF
--- a/pkg/oam/builtin/README.md
+++ b/pkg/oam/builtin/README.md
@@ -8,7 +8,9 @@ handlers (e.g. `CertificateRendering`, `ExposeRendering`, `ExternalSecretRenderi
 `DecodeStrict[T]` helper used by handlers to decode capability properties.
 
 `ExposeRendering` additionally carries `certManagerClusterIssuer` (platform-managed TLS on
-the ingress path) and `allowedHostnameWildcard` (hostname constraint for both paths).
+the ingress path), `allowedHostnameWildcard` (hostname constraint for both paths), and the
+ingress-only `sslRedirect` / `forceSslRedirect` platform defaults (author-overridable via the
+matching inline expose properties).
 
 These are internal schema types used by [`builtin/components`](components) and
 [`builtin/traits`](traits); they are not a user-facing API. See

--- a/pkg/oam/builtin/expose.go
+++ b/pkg/oam/builtin/expose.go
@@ -30,4 +30,14 @@ type ExposeRendering struct {
 	// user-supplied hostnames on both the ingress and gateway paths. Empty skips
 	// hostname validation.
 	AllowedHostnameWildcard string `yaml:"allowedHostnameWildcard,omitempty" json:"allowedHostnameWildcard,omitempty"`
+
+	// SSLRedirect is the platform default for the nginx-ingress
+	// nginx.ingress.kubernetes.io/ssl-redirect annotation. Ingress-only. A
+	// component may override it via the inline sslRedirect property.
+	SSLRedirect *bool `yaml:"sslRedirect,omitempty" json:"sslRedirect,omitempty"`
+
+	// ForceSSLRedirect is the platform default for the nginx-ingress
+	// nginx.ingress.kubernetes.io/force-ssl-redirect annotation. Ingress-only. A
+	// component may override it via the inline forceSslRedirect property.
+	ForceSSLRedirect *bool `yaml:"forceSslRedirect,omitempty" json:"forceSslRedirect,omitempty"`
 }

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -76,6 +76,12 @@ not the app — chooses the implementation:
   expose trait (use the low-level `ingress` trait for full TLS control). Both paths
   validate user hostnames against the `allowedHostnameWildcard` capability field (empty ⇒
   no validation); a violation is a `ValidationError`.
+  On the ingress path a bare `hostnames: [...]` shorthand is accepted: when `rules` is
+  absent it expands to one rule per host with `path: /` + the component service port
+  (supply `rules` for finer control; both together keep `rules` for routing while all
+  hosts are still wildcard-validated). Platform-default `ssl-redirect` / `force-ssl-redirect`
+  come from the `sslRedirect` / `forceSslRedirect` capability fields (author-overridable via
+  the same inline properties; the typed value wins over a raw same-key annotation).
 - **certificate** → `issuerRef` (cert-manager issuer/cluster-issuer).
 - **external-secret** → `secretStoreRef` (or the inline `provider` shorthand).
 

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -2,6 +2,7 @@ package traits
 
 import (
 	"maps"
+	"strconv"
 
 	"github.com/go-kure/kure/pkg/stack"
 
@@ -50,6 +51,9 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 		if r.CertManagerClusterIssuer != "" {
 			return nil, errors.New("expose rendering: certManagerClusterIssuer is only valid when controllerType is \"ingress\"")
 		}
+		if r.SSLRedirect != nil || r.ForceSSLRedirect != nil {
+			return nil, errors.New("expose rendering: sslRedirect and forceSslRedirect are only valid when controllerType is \"ingress\"")
+		}
 		if r.GatewayNamespace == "" {
 			rendering["gatewayNamespace"] = "gateway-system"
 		}
@@ -76,8 +80,10 @@ func (h *ExposeHandler) PropertySchema() map[string]oam.PropertySchema {
 		"gatewayNamespace":         {Type: oam.PropertyTypeString, Default: "gateway-system", Description: "Namespace of the Gateway (gateway controllerType only)."},
 		"annotations":              {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Additional annotations to set on the generated resource."},
 		"rules":                    {Type: oam.PropertyTypeArray, Description: "Ingress-style host rules passed through to the ingress handler.", Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single ingress-style host rule."}},
-		"hostnames":                {Type: oam.PropertyTypeArray, Description: "Gateway-style hostnames passed through to the httproute handler.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A hostname for the gateway route."}},
+		"hostnames":                {Type: oam.PropertyTypeArray, Description: "Hostnames: gateway routes, or an ingress shorthand that expands to one rule per host when rules is absent.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A hostname to route."}},
 		"ingressClassName":         {Type: oam.PropertyTypeString, Description: "IngressClass to use (ingress controllerType only)."},
+		"sslRedirect":              {Type: oam.PropertyTypeBoolean, Description: "nginx ssl-redirect annotation (ingress controllerType only); platform default via capability rendering, override-able inline."},
+		"forceSslRedirect":         {Type: oam.PropertyTypeBoolean, Description: "nginx force-ssl-redirect annotation (ingress controllerType only); platform default via capability rendering, override-able inline."},
 		"servicePort":              {Type: oam.PropertyTypeInteger, Description: "Service port to route to when the component does not expose one."},
 		"serviceName":              {Type: oam.PropertyTypeString, Description: "Service name to route to; requires servicePort to also be set."},
 		"name":                     {Type: oam.PropertyTypeString, Description: "Overrides the sub-application name, allowing multiple expose traits per component."},
@@ -103,8 +109,19 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 
 	switch controllerType {
 	case "ingress":
-		hosts := uniqueStrings(ruleHosts(props))
-		if err := validateHostnames(hosts, wildcard, app.Name); err != nil {
+		// hostnames shorthand: when hostnames is set and rules is not, synthesize
+		// one rule per host (path "/" + the component service port are defaulted by
+		// IngressHandler). hostnames is never an IngressHandler input on this path.
+		shorthand := hostnameList(props)
+		if len(shorthand) > 0 {
+			if _, hasRules := props["rules"]; !hasRules {
+				props["rules"] = expandHostnamesToIngressRules(shorthand)
+			}
+		}
+		delete(props, "hostnames")
+		// Validate every host that appears — the rules' hosts and any shorthand
+		// hostnames — against the platform wildcard, even when both are present.
+		if err := validateHostnames(uniqueStrings(append(ruleHosts(props), shorthand...)), wildcard, app.Name); err != nil {
 			return err
 		}
 		// expose is platform-managed: the user does not author TLS.
@@ -113,12 +130,29 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 			if err := setClusterIssuerAnnotation(props, issuer, app.Name); err != nil {
 				return err
 			}
-			if len(hosts) > 0 {
-				props["tls"] = synthesizedIngressTLS(hosts, app.Name)
+			// TLS covers the effective routing hosts only. When both `rules` and
+			// `hostnames` are supplied, `rules` drives routing, so a hostnames entry
+			// that is not routed must not get a synthesized certificate.
+			if routingHosts := uniqueStrings(ruleHosts(props)); len(routingHosts) > 0 {
+				props["tls"] = synthesizedIngressTLS(routingHosts, app.Name)
 			}
 		}
+		// ssl-redirect / force-ssl-redirect: typed property (capability default or
+		// inline override) wins over a same-key raw annotation.
+		setSSLRedirectAnnotations(props)
 		return (&IngressHandler{}).Apply(&oam.Trait{Type: "expose", Properties: props}, app, bundle)
 	case "gateway":
+		// ssl-redirect is nginx-ingress-specific; reject the inline properties on the
+		// gateway path (the rendering guard only covers the capability-supplied form).
+		for _, k := range []string{"sslRedirect", "forceSslRedirect"} {
+			if _, ok := props[k]; ok {
+				return &errors.ValidationError{
+					Field:     k,
+					Component: app.Name,
+					Message:   k + " is only valid when controllerType is \"ingress\"",
+				}
+			}
+		}
 		if err := validateHostnames(hostnameList(props), wildcard, app.Name); err != nil {
 			return err
 		}
@@ -181,6 +215,57 @@ func setClusterIssuerAnnotation(props map[string]any, issuer, component string) 
 	anns[clusterIssuerAnnotation] = issuer
 	props["annotations"] = anns
 	return nil
+}
+
+// expandHostnamesToIngressRules turns the hostnames shorthand into ingress rules,
+// one host per rule with a single empty path object. IngressHandler defaults the
+// path to "/" and the backend port to the component service port.
+func expandHostnamesToIngressRules(hostnames []string) []any {
+	rules := make([]any, len(hostnames))
+	for i, h := range hostnames {
+		rules[i] = map[string]any{
+			"host":  h,
+			"paths": []any{map[string]any{}},
+		}
+	}
+	return rules
+}
+
+// setSSLRedirectAnnotations writes the nginx ssl-redirect / force-ssl-redirect
+// annotations from the typed sslRedirect / forceSslRedirect properties, which carry
+// the capability-rendered platform default (override-able inline). The typed value
+// is authoritative: it is written last and wins over a same-key raw annotation. When
+// the property is absent, an existing raw annotation is left untouched. The property
+// keys are consumed here so they never reach IngressHandler.
+func setSSLRedirectAnnotations(props map[string]any) {
+	var anns map[string]any
+	set := func(key string, val bool) {
+		if anns == nil {
+			if existing, ok := props["annotations"].(map[string]any); ok {
+				anns = existing
+			} else {
+				anns = map[string]any{}
+			}
+		}
+		anns[key] = strconv.FormatBool(val)
+	}
+	if v, ok := boolProp(props, "sslRedirect"); ok {
+		set(sslRedirectAnnotation, v)
+	}
+	if v, ok := boolProp(props, "forceSslRedirect"); ok {
+		set(forceSSLRedirectAnnotation, v)
+	}
+	if anns != nil {
+		props["annotations"] = anns
+	}
+	delete(props, "sslRedirect")
+	delete(props, "forceSslRedirect")
+}
+
+// boolProp reads a boolean property; ok is false when absent or not a bool.
+func boolProp(props map[string]any, key string) (val, ok bool) {
+	val, ok = props[key].(bool)
+	return val, ok
 }
 
 // synthesizedIngressTLS builds the single managed TLS entry: all hosts under one

--- a/pkg/oam/builtin/traits/expose_shorthand_sslredirect_test.go
+++ b/pkg/oam/builtin/traits/expose_shorthand_sslredirect_test.go
@@ -1,0 +1,201 @@
+package traits_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	pkgerrors "github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+func exposeIngress(props map[string]any) *oam.Trait {
+	base := map[string]any{"controllerType": "ingress", "ingressClassName": "nginx"}
+	for k, v := range props {
+		base[k] = v
+	}
+	return &oam.Trait{Type: "expose", Properties: base}
+}
+
+// (a) hostnames shorthand → one rule per host, path "/" + component service port (80).
+func TestExposeHandler_Ingress_HostnamesShorthand(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(map[string]any{"hostnames": []any{"a.apps.example.com"}})
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.Rules) != 1 || ing.Spec.Rules[0].Host != "a.apps.example.com" {
+		t.Fatalf("rules = %+v, want single host a.apps.example.com", ing.Spec.Rules)
+	}
+	paths := ing.Spec.Rules[0].HTTP.Paths
+	if len(paths) != 1 || paths[0].Path != "/" {
+		t.Fatalf("paths = %+v, want single path /", paths)
+	}
+	if got := paths[0].Backend.Service.Port.Number; got != 80 {
+		t.Errorf("backend port = %d, want 80 (component service port)", got)
+	}
+	if ing.Spec.IngressClassName == nil || *ing.Spec.IngressClassName != "nginx" {
+		t.Errorf("ingressClassName = %v, want nginx", ing.Spec.IngressClassName)
+	}
+}
+
+// hostnames + rules together: rules drive routing (existing behavior preserved).
+func TestExposeHandler_Ingress_HostnamesAndRules(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(map[string]any{
+		"allowedHostnameWildcard": "*.apps.example.com",
+		"hostnames":               []any{"extra.apps.example.com"},
+		"rules": []any{map[string]any{
+			"host":  "main.apps.example.com",
+			"paths": []any{map[string]any{"path": "/"}},
+		}},
+	})
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.Rules) != 1 || ing.Spec.Rules[0].Host != "main.apps.example.com" {
+		t.Fatalf("rules = %+v, want routing from rules (main.apps.example.com)", ing.Spec.Rules)
+	}
+}
+
+// Reviewer pin: a shorthand hostname outside the wildcard is rejected even when the
+// rules carry an allowed host.
+func TestExposeHandler_Ingress_HostnameOutsideWildcard_RejectedWithAllowedRule(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(map[string]any{
+		"allowedHostnameWildcard": "*.apps.example.com",
+		"hostnames":               []any{"bad.other.com"},
+		"rules": []any{map[string]any{
+			"host":  "good.apps.example.com",
+			"paths": []any{map[string]any{"path": "/"}},
+		}},
+	})
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("want *ValidationError for bad.other.com, got %v", err)
+	}
+}
+
+// (b) ssl-redirect: typed property (capability default or inline) → nginx annotation.
+func TestExposeHandler_Ingress_SSLRedirect(t *testing.T) {
+	cases := []struct {
+		name      string
+		props     map[string]any
+		wantSSL   string // "" = annotation absent
+		wantForce string
+	}{
+		{"default true", map[string]any{"sslRedirect": true}, "true", ""},
+		{"override false", map[string]any{"sslRedirect": false}, "false", ""},
+		{"force true", map[string]any{"forceSslRedirect": true}, "", "true"},
+		{
+			"field beats annotation",
+			map[string]any{
+				"sslRedirect": true,
+				"annotations": map[string]any{"nginx.ingress.kubernetes.io/ssl-redirect": "false"},
+			},
+			"true", "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := &traits.ExposeHandler{}
+			app := newWebApp("web", "default")
+			bundle := &stack.Bundle{}
+			props := map[string]any{"hostnames": []any{"a.apps.example.com"}}
+			for k, v := range tc.props {
+				props[k] = v
+			}
+			if err := h.Apply(exposeIngress(props), app, bundle); err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			ing := ingressFromBundle(t, bundle)
+			if got := ing.Annotations["nginx.ingress.kubernetes.io/ssl-redirect"]; got != tc.wantSSL {
+				t.Errorf("ssl-redirect = %q, want %q", got, tc.wantSSL)
+			}
+			if got := ing.Annotations["nginx.ingress.kubernetes.io/force-ssl-redirect"]; got != tc.wantForce {
+				t.Errorf("force-ssl-redirect = %q, want %q", got, tc.wantForce)
+			}
+		})
+	}
+}
+
+// (c) coverage: capability-rendered ingressClassName lands on spec.ingressClassName.
+func TestExposeHandler_Ingress_IngressClassName(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(map[string]any{"hostnames": []any{"a.apps.example.com"}})
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if ing.Spec.IngressClassName == nil || *ing.Spec.IngressClassName != "nginx" {
+		t.Errorf("ingressClassName = %v, want nginx", ing.Spec.IngressClassName)
+	}
+}
+
+// ssl-redirect fields are ingress-only: rejected on the gateway rendering.
+func TestExposeHandler_Gateway_SSLRedirect_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "public-gateway",
+		"sslRedirect":    true,
+	})
+	if err == nil {
+		t.Fatal("want error: sslRedirect not valid for gateway")
+	}
+}
+
+// Inline ssl-redirect on a gateway expose trait is rejected at Apply time (the
+// rendering guard only covers the capability-supplied form).
+func TestExposeHandler_Gateway_InlineSSLRedirect_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{Type: "expose", Properties: map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "public-gateway",
+		"sslRedirect":    true,
+	}}
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("want *ValidationError for inline sslRedirect on gateway, got %v", err)
+	}
+}
+
+// Managed TLS covers the effective routing hosts only: with both rules and hostnames,
+// a hostnames entry that is not routed by rules must not get a synthesized cert.
+func TestExposeHandler_Ingress_ManagedTLS_RoutingHostsOnly(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(map[string]any{
+		"certManagerClusterIssuer": "letsencrypt",
+		"allowedHostnameWildcard":  "*.apps.example.com",
+		"hostnames":                []any{"extra.apps.example.com"}, // validated, not routed
+		"rules": []any{map[string]any{
+			"host":  "main.apps.example.com",
+			"paths": []any{map[string]any{"path": "/"}},
+		}},
+	})
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.TLS) != 1 || len(ing.Spec.TLS[0].Hosts) != 1 || ing.Spec.TLS[0].Hosts[0] != "main.apps.example.com" {
+		t.Fatalf("TLS = %+v, want a single entry for main.apps.example.com only (extra.apps.example.com not routed)", ing.Spec.TLS)
+	}
+}

--- a/pkg/oam/builtin/traits/hostname.go
+++ b/pkg/oam/builtin/traits/hostname.go
@@ -11,6 +11,14 @@ import (
 // the ClusterIssuer used to provision the ingress TLS certificate.
 const clusterIssuerAnnotation = "cert-manager.io/cluster-issuer"
 
+// sslRedirectAnnotation / forceSSLRedirectAnnotation are the nginx-ingress
+// annotations the expose trait writes from its sslRedirect / forceSslRedirect
+// properties (platform default via capability rendering, override-able inline).
+const (
+	sslRedirectAnnotation      = "nginx.ingress.kubernetes.io/ssl-redirect"
+	forceSSLRedirectAnnotation = "nginx.ingress.kubernetes.io/force-ssl-redirect"
+)
+
 // matchHostnameWildcard reports whether host is permitted by pattern. An empty
 // pattern permits everything. A pattern without a leading "*." must match host
 // exactly. A "*.suffix" pattern matches exactly one DNS label in place of the


### PR DESCRIPTION
Closes go-kure/launcher#190. Companion to crane#320.

## What

Two additions to the `expose` trait **ingress** path, plus a test pinning the already-working ingressClassName default.

- **(a) `hostnames:` shorthand** — when `hostnames` is set and `rules` is absent, synthesize one ingress rule per host; `IngressHandler` defaults `path: /` + the component service port. **No hard XOR**: `hostnames` + `rules` together preserves current behavior (rules drive routing), and every host — rule hosts *and* shorthand hostnames — is validated against `allowedHostnameWildcard`.
- **(b) platform-default `ssl-redirect`/`force-ssl-redirect`** — new `sslRedirect`/`forceSslRedirect` on `ExposeRendering` (capability-rendered default) and the expose PropertySchema (author-facing override). `Apply` writes the nginx annotations from the merged value, gated on `controllerType: ingress`. Typed field is authoritative (wins over a same-key raw annotation); absent → raw annotation preserved. Rejected on the gateway path.
- **(c)** `ingressClassName` default already works (`ExposeRendering.IngressClassName` → `spec.ingressClassName`) — added a test.

## Tests

New `expose_shorthand_sslredirect_test.go`: shorthand→rules (path `/` + port 80), both-present routing, hostname-outside-wildcard rejection with an allowed rule host, ssl-redirect default/override-false/force/field-beats-annotation, ingressClassName passthrough, gateway ingress-only guard. Full `go test ./...`, `go vet`, `golangci-lint` all green.

Held for review + release; crane#320 bumps the pin and adds the capability-rendering data + expose scenarios once this ships.