### PR TITLE
feat(oam): add Description to PropertySchema + populate builtin handler descriptions

### DIFF
--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -369,6 +370,62 @@ func assertExposesSchema(t *testing.T, kind, name string, h any) {
 	if p.PropertySchema() == nil {
 		t.Errorf("%s handler %q returns a nil PropertySchema map", kind, name)
 	}
+}
+
+// TestBuiltinHandlerSchemaDescriptions asserts that every built-in handler's
+// PropertySchema carries a non-empty Description on every node at every depth —
+// each top-level property, each nested Properties field, and each array Items
+// schema, recursively. Crane renders these in its Handler API Reference; a blank
+// description shows as an empty table row, including on the deepest nested
+// tables. It iterates the same registration maps as the parity test above so it
+// covers exactly the set crane renders.
+func TestBuiltinHandlerSchemaDescriptions(t *testing.T) {
+	for name, h := range builtinComponentHandlers() {
+		assertSchemaDescribed(t, "component", name, h)
+	}
+	for name, h := range builtinTraitHandlers() {
+		assertSchemaDescribed(t, "trait", name, h)
+	}
+}
+
+// assertSchemaDescribed walks a handler's top-level PropertySchema entries. A
+// handler that exposes no properties (e.g. prune-protection's empty map) has
+// nothing to walk and passes.
+func assertSchemaDescribed(t *testing.T, kind, name string, h any) {
+	t.Helper()
+	p, ok := h.(oam.PropertySchemaProvider)
+	if !ok {
+		return // TestNewBuiltinTransformer_HandlerSchemaParity already flags this.
+	}
+	schema := p.PropertySchema()
+	for _, k := range sortedSchemaKeys(schema) {
+		assertDescribed(t, fmt.Sprintf("%s %s.%s", kind, name, k), schema[k])
+	}
+}
+
+// assertDescribed fails if node — or any nested Properties value or Items schema,
+// recursively — has a blank (or whitespace-only) Description. Keys are sorted so
+// failure output is deterministic.
+func assertDescribed(t *testing.T, path string, node oam.PropertySchema) {
+	t.Helper()
+	if strings.TrimSpace(node.Description) == "" {
+		t.Errorf("%s: PropertySchema node has empty Description", path)
+	}
+	for _, k := range sortedSchemaKeys(node.Properties) {
+		assertDescribed(t, path+"."+k, node.Properties[k])
+	}
+	if node.Items != nil {
+		assertDescribed(t, path+"[]", *node.Items)
+	}
+}
+
+func sortedSchemaKeys(m map[string]oam.PropertySchema) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // --- Parameter substitution tests ---

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -57,11 +57,16 @@ parse → resolve parameters → transform (component + trait handlers) → mani
 Handlers may implement `PropertySchemaProvider` (`PropertySchema() map[string]PropertySchema`)
 to declare a constrained schema for their user-facing properties. `PropertySchema` is the
 richer sibling of `CapabilityPropertySchema`: `Type` (string/integer/boolean/number/array/object),
-`Required`, `Default`, `Enum`, nested `Properties`, `Items`, and `AdditionalProperties` (default
-false; escape-hatch fields set it true). `Transformer.HandlerSchemas()` returns a
+`Description`, `Required`, `Default`, `Enum`, nested `Properties`, `Items`, and `AdditionalProperties`
+(default false; escape-hatch fields set it true). `Transformer.HandlerSchemas()` returns a
 `HandlerSchemaSet{ Components, Traits }` of every registered handler that declares one, so crane's
 validator can check a component/trait's properties before the handler is invoked. Built-in
 examples: the `configmap` trait and the `passthrough` component.
+
+`Description` is optional (`json:"description,omitempty"`) but every built-in property populates it —
+including nested object fields and array item schemas at every depth — so crane can surface prose in
+its generated Handler API Reference. A completeness test (`pkg/cmd/kurel`) enforces that no built-in
+schema node is left without a description.
 
 ## Policy defaults & enforcement
 

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -12,7 +12,9 @@ mapping a component `type` string to a handler implementing `CanHandle` +
 user-facing properties so crane can validate them before invocation. Deeply nested or
 K8s-adjacent shapes are kept shallow/open (`additionalProperties`) rather than modeled
 field-by-field; escape-hatch fields (e.g. `passthrough.object`, `manifests`/`crd` inline
-content) stay open by design.
+content) stay open by design. Every property (including nested object fields and array item
+schemas at every depth) carries a `Description`, surfaced in crane's generated Handler API
+Reference.
 
 ## Component types
 

--- a/pkg/oam/builtin/components/crd.go
+++ b/pkg/oam/builtin/components/crd.go
@@ -21,8 +21,8 @@ func (h *CRDHandler) CanHandle(componentType string) bool { return componentType
 // parseManifestSource and is not expressible in the schema vocabulary.
 func (h *CRDHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"inline": {Type: oam.PropertyTypeString},
-		"url":    {Type: oam.PropertyTypeString},
+		"inline": {Type: oam.PropertyTypeString, Description: "Raw CRD YAML emitted inline (mutually exclusive with url)."},
+		"url":    {Type: oam.PropertyTypeString, Description: "URL of the CRD YAML source (mutually exclusive with inline)."},
 	}
 }
 

--- a/pkg/oam/builtin/components/cronjob.go
+++ b/pkg/oam/builtin/components/cronjob.go
@@ -27,11 +27,11 @@ func (h *CronjobHandler) CanHandle(componentType string) bool {
 // PropertySchema declares the cronjob component's user-facing properties.
 func (h *CronjobHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"image":                      {Type: oam.PropertyTypeString, Required: true},
-		"schedule":                   {Type: oam.PropertyTypeString, Required: true},
-		"restartPolicy":              {Type: oam.PropertyTypeString, Default: "OnFailure", Enum: []any{"Never", "OnFailure"}},
-		"successfulJobsHistoryLimit": {Type: oam.PropertyTypeInteger, Default: 3},
-		"failedJobsHistoryLimit":     {Type: oam.PropertyTypeInteger, Default: 1},
+		"image":                      {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference for the job container."},
+		"schedule":                   {Type: oam.PropertyTypeString, Required: true, Description: "Cron schedule in standard 5-field format (e.g. \"0 2 * * *\")."},
+		"restartPolicy":              {Type: oam.PropertyTypeString, Default: "OnFailure", Enum: []any{"Never", "OnFailure"}, Description: "Pod restart policy for the job's containers."},
+		"successfulJobsHistoryLimit": {Type: oam.PropertyTypeInteger, Default: 3, Description: "Number of successful finished jobs to retain."},
+		"failedJobsHistoryLimit":     {Type: oam.PropertyTypeInteger, Default: 1, Description: "Number of failed finished jobs to retain."},
 		"env":                        schemaEnv(),
 		"resources":                  schemaResources(),
 		"command":                    schemaStringArray(),

--- a/pkg/oam/builtin/components/daemonset.go
+++ b/pkg/oam/builtin/components/daemonset.go
@@ -23,8 +23,8 @@ func (h *DaemonsetHandler) CanHandle(componentType string) bool {
 // PropertySchema declares the daemonset component's user-facing properties.
 func (h *DaemonsetHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"image":          {Type: oam.PropertyTypeString, Required: true},
-		"port":           {Type: oam.PropertyTypeInteger},
+		"image":          {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference for the main container."},
+		"port":           {Type: oam.PropertyTypeInteger, Description: "Container port to expose; when set, a ClusterIP Service is generated."},
 		"env":            schemaEnv(),
 		"resources":      schemaResources(),
 		"command":        schemaStringArray(),

--- a/pkg/oam/builtin/components/helmchart.go
+++ b/pkg/oam/builtin/components/helmchart.go
@@ -32,20 +32,22 @@ func (h *HelmchartHandler) CanHandle(componentType string) bool {
 // Helm `values` tree and the Flux-shaped source/driftDetection/install/upgrade
 // blocks are kept open (AdditionalProperties) rather than modeled field-by-field.
 func (h *HelmchartHandler) PropertySchema() map[string]oam.PropertySchema {
-	openObject := oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}
+	openObject := func(desc string) oam.PropertySchema {
+		return oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: desc}
+	}
 	return map[string]oam.PropertySchema{
-		"chart":           {Type: oam.PropertyTypeString},
-		"version":         {Type: oam.PropertyTypeString},
-		"delivery":        {Type: oam.PropertyTypeString, Default: "native", Enum: []any{"native", "template"}},
-		"interval":        {Type: oam.PropertyTypeString},
-		"releaseName":     {Type: oam.PropertyTypeString},
-		"targetNamespace": {Type: oam.PropertyTypeString},
-		"source":          {Type: oam.PropertyTypeObject, Required: true, AdditionalProperties: true},
-		"values":          openObject,
-		"driftDetection":  openObject,
-		"install":         openObject,
-		"upgrade":         openObject,
-		"valuesFrom":      {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}},
+		"chart":           {Type: oam.PropertyTypeString, Description: "Chart name within a HelmRepository source."},
+		"version":         {Type: oam.PropertyTypeString, Description: "Chart version to install."},
+		"delivery":        {Type: oam.PropertyTypeString, Default: "native", Enum: []any{"native", "template"}, Description: "Delivery mode: native emits a HelmRelease, template renders the chart client-side."},
+		"interval":        {Type: oam.PropertyTypeString, Description: "Reconciliation interval as a Go duration (default 60m)."},
+		"releaseName":     {Type: oam.PropertyTypeString, Description: "Helm release name (defaults to the component name)."},
+		"targetNamespace": {Type: oam.PropertyTypeString, Description: "Namespace into which the HelmRelease installs resources."},
+		"source":          {Type: oam.PropertyTypeObject, Required: true, AdditionalProperties: true, Description: "Chart source: an inline url, or a reference (name/kind) to an existing source CR."},
+		"values":          openObject("Helm values tree passed to the release."),
+		"driftDetection":  openObject("Flux drift detection settings (mode: enabled, warn, or disabled)."),
+		"install":         openObject("Helm install options (e.g. crds: Skip, Create, or CreateReplace)."),
+		"upgrade":         openObject("Helm upgrade options (e.g. crds: Skip, Create, or CreateReplace)."),
+		"valuesFrom":      {Type: oam.PropertyTypeArray, Description: "References to ConfigMaps or Secrets supplying additional Helm values.", Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single ConfigMap or Secret values reference (kind, name, valuesKey, targetPath)."}},
 	}
 }
 

--- a/pkg/oam/builtin/components/manifests.go
+++ b/pkg/oam/builtin/components/manifests.go
@@ -23,16 +23,18 @@ func (h *ManifestsHandler) CanHandle(componentType string) bool { return compone
 // parseManifestSource); `scopeOverrides` supplies scope for unknown kinds.
 func (h *ManifestsHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"inline": {Type: oam.PropertyTypeString},
-		"url":    {Type: oam.PropertyTypeString},
+		"inline": {Type: oam.PropertyTypeString, Description: "Raw multi-document manifest YAML emitted inline (mutually exclusive with url)."},
+		"url":    {Type: oam.PropertyTypeString, Description: "URL of the manifest YAML source (mutually exclusive with inline)."},
 		"scopeOverrides": {
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: "Explicit scope entries for kinds whose scope is otherwise unknown.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A single scope override for one apiVersion/kind.",
 				Properties: map[string]oam.PropertySchema{
-					"apiVersion": {Type: oam.PropertyTypeString, Required: true},
-					"kind":       {Type: oam.PropertyTypeString, Required: true},
-					"scope":      {Type: oam.PropertyTypeString, Required: true, Enum: []any{"Cluster", "Namespaced"}},
+					"apiVersion": {Type: oam.PropertyTypeString, Required: true, Description: "API version of the kind whose scope is being overridden."},
+					"kind":       {Type: oam.PropertyTypeString, Required: true, Description: "Kind whose scope is being overridden."},
+					"scope":      {Type: oam.PropertyTypeString, Required: true, Enum: []any{"Cluster", "Namespaced"}, Description: "Whether the kind is cluster-scoped or namespaced."},
 				},
 			},
 		},

--- a/pkg/oam/builtin/components/oci.go
+++ b/pkg/oam/builtin/components/oci.go
@@ -30,17 +30,18 @@ func (h *OCIHandler) CanHandle(componentType string) bool { return componentType
 func (h *OCIHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"source": {
-			Type:     oam.PropertyTypeObject,
-			Required: true,
+			Type:        oam.PropertyTypeObject,
+			Required:    true,
+			Description: "OCIRepository source of the artifact to reconcile.",
 			Properties: map[string]oam.PropertySchema{
-				"url": {Type: oam.PropertyTypeString, Required: true},
+				"url": {Type: oam.PropertyTypeString, Required: true, Description: "OCI artifact URL (must use the oci:// scheme)."},
 			},
 		},
-		"version":         {Type: oam.PropertyTypeString, Required: true},
-		"path":            {Type: oam.PropertyTypeString, Default: "./"},
-		"prune":           {Type: oam.PropertyTypeBoolean, Default: true},
-		"interval":        {Type: oam.PropertyTypeString},
-		"targetNamespace": {Type: oam.PropertyTypeString},
+		"version":         {Type: oam.PropertyTypeString, Required: true, Description: "Artifact version to reconcile: a tag or sha256:<digest>."},
+		"path":            {Type: oam.PropertyTypeString, Default: "./", Description: "Path within the artifact that the Kustomization reconciles."},
+		"prune":           {Type: oam.PropertyTypeBoolean, Default: true, Description: "Whether the Kustomization prunes resources removed from the source."},
+		"interval":        {Type: oam.PropertyTypeString, Description: "Reconciliation interval as a Go duration (default 60m)."},
+		"targetNamespace": {Type: oam.PropertyTypeString, Description: "Namespace into which the Kustomization applies resources."},
 	}
 }
 

--- a/pkg/oam/builtin/components/passthrough.go
+++ b/pkg/oam/builtin/components/passthrough.go
@@ -32,8 +32,8 @@ func (h *PassthroughHandler) CanHandle(componentType string) bool {
 // escape-hatch body emitted verbatim, so it is an open object (additionalProperties).
 func (h *PassthroughHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"object":        {Type: oam.PropertyTypeObject, Required: true, AdditionalProperties: true},
-		"clusterScoped": {Type: oam.PropertyTypeBoolean, Default: false},
+		"object":        {Type: oam.PropertyTypeObject, Required: true, AdditionalProperties: true, Description: "The Kubernetes object emitted verbatim (apiVersion, kind, metadata, and any body fields)."},
+		"clusterScoped": {Type: oam.PropertyTypeBoolean, Default: false, Description: "Whether the emitted object is cluster-scoped, suppressing namespace stamping."},
 	}
 }
 

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -24,27 +24,37 @@ func (h *PostgresqlHandler) CanHandle(componentType string) bool {
 // …) are deep and K8s-adjacent, so they are kept open (AdditionalProperties)
 // rather than modeled field-by-field.
 func (h *PostgresqlHandler) PropertySchema() map[string]oam.PropertySchema {
-	openObject := oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}
-	openArray := oam.PropertySchema{Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}}
+	// The CNPG-shaped sub-objects are kept open; each reuses the same open shape
+	// but carries its own description, so a per-key helper supplies the prose.
+	openObj := func(desc string) oam.PropertySchema {
+		return oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: desc}
+	}
+	openArr := func(desc, itemDesc string) oam.PropertySchema {
+		return oam.PropertySchema{
+			Type:        oam.PropertyTypeArray,
+			Description: desc,
+			Items:       &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: itemDesc},
+		}
+	}
 	return map[string]oam.PropertySchema{
-		"provider":          {Type: oam.PropertyTypeString, Default: "cnpg", Enum: []any{"cnpg"}},
-		"version":           {Type: oam.PropertyTypeString, Default: "16"},
-		"storageSize":       {Type: oam.PropertyTypeString, Default: "1Gi"},
-		"replicas":          {Type: oam.PropertyTypeInteger, Default: 1},
-		"imageName":         {Type: oam.PropertyTypeString},
+		"provider":          {Type: oam.PropertyTypeString, Default: "cnpg", Enum: []any{"cnpg"}, Description: "Database provider (only cnpg is supported)."},
+		"version":           {Type: oam.PropertyTypeString, Default: "16", Description: "PostgreSQL major version for the cluster image."},
+		"storageSize":       {Type: oam.PropertyTypeString, Default: "1Gi", Description: "Persistent storage size requested for each instance."},
+		"replicas":          {Type: oam.PropertyTypeInteger, Default: 1, Description: "Number of PostgreSQL instances in the cluster."},
+		"imageName":         {Type: oam.PropertyTypeString, Description: "Override for the container image (defaults to the CloudNativePG image for the version)."},
 		"resources":         schemaResources(),
-		"backup":            openObject,
-		"monitoring":        openObject,
-		"pooler":            openObject,
-		"bootstrap":         openObject,
-		"replication":       openObject,
-		"postgresql":        openObject,
-		"inheritedMetadata": openObject,
-		"objectStore":       openObject,
-		"affinity":          openObject,
-		"externalClusters":  openArray,
-		"managedRoles":      openArray,
-		"databases":         openArray,
+		"backup":            openObj("Barman object-store backup settings (retentionPolicy, destinationPath, endpointURL, secretName)."),
+		"monitoring":        openObj("Monitoring settings, including the PodMonitor toggle and custom queries."),
+		"pooler":            openObj("PgBouncer connection pooler settings (enabled, instances, type, poolMode, parameters)."),
+		"bootstrap":         openObj("Cluster bootstrap source (recovery or pg_basebackup)."),
+		"replication":       openObj("Synchronous replication settings (method, number, dataDurability)."),
+		"postgresql":        openObj("PostgreSQL server settings, including the parameters map."),
+		"inheritedMetadata": openObj("Labels and annotations propagated to the generated resources."),
+		"objectStore":       openObj("Barman Cloud ObjectStore settings for backups (destinationPath, endpointURL, secretName, retentionPolicy, serverName)."),
+		"affinity":          openObj("Pod affinity and anti-affinity scheduling settings."),
+		"externalClusters":  openArr("External clusters referenced for bootstrap or replica sources.", "A single external cluster definition."),
+		"managedRoles":      openArr("Database roles created and reconciled by the operator.", "A single managed role definition."),
+		"databases":         openArr("Databases created and reconciled within the cluster.", "A single database definition."),
 	}
 }
 

--- a/pkg/oam/builtin/components/schema.go
+++ b/pkg/oam/builtin/components/schema.go
@@ -19,13 +19,15 @@ func accessModesEnum() []any {
 // kept open — it carries secretKeyRef/configMapKeyRef sub-objects.
 func schemaEnv() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeArray,
+		Type:        oam.PropertyTypeArray,
+		Description: "Environment variables to set on the container.",
 		Items: &oam.PropertySchema{
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "A single environment variable.",
 			Properties: map[string]oam.PropertySchema{
-				"name":      {Type: oam.PropertyTypeString, Required: true},
-				"value":     {Type: oam.PropertyTypeString},
-				"valueFrom": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+				"name":      {Type: oam.PropertyTypeString, Required: true, Description: "Environment variable name."},
+				"value":     {Type: oam.PropertyTypeString, Description: "Literal value for the variable."},
+				"valueFrom": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Source the value from another object (e.g. secretKeyRef or configMapKeyRef)."},
 			},
 		},
 	}
@@ -37,15 +39,16 @@ func schemaResources() oam.PropertySchema {
 	// sub-map state (honoring the file-level freshness contract above).
 	quantity := func() map[string]oam.PropertySchema {
 		return map[string]oam.PropertySchema{
-			"cpu":    {Type: oam.PropertyTypeString},
-			"memory": {Type: oam.PropertyTypeString},
+			"cpu":    {Type: oam.PropertyTypeString, Description: `CPU quantity (e.g. "500m" or "1").`},
+			"memory": {Type: oam.PropertyTypeString, Description: `Memory quantity (e.g. "512Mi" or "1Gi").`},
 		}
 	}
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Compute resource requests and limits for the container.",
 		Properties: map[string]oam.PropertySchema{
-			"requests": {Type: oam.PropertyTypeObject, Properties: quantity()},
-			"limits":   {Type: oam.PropertyTypeObject, Properties: quantity()},
+			"requests": {Type: oam.PropertyTypeObject, Description: "Minimum resources guaranteed to the container.", Properties: quantity()},
+			"limits":   {Type: oam.PropertyTypeObject, Description: "Maximum resources the container may use.", Properties: quantity()},
 		},
 	}
 }
@@ -53,8 +56,9 @@ func schemaResources() oam.PropertySchema {
 // schemaStringArray describes an array-of-strings property (command/args).
 func schemaStringArray() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type:  oam.PropertyTypeArray,
-		Items: &oam.PropertySchema{Type: oam.PropertyTypeString},
+		Type:        oam.PropertyTypeArray,
+		Description: "A list of string values (e.g. command or args).",
+		Items:       &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A single string value."},
 	}
 }
 
@@ -62,13 +66,16 @@ func schemaStringArray() oam.PropertySchema {
 // probe carries an int-or-string port and many optional K8s fields, so the
 // individual probe objects are kept open.
 func schemaProbes() oam.PropertySchema {
-	probe := oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}
+	probe := func(desc string) oam.PropertySchema {
+		return oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: desc}
+	}
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Health probes for the container.",
 		Properties: map[string]oam.PropertySchema{
-			"readiness": probe,
-			"liveness":  probe,
-			"startup":   probe,
+			"readiness": probe("Readiness probe determining when the container can receive traffic."),
+			"liveness":  probe("Liveness probe determining when the container should be restarted."),
+			"startup":   probe("Startup probe determining when the container has finished starting."),
 		},
 	}
 }
@@ -78,15 +85,17 @@ func schemaProbes() oam.PropertySchema {
 // open beyond the common fields.
 func schemaVolumes() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeArray,
+		Type:        oam.PropertyTypeArray,
+		Description: "Volumes to attach and mount into the container.",
 		Items: &oam.PropertySchema{
 			Type:                 oam.PropertyTypeObject,
 			AdditionalProperties: true,
+			Description:          "A single volume and its mount.",
 			Properties: map[string]oam.PropertySchema{
-				"name":      {Type: oam.PropertyTypeString, Required: true},
-				"type":      {Type: oam.PropertyTypeString, Enum: []any{"hostPath", "emptyDir", "pvc", "configMap", "secret"}},
-				"mountPath": {Type: oam.PropertyTypeString, Required: true},
-				"readOnly":  {Type: oam.PropertyTypeBoolean},
+				"name":      {Type: oam.PropertyTypeString, Required: true, Description: "Volume name."},
+				"type":      {Type: oam.PropertyTypeString, Enum: []any{"hostPath", "emptyDir", "pvc", "configMap", "secret"}, Description: "Volume source type."},
+				"mountPath": {Type: oam.PropertyTypeString, Required: true, Description: "Path where the volume is mounted in the container."},
+				"readOnly":  {Type: oam.PropertyTypeBoolean, Description: "Mount the volume read-only."},
 			},
 		},
 	}
@@ -97,13 +106,15 @@ func schemaVolumes() oam.PropertySchema {
 // volumeMounts/ports shapes are kept open on the item object.
 func schemaContainers() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeArray,
+		Type:        oam.PropertyTypeArray,
+		Description: "Additional containers to run in the pod (init containers or sidecars).",
 		Items: &oam.PropertySchema{
 			Type:                 oam.PropertyTypeObject,
 			AdditionalProperties: true,
+			Description:          "A single container definition.",
 			Properties: map[string]oam.PropertySchema{
-				"name":  {Type: oam.PropertyTypeString, Required: true},
-				"image": {Type: oam.PropertyTypeString, Required: true},
+				"name":  {Type: oam.PropertyTypeString, Required: true, Description: "Container name."},
+				"image": {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference."},
 			},
 		},
 	}
@@ -112,12 +123,13 @@ func schemaContainers() oam.PropertySchema {
 // schemaAffinity describes the shared `affinity` property (see parseAffinity).
 func schemaAffinity() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Pod affinity and anti-affinity scheduling rules.",
 		Properties: map[string]oam.PropertySchema{
-			"enablePodAntiAffinity": {Type: oam.PropertyTypeBoolean},
-			"topologyKey":           {Type: oam.PropertyTypeString, Default: "kubernetes.io/hostname"},
-			"podAntiAffinityType":   {Type: oam.PropertyTypeString, Default: "preferred", Enum: []any{"preferred", "required"}},
-			"nodeSelector":          {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+			"enablePodAntiAffinity": {Type: oam.PropertyTypeBoolean, Description: "Spread pods across nodes using pod anti-affinity."},
+			"topologyKey":           {Type: oam.PropertyTypeString, Default: "kubernetes.io/hostname", Description: "Node topology key the anti-affinity rule is evaluated against."},
+			"podAntiAffinityType":   {Type: oam.PropertyTypeString, Default: "preferred", Enum: []any{"preferred", "required"}, Description: "Whether anti-affinity is a soft preference or a hard requirement."},
+			"nodeSelector":          {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Node labels the pod must match to be scheduled."},
 		},
 	}
 }
@@ -125,14 +137,16 @@ func schemaAffinity() oam.PropertySchema {
 // schemaTolerations describes the shared `tolerations` property (see parseTolerations).
 func schemaTolerations() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeArray,
+		Type:        oam.PropertyTypeArray,
+		Description: "Node taint tolerations allowing the pod to schedule onto tainted nodes.",
 		Items: &oam.PropertySchema{
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "A single taint toleration.",
 			Properties: map[string]oam.PropertySchema{
-				"key":      {Type: oam.PropertyTypeString},
-				"operator": {Type: oam.PropertyTypeString, Enum: []any{"Exists", "Equal"}},
-				"value":    {Type: oam.PropertyTypeString},
-				"effect":   {Type: oam.PropertyTypeString, Enum: []any{"NoSchedule", "PreferNoSchedule", "NoExecute", ""}},
+				"key":      {Type: oam.PropertyTypeString, Description: "Taint key to tolerate."},
+				"operator": {Type: oam.PropertyTypeString, Enum: []any{"Exists", "Equal"}, Description: "How the taint key/value are matched."},
+				"value":    {Type: oam.PropertyTypeString, Description: "Taint value to match when operator is Equal."},
+				"effect":   {Type: oam.PropertyTypeString, Enum: []any{"NoSchedule", "PreferNoSchedule", "NoExecute", ""}, Description: "Taint effect to tolerate (empty matches all effects)."},
 			},
 		},
 	}
@@ -142,15 +156,17 @@ func schemaTolerations() oam.PropertySchema {
 // (see parseVolumeClaimTemplates).
 func schemaVolumeClaimTemplates() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeArray,
+		Type:        oam.PropertyTypeArray,
+		Description: "PersistentVolumeClaim templates provisioned per replica.",
 		Items: &oam.PropertySchema{
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "A single volume claim template.",
 			Properties: map[string]oam.PropertySchema{
-				"name":         {Type: oam.PropertyTypeString, Required: true},
-				"size":         {Type: oam.PropertyTypeString, Required: true},
-				"mountPath":    {Type: oam.PropertyTypeString, Required: true},
-				"storageClass": {Type: oam.PropertyTypeString},
-				"accessModes":  {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Enum: accessModesEnum()}},
+				"name":         {Type: oam.PropertyTypeString, Required: true, Description: "Claim name (also used as the mount name)."},
+				"size":         {Type: oam.PropertyTypeString, Required: true, Description: `Requested storage size (e.g. "10Gi").`},
+				"mountPath":    {Type: oam.PropertyTypeString, Required: true, Description: "Path where the claim is mounted in the container."},
+				"storageClass": {Type: oam.PropertyTypeString, Description: "StorageClass used to provision the volume."},
+				"accessModes":  {Type: oam.PropertyTypeArray, Description: "Requested access modes for the volume.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Enum: accessModesEnum(), Description: "A single access mode."}},
 			},
 		},
 	}

--- a/pkg/oam/builtin/components/statefulset.go
+++ b/pkg/oam/builtin/components/statefulset.go
@@ -24,10 +24,10 @@ func (h *StatefulsetHandler) CanHandle(componentType string) bool {
 // PropertySchema declares the statefulset component's user-facing properties.
 func (h *StatefulsetHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"image":                {Type: oam.PropertyTypeString, Required: true},
-		"replicas":             {Type: oam.PropertyTypeInteger, Default: 1},
-		"port":                 {Type: oam.PropertyTypeInteger},
-		"serviceName":          {Type: oam.PropertyTypeString},
+		"image":                {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference for the main container."},
+		"replicas":             {Type: oam.PropertyTypeInteger, Default: 1, Description: "Number of StatefulSet pod replicas."},
+		"port":                 {Type: oam.PropertyTypeInteger, Description: "Container port to expose via the headless Service."},
+		"serviceName":          {Type: oam.PropertyTypeString, Description: "Name of the headless Service (defaults to the component name)."},
 		"env":                  schemaEnv(),
 		"resources":            schemaResources(),
 		"command":              schemaStringArray(),

--- a/pkg/oam/builtin/components/webservice.go
+++ b/pkg/oam/builtin/components/webservice.go
@@ -23,10 +23,10 @@ func (h *WebserviceHandler) CanHandle(componentType string) bool {
 // PropertySchema declares the webservice component's user-facing properties.
 func (h *WebserviceHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"image":          {Type: oam.PropertyTypeString, Required: true},
-		"port":           {Type: oam.PropertyTypeInteger, Default: 80},
-		"replicas":       {Type: oam.PropertyTypeInteger, Default: 1},
-		"topologySpread": {Type: oam.PropertyTypeBoolean, Default: true},
+		"image":          {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference for the main container."},
+		"port":           {Type: oam.PropertyTypeInteger, Default: 80, Description: "Container port exposed by the Deployment and its ClusterIP Service."},
+		"replicas":       {Type: oam.PropertyTypeInteger, Default: 1, Description: "Number of Deployment pod replicas."},
+		"topologySpread": {Type: oam.PropertyTypeBoolean, Default: true, Description: "Whether default topology spread constraints are applied across nodes."},
 		"env":            schemaEnv(),
 		"resources":      schemaResources(),
 		"command":        schemaStringArray(),

--- a/pkg/oam/builtin/components/worker.go
+++ b/pkg/oam/builtin/components/worker.go
@@ -23,9 +23,9 @@ func (h *WorkerHandler) CanHandle(componentType string) bool {
 // webservice minus `port` (worker emits no Service).
 func (h *WorkerHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"image":          {Type: oam.PropertyTypeString, Required: true},
-		"replicas":       {Type: oam.PropertyTypeInteger, Default: 1},
-		"topologySpread": {Type: oam.PropertyTypeBoolean, Default: true},
+		"image":          {Type: oam.PropertyTypeString, Required: true, Description: "Container image reference for the main container."},
+		"replicas":       {Type: oam.PropertyTypeInteger, Default: 1, Description: "Number of Deployment pod replicas."},
+		"topologySpread": {Type: oam.PropertyTypeBoolean, Default: true, Description: "Whether default topology spread constraints are applied across nodes."},
 		"env":            schemaEnv(),
 		"resources":      schemaResources(),
 		"command":        schemaStringArray(),

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -14,7 +14,9 @@ crane can validate them before invocation. This includes the platform-reserved k
 handler reads from merged properties (e.g. `networkPolicy`, `allowedHostnameWildcard`,
 `controllerType`). Deeply nested or K8s-adjacent shapes are kept shallow/open
 (`additionalProperties`) rather than modeled field-by-field; `prune-protection` accepts no
-properties and so declares an empty schema.
+properties and so declares an empty schema. Every property (including nested object fields and
+array item schemas at every depth) carries a `Description`, surfaced in crane's generated Handler
+API Reference.
 
 Capability-injected fields are **not** marked `Required` in a handler's schema, because
 they are supplied by capability rendering (validated in `ValidateAndApplyDefaults`), not by

--- a/pkg/oam/builtin/traits/certificate.go
+++ b/pkg/oam/builtin/traits/certificate.go
@@ -48,31 +48,33 @@ func (h *CertificateHandler) ValidateAndApplyDefaults(rendering map[string]any) 
 // PropertySchema declares the certificate trait's user-facing properties.
 func (h *CertificateHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"secretName": {Type: oam.PropertyTypeString, Required: true},
+		"secretName": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the Secret that stores the issued certificate and its private key."},
 		// issuerRef is capability-injected (CapabilityRequired; validated in
 		// ValidateAndApplyDefaults), so the parent is NOT user-required. If a user does
 		// supply issuerRef, its name is still required so `issuerRef: {}` fails in schema
 		// preflight rather than later in parseProperties.
 		"issuerRef": {
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "Reference to the cert-manager issuer that signs the certificate (normally capability-injected).",
 			Properties: map[string]oam.PropertySchema{
-				"name": {Type: oam.PropertyTypeString, Required: true},
-				"kind": {Type: oam.PropertyTypeString, Default: "ClusterIssuer"},
+				"name": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the issuer to sign the certificate."},
+				"kind": {Type: oam.PropertyTypeString, Default: "ClusterIssuer", Description: "Issuer kind (Issuer or ClusterIssuer)."},
 			},
 		},
-		"dnsNames":    {Type: oam.PropertyTypeArray, Required: true, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
-		"duration":    {Type: oam.PropertyTypeString, Default: "2160h"},
-		"renewBefore": {Type: oam.PropertyTypeString, Default: "360h"},
+		"dnsNames":    {Type: oam.PropertyTypeArray, Required: true, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A DNS name (SAN) to include in the certificate."}, Description: "DNS names the certificate is issued for."},
+		"duration":    {Type: oam.PropertyTypeString, Default: "2160h", Description: "Total validity duration of the certificate as a Go duration (e.g. 2160h)."},
+		"renewBefore": {Type: oam.PropertyTypeString, Default: "360h", Description: "How long before expiry cert-manager renews the certificate, as a Go duration."},
 		// privateKey is user-authored (not capability-injected) and optional; when
 		// omitted cert-manager applies its own defaults (RSA 2048). algorithm-specific
 		// size validation is enforced in parseProperties, not the schema.
 		"privateKey": {
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "Private key options; when omitted cert-manager applies its own defaults (RSA 2048).",
 			Properties: map[string]oam.PropertySchema{
-				"algorithm":      {Type: oam.PropertyTypeString, Enum: []any{"RSA", "ECDSA", "Ed25519"}},
-				"size":           {Type: oam.PropertyTypeInteger},
-				"encoding":       {Type: oam.PropertyTypeString, Enum: []any{"PKCS1", "PKCS8"}},
-				"rotationPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Never", "Always"}},
+				"algorithm":      {Type: oam.PropertyTypeString, Enum: []any{"RSA", "ECDSA", "Ed25519"}, Description: "Private key algorithm (RSA, ECDSA, or Ed25519)."},
+				"size":           {Type: oam.PropertyTypeInteger, Description: "Private key size in bits; valid values depend on the algorithm."},
+				"encoding":       {Type: oam.PropertyTypeString, Enum: []any{"PKCS1", "PKCS8"}, Description: "Private key encoding (PKCS1 or PKCS8)."},
+				"rotationPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Never", "Always"}, Description: "Whether cert-manager regenerates the private key on renewal (Never or Always)."},
 			},
 		},
 	}

--- a/pkg/oam/builtin/traits/cilium_networkpolicy.go
+++ b/pkg/oam/builtin/traits/cilium_networkpolicy.go
@@ -35,10 +35,10 @@ func (h *CiliumNetworkPolicyHandler) ValidateAndApplyDefaults(rendering map[stri
 // kept open (AdditionalProperties on the objects / array items).
 func (h *CiliumNetworkPolicyHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"name":             {Type: oam.PropertyTypeString, Required: true},
-		"endpointSelector": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
-		"egress":           {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}},
-		"ingress":          {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}},
+		"name":             {Type: oam.PropertyTypeString, Required: true, Description: "Name of the generated CiliumNetworkPolicy resource."},
+		"endpointSelector": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Cilium endpoint selector matching the pods this policy applies to."},
+		"egress":           {Type: oam.PropertyTypeArray, Description: "Cilium egress rules controlling outbound traffic.", Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single Cilium egress rule (opaque api.Rule shape)."}},
+		"ingress":          {Type: oam.PropertyTypeArray, Description: "Cilium ingress rules controlling inbound traffic.", Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single Cilium ingress rule (opaque api.Rule shape)."}},
 	}
 }
 

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -40,9 +40,9 @@ func (h *ConfigMapHandler) CanHandle(traitType string) bool {
 // can validate them before invocation. `data` is an open map (escape hatch).
 func (h *ConfigMapHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"name":      {Type: oam.PropertyTypeString, Required: true},
-		"mountPath": {Type: oam.PropertyTypeString},
-		"data":      {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+		"name":      {Type: oam.PropertyTypeString, Required: true, Description: "Name of the ConfigMap resource to create."},
+		"mountPath": {Type: oam.PropertyTypeString, Description: "Path at which the ConfigMap is mounted as a volume into the component's workload; when set, the component is decorated with the volume mount."},
+		"data":      {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Key/value pairs stored in the ConfigMap data (values are stringified)."},
 	}
 }
 

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -69,19 +69,19 @@ func (h *ExposeHandler) PropertySchema() map[string]oam.PropertySchema {
 		// controllerType is capability-injected, not user-set (see doc above), so it is
 		// NOT user-required here; it is validated in ValidateAndApplyDefaults. Kept in the
 		// schema as an optional enum so a value, if present, is type/enum-checked.
-		"controllerType":           {Type: oam.PropertyTypeString, Enum: []any{"ingress", "gateway"}},
-		"certManagerClusterIssuer": {Type: oam.PropertyTypeString},
-		"allowedHostnameWildcard":  {Type: oam.PropertyTypeString},
-		"gatewayName":              {Type: oam.PropertyTypeString},
-		"gatewayNamespace":         {Type: oam.PropertyTypeString, Default: "gateway-system"},
-		"annotations":              {Type: oam.PropertyTypeObject, AdditionalProperties: true},
-		"rules":                    {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}},
-		"hostnames":                {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
-		"ingressClassName":         {Type: oam.PropertyTypeString},
-		"servicePort":              {Type: oam.PropertyTypeInteger},
-		"serviceName":              {Type: oam.PropertyTypeString},
-		"name":                     {Type: oam.PropertyTypeString},
-		"scope":                    {Type: oam.PropertyTypeString},
+		"controllerType":           {Type: oam.PropertyTypeString, Enum: []any{"ingress", "gateway"}, Description: "Capability-injected controller kind (ingress or gateway) this expose dispatches to."},
+		"certManagerClusterIssuer": {Type: oam.PropertyTypeString, Description: "cert-manager ClusterIssuer used to synthesize TLS (ingress controllerType only)."},
+		"allowedHostnameWildcard":  {Type: oam.PropertyTypeString, Description: "Platform-reserved wildcard the hostnames must fall under."},
+		"gatewayName":              {Type: oam.PropertyTypeString, Description: "Gateway name used to synthesize parentRefs (gateway controllerType only)."},
+		"gatewayNamespace":         {Type: oam.PropertyTypeString, Default: "gateway-system", Description: "Namespace of the Gateway (gateway controllerType only)."},
+		"annotations":              {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Additional annotations to set on the generated resource."},
+		"rules":                    {Type: oam.PropertyTypeArray, Description: "Ingress-style host rules passed through to the ingress handler.", Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single ingress-style host rule."}},
+		"hostnames":                {Type: oam.PropertyTypeArray, Description: "Gateway-style hostnames passed through to the httproute handler.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A hostname for the gateway route."}},
+		"ingressClassName":         {Type: oam.PropertyTypeString, Description: "IngressClass to use (ingress controllerType only)."},
+		"servicePort":              {Type: oam.PropertyTypeInteger, Description: "Service port to route to when the component does not expose one."},
+		"serviceName":              {Type: oam.PropertyTypeString, Description: "Service name to route to; requires servicePort to also be set."},
+		"name":                     {Type: oam.PropertyTypeString, Description: "Overrides the sub-application name, allowing multiple expose traits per component."},
+		"scope":                    {Type: oam.PropertyTypeString, Description: "Suffix appended to the sub-application name to disambiguate multiple expose traits."},
 		"networkPolicy":            schemaNetworkPolicy(),
 	}
 }

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -65,55 +65,62 @@ func (h *ExternalSecretHandler) Apply(trait *oam.Trait, app *stack.Application, 
 // PropertySchema declares the external-secret trait's user-facing properties.
 func (h *ExternalSecretHandler) PropertySchema() map[string]oam.PropertySchema {
 	remoteRef := oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Reference to a key in the external secret store.",
 		Properties: map[string]oam.PropertySchema{
-			"key":              {Type: oam.PropertyTypeString, Required: true},
-			"property":         {Type: oam.PropertyTypeString},
-			"version":          {Type: oam.PropertyTypeString},
-			"decodingStrategy": {Type: oam.PropertyTypeString},
+			"key":              {Type: oam.PropertyTypeString, Required: true, Description: "Key or path of the secret in the remote store."},
+			"property":         {Type: oam.PropertyTypeString, Description: "Specific property within the remote secret to extract."},
+			"version":          {Type: oam.PropertyTypeString, Description: "Version of the remote secret to fetch."},
+			"decodingStrategy": {Type: oam.PropertyTypeString, Description: "How the fetched value is decoded (e.g. Base64, None)."},
 		},
 	}
 	requiredRemoteRef := remoteRef
 	requiredRemoteRef.Required = true
 	return map[string]oam.PropertySchema{
-		"secretName": {Type: oam.PropertyTypeString, Required: true},
+		"secretName": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the generated ExternalSecret and the default target Secret."},
 		"secretStoreRef": {
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "Reference to the SecretStore or ClusterSecretStore backing this secret.",
 			Properties: map[string]oam.PropertySchema{
-				"name": {Type: oam.PropertyTypeString, Required: true},
-				"kind": {Type: oam.PropertyTypeString, Default: "ClusterSecretStore"},
+				"name": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the referenced secret store."},
+				"kind": {Type: oam.PropertyTypeString, Default: "ClusterSecretStore", Description: "Kind of the referenced store (SecretStore or ClusterSecretStore)."},
 			},
 		},
-		"provider":         {Type: oam.PropertyTypeString},
-		"refreshInterval":  {Type: oam.PropertyTypeString, Default: "1h"},
-		"targetSecretName": {Type: oam.PropertyTypeString},
+		"provider":         {Type: oam.PropertyTypeString, Description: "Shorthand naming a ClusterSecretStore, used when secretStoreRef is not set."},
+		"refreshInterval":  {Type: oam.PropertyTypeString, Default: "1h", Description: "How often the secret is re-fetched from the store (e.g. 1h)."},
+		"targetSecretName": {Type: oam.PropertyTypeString, Description: "Overrides the name of the produced Kubernetes Secret (defaults to secretName)."},
 		"target": {
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "Configuration for the Kubernetes Secret this ExternalSecret produces.",
 			Properties: map[string]oam.PropertySchema{
-				"creationPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Owner", "Orphan", "Merge", "None"}},
-				"deletionPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Delete", "Merge", "Retain"}},
+				"creationPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Owner", "Orphan", "Merge", "None"}, Description: "Controls how the target Secret is created and owned."},
+				"deletionPolicy": {Type: oam.PropertyTypeString, Enum: []any{"Delete", "Merge", "Retain"}, Description: "Controls what happens to the target Secret when source data is removed."},
 				"template": {
-					Type: oam.PropertyTypeObject,
+					Type:        oam.PropertyTypeObject,
+					Description: "Template shaping the generated Secret's type and data.",
 					Properties: map[string]oam.PropertySchema{
-						"type": {Type: oam.PropertyTypeString},
-						"data": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+						"type": {Type: oam.PropertyTypeString, Description: "Type of the generated Kubernetes Secret (e.g. Opaque)."},
+						"data": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Templated key/value entries rendered into the Secret."},
 					},
 				},
 			},
 		},
 		"data": {
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: "Explicit mappings from remote store keys to entries in the target Secret.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A single mapping of a remote reference to a target Secret key.",
 				Properties: map[string]oam.PropertySchema{
-					"secretKey": {Type: oam.PropertyTypeString, Required: true},
+					"secretKey": {Type: oam.PropertyTypeString, Required: true, Description: "Key in the target Secret to populate."},
 					"remoteRef": requiredRemoteRef,
 				},
 			},
 		},
 		"dataFrom": {
-			Type:  oam.PropertyTypeArray,
-			Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true},
+			Type:        oam.PropertyTypeArray,
+			Description: "Bulk imports of secret data via extract or find queries.",
+			Items:       &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "A single extract or find query pulling multiple keys."},
 		},
 		"remoteRef": remoteRef,
 	}

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -62,39 +62,51 @@ func synthesizeParentRef(name, namespace string) map[string]any {
 // kept open beyond the enumerated backendRefs/matches/filters keys. `gatewayName`/
 // `gatewayNamespace`/`networkPolicy` are platform-reserved capability keys.
 func (h *HTTPRouteHandler) PropertySchema() map[string]oam.PropertySchema {
-	openArray := oam.PropertySchema{Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true}}
+	// openArray builds an array of opaque objects; matches/backendRefs/filters share
+	// the shape but have different meanings, so an accurate description is passed in.
+	openArray := func(arrayDesc, itemDesc string) oam.PropertySchema {
+		return oam.PropertySchema{
+			Type:        oam.PropertyTypeArray,
+			Description: arrayDesc,
+			Items:       &oam.PropertySchema{Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: itemDesc},
+		}
+	}
 	return map[string]oam.PropertySchema{
 		"parentRefs": {
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: "Gateway parent references this route attaches to.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A single Gateway parent reference.",
 				Properties: map[string]oam.PropertySchema{
-					"name":      {Type: oam.PropertyTypeString, Required: true},
-					"namespace": {Type: oam.PropertyTypeString},
+					"name":      {Type: oam.PropertyTypeString, Required: true, Description: "Name of the parent Gateway."},
+					"namespace": {Type: oam.PropertyTypeString, Description: "Namespace of the parent Gateway (defaults to gateway-system)."},
 				},
 			},
 		},
-		"hostnames": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
+		"hostnames": {Type: oam.PropertyTypeArray, Description: "Hostnames this route matches.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A hostname the route matches."}},
 		"rules": {
-			Type:     oam.PropertyTypeArray,
-			Required: true,
+			Type:        oam.PropertyTypeArray,
+			Required:    true,
+			Description: "Routing rules for the HTTPRoute.",
 			Items: &oam.PropertySchema{
 				Type:                 oam.PropertyTypeObject,
 				AdditionalProperties: true,
+				Description:          "A single routing rule (matches, backends, filters, timeouts).",
 				Properties: map[string]oam.PropertySchema{
-					"matches":     openArray,
-					"backendRefs": openArray,
-					"filters":     openArray,
-					"timeouts":    {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+					"matches":     openArray("Gateway API match conditions selecting requests for this rule.", "A single Gateway API match condition."),
+					"backendRefs": openArray("Backend services requests matching this rule are forwarded to.", "A single backend reference (name/port)."),
+					"filters":     openArray("Gateway API filters applied to matching requests.", "A single Gateway API filter (e.g. RequestRedirect, URLRewrite)."),
+					"timeouts":    {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Per-rule request and backendRequest timeouts."},
 				},
 			},
 		},
-		"gatewayName":      {Type: oam.PropertyTypeString},
-		"gatewayNamespace": {Type: oam.PropertyTypeString, Default: "gateway-system"},
-		"servicePort":      {Type: oam.PropertyTypeInteger},
-		"serviceName":      {Type: oam.PropertyTypeString},
-		"name":             {Type: oam.PropertyTypeString},
-		"scope":            {Type: oam.PropertyTypeString},
+		"gatewayName":      {Type: oam.PropertyTypeString, Description: "Capability-supplied Gateway name used to synthesize parentRefs."},
+		"gatewayNamespace": {Type: oam.PropertyTypeString, Default: "gateway-system", Description: "Namespace of the capability-supplied Gateway."},
+		"servicePort":      {Type: oam.PropertyTypeInteger, Description: "Service port to route to when the component does not expose one."},
+		"serviceName":      {Type: oam.PropertyTypeString, Description: "Service name to route to; requires servicePort to also be set."},
+		"name":             {Type: oam.PropertyTypeString, Description: "Overrides the sub-application name, allowing multiple httproute traits per component."},
+		"scope":            {Type: oam.PropertyTypeString, Description: "Suffix appended to the sub-application name to disambiguate multiple httproute traits."},
 		"networkPolicy":    schemaNetworkPolicy(),
 	}
 }

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -78,23 +78,27 @@ func (h *IngressHandler) CanHandle(traitType string) bool {
 func (h *IngressHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"rules": {
-			Type:     oam.PropertyTypeArray,
-			Required: true,
+			Type:        oam.PropertyTypeArray,
+			Required:    true,
+			Description: "Host-based routing rules for the Ingress.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A single host rule with its paths.",
 				Properties: map[string]oam.PropertySchema{
-					"host": {Type: oam.PropertyTypeString, Required: true},
+					"host": {Type: oam.PropertyTypeString, Required: true, Description: "Hostname this rule matches."},
 					"paths": {
-						Type:     oam.PropertyTypeArray,
-						Required: true,
+						Type:        oam.PropertyTypeArray,
+						Required:    true,
+						Description: "Paths under the host and the service backend each routes to.",
 						Items: &oam.PropertySchema{
-							Type: oam.PropertyTypeObject,
+							Type:        oam.PropertyTypeObject,
+							Description: "A single path mapping to a service backend.",
 							Properties: map[string]oam.PropertySchema{
-								"path":     {Type: oam.PropertyTypeString, Default: "/"},
-								"pathType": {Type: oam.PropertyTypeString, Default: "Prefix", Enum: []any{"Prefix", "Exact", "ImplementationSpecific"}},
-								"backend":  {Type: oam.PropertyTypeString},
-								"port":     {Type: oam.PropertyTypeInteger},
-								"portName": {Type: oam.PropertyTypeString},
+								"path":     {Type: oam.PropertyTypeString, Default: "/", Description: "URL path to match."},
+								"pathType": {Type: oam.PropertyTypeString, Default: "Prefix", Enum: []any{"Prefix", "Exact", "ImplementationSpecific"}, Description: "How the path is matched (Prefix, Exact, or ImplementationSpecific)."},
+								"backend":  {Type: oam.PropertyTypeString, Description: "Service name to route to (defaults to the component's service)."},
+								"port":     {Type: oam.PropertyTypeInteger, Description: "Service port number to route to."},
+								"portName": {Type: oam.PropertyTypeString, Description: "Named service port to route to (alternative to port)."},
 							},
 						},
 					},
@@ -102,22 +106,24 @@ func (h *IngressHandler) PropertySchema() map[string]oam.PropertySchema {
 			},
 		},
 		"tls": {
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: "TLS configuration for the Ingress hosts.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A single TLS entry pairing hosts with a secret.",
 				Properties: map[string]oam.PropertySchema{
-					"hosts":      {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
-					"secretName": {Type: oam.PropertyTypeString},
+					"hosts":      {Type: oam.PropertyTypeArray, Description: "Hostnames covered by this TLS certificate.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A hostname covered by the certificate."}},
+					"secretName": {Type: oam.PropertyTypeString, Description: "Name of the Secret holding the TLS certificate."},
 				},
 			},
 		},
-		"annotations":             {Type: oam.PropertyTypeObject, AdditionalProperties: true},
-		"ingressClassName":        {Type: oam.PropertyTypeString},
-		"servicePort":             {Type: oam.PropertyTypeInteger},
-		"serviceName":             {Type: oam.PropertyTypeString},
-		"name":                    {Type: oam.PropertyTypeString},
-		"scope":                   {Type: oam.PropertyTypeString},
-		"allowedHostnameWildcard": {Type: oam.PropertyTypeString},
+		"annotations":             {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Additional annotations to set on the Ingress resource."},
+		"ingressClassName":        {Type: oam.PropertyTypeString, Description: "IngressClass that should handle this Ingress."},
+		"servicePort":             {Type: oam.PropertyTypeInteger, Description: "Service port to route to when the component does not expose one (e.g. helmchart)."},
+		"serviceName":             {Type: oam.PropertyTypeString, Description: "Service name to route to; requires servicePort to also be set."},
+		"name":                    {Type: oam.PropertyTypeString, Description: "Overrides the sub-application name, allowing multiple ingress traits per component."},
+		"scope":                   {Type: oam.PropertyTypeString, Description: "Suffix appended to the sub-application name to disambiguate multiple ingress traits."},
+		"allowedHostnameWildcard": {Type: oam.PropertyTypeString, Description: "Platform-reserved wildcard the rule hostnames must fall under."},
 		"networkPolicy":           schemaNetworkPolicy(),
 	}
 }

--- a/pkg/oam/builtin/traits/networkpolicy.go
+++ b/pkg/oam/builtin/traits/networkpolicy.go
@@ -36,21 +36,24 @@ func (h *NetworkPolicyHandler) ValidateAndApplyDefaults(rendering map[string]any
 // PropertySchema declares the networkpolicy trait's user-facing properties.
 func (h *NetworkPolicyHandler) PropertySchema() map[string]oam.PropertySchema {
 	labelSelector := oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Label selector matching the pods or namespaces this peer applies to.",
 		Properties: map[string]oam.PropertySchema{
-			"matchLabels": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+			"matchLabels": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Label key/value pairs a pod or namespace must carry to match."},
 		},
 	}
 	peer := oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "A network peer selected by pod/namespace label selectors or an IP block.",
 		Properties: map[string]oam.PropertySchema{
 			"podSelector":       labelSelector,
 			"namespaceSelector": labelSelector,
 			"ipBlock": {
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "An IP block (CIDR with optional exceptions) this rule applies to.",
 				Properties: map[string]oam.PropertySchema{
-					"cidr":   {Type: oam.PropertyTypeString, Required: true},
-					"except": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
+					"cidr":   {Type: oam.PropertyTypeString, Required: true, Description: "CIDR range the rule applies to."},
+					"except": {Type: oam.PropertyTypeArray, Description: "CIDR ranges to exclude from the block.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A CIDR range excluded from the block."}},
 				},
 			},
 		},
@@ -59,25 +62,38 @@ func (h *NetworkPolicyHandler) PropertySchema() map[string]oam.PropertySchema {
 	port := oam.PropertySchema{
 		Type:                 oam.PropertyTypeObject,
 		AdditionalProperties: true,
+		Description:          "A port (number or named port) with its protocol.",
 		Properties: map[string]oam.PropertySchema{
-			"protocol": {Type: oam.PropertyTypeString, Default: "TCP", Enum: []any{"TCP", "UDP", "SCTP"}},
+			"protocol": {Type: oam.PropertyTypeString, Default: "TCP", Enum: []any{"TCP", "UDP", "SCTP"}, Description: "IP protocol for the port (TCP, UDP, or SCTP)."},
 		},
 	}
-	peerList := func(dir string) oam.PropertySchema {
+	// peerList is a helper: the direction key and the surrounding descriptions differ
+	// between ingress and egress, so each accurate description is passed in.
+	peerList := func(dir, listDesc, ruleDesc, peersDesc, portsDesc string) oam.PropertySchema {
 		return oam.PropertySchema{
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: listDesc,
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: ruleDesc,
 				Properties: map[string]oam.PropertySchema{
-					dir:     {Type: oam.PropertyTypeArray, Items: &peer},
-					"ports": {Type: oam.PropertyTypeArray, Items: &port},
+					dir:     {Type: oam.PropertyTypeArray, Description: peersDesc, Items: &peer},
+					"ports": {Type: oam.PropertyTypeArray, Description: portsDesc, Items: &port},
 				},
 			},
 		}
 	}
 	return map[string]oam.PropertySchema{
-		"ingress": peerList("from"),
-		"egress":  peerList("to"),
+		"ingress": peerList("from",
+			"Ingress rules allowing inbound traffic to the workload.",
+			"A single ingress rule pairing allowed peers with ports.",
+			"Peers allowed to connect to the workload.",
+			"Ports on the workload the peers may connect to."),
+		"egress": peerList("to",
+			"Egress rules allowing outbound traffic from the workload.",
+			"A single egress rule pairing allowed peers with ports.",
+			"Peers the workload is allowed to connect to.",
+			"Destination ports the workload may connect to."),
 	}
 }
 

--- a/pkg/oam/builtin/traits/patches.go
+++ b/pkg/oam/builtin/traits/patches.go
@@ -25,14 +25,16 @@ func (h *FluxCDPatchesHandler) CanHandle(traitType string) bool {
 func (h *FluxCDPatchesHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"patches": {
-			Type:     oam.PropertyTypeArray,
-			Required: true,
+			Type:        oam.PropertyTypeArray,
+			Required:    true,
+			Description: "Strategic-merge or JSON6902 patches applied to the generated Kustomization.",
 			Items: &oam.PropertySchema{
 				Type:                 oam.PropertyTypeObject,
 				AdditionalProperties: true,
+				Description:          "A single patch with its body and optional target selector.",
 				Properties: map[string]oam.PropertySchema{
-					"patch":  {Type: oam.PropertyTypeString, Required: true},
-					"target": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+					"patch":  {Type: oam.PropertyTypeString, Required: true, Description: "Patch body as a strategic-merge YAML or JSON6902 document."},
+					"target": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Kustomize target selector (group/version/kind/name/namespace/labelSelector/annotationSelector) restricting which resources the patch applies to."},
 				},
 			},
 		},

--- a/pkg/oam/builtin/traits/postbuild.go
+++ b/pkg/oam/builtin/traits/postbuild.go
@@ -23,15 +23,17 @@ func (h *PostBuildHandler) CanHandle(traitType string) bool {
 // `substitute` is an open map of string→string.
 func (h *PostBuildHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"substitute": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+		"substitute": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Literal key/value variables substituted into the Kustomization at post-build."},
 		"substituteFrom": {
-			Type: oam.PropertyTypeArray,
+			Type:        oam.PropertyTypeArray,
+			Description: "References to ConfigMaps or Secrets whose keys supply post-build substitution variables.",
 			Items: &oam.PropertySchema{
-				Type: oam.PropertyTypeObject,
+				Type:        oam.PropertyTypeObject,
+				Description: "A ConfigMap or Secret providing post-build substitution variables.",
 				Properties: map[string]oam.PropertySchema{
-					"kind":     {Type: oam.PropertyTypeString, Required: true, Enum: []any{"ConfigMap", "Secret"}},
-					"name":     {Type: oam.PropertyTypeString, Required: true},
-					"optional": {Type: oam.PropertyTypeBoolean},
+					"kind":     {Type: oam.PropertyTypeString, Required: true, Enum: []any{"ConfigMap", "Secret"}, Description: "Source kind (ConfigMap or Secret)."},
+					"name":     {Type: oam.PropertyTypeString, Required: true, Description: "Name of the ConfigMap or Secret to read variables from."},
+					"optional": {Type: oam.PropertyTypeBoolean, Description: "Whether a missing source is tolerated instead of failing the build."},
 				},
 			},
 		},

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -29,16 +29,17 @@ func (h *PVCHandler) CanHandle(traitType string) bool {
 // PropertySchema declares the pvc trait's user-facing properties.
 func (h *PVCHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"name": {Type: oam.PropertyTypeString, Required: true},
+		"name": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the PersistentVolumeClaim to create."},
 		// size is not schema-required: an EnvironmentPolicy may supply it via
 		// DefaultStorageSize. When neither the trait nor a policy default provides a
 		// value, ApplyPolicy errors (pvc has no last-resort handler default).
-		"size":             {Type: oam.PropertyTypeString},
-		"storageClassName": {Type: oam.PropertyTypeString},
+		"size":             {Type: oam.PropertyTypeString, Description: "Requested storage size as a Kubernetes quantity (e.g. 10Gi); may instead come from an EnvironmentPolicy storage default."},
+		"storageClassName": {Type: oam.PropertyTypeString, Description: "StorageClass backing the volume."},
 		"accessModes": {
-			Type:    oam.PropertyTypeArray,
-			Default: []any{"ReadWriteOnce"},
-			Items:   &oam.PropertySchema{Type: oam.PropertyTypeString, Enum: []any{"ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"}},
+			Type:        oam.PropertyTypeArray,
+			Default:     []any{"ReadWriteOnce"},
+			Description: "Access modes requested for the volume.",
+			Items:       &oam.PropertySchema{Type: oam.PropertyTypeString, Enum: []any{"ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"}, Description: "A volume access mode (ReadWriteOnce, ReadOnlyMany, ReadWriteMany, or ReadWriteOncePod)."},
 		},
 	}
 }

--- a/pkg/oam/builtin/traits/rbac.go
+++ b/pkg/oam/builtin/traits/rbac.go
@@ -25,19 +25,21 @@ func (h *RBACHandler) CanHandle(traitType string) bool {
 func (h *RBACHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"rules": {
-			Type:     oam.PropertyTypeArray,
-			Required: true,
+			Type:        oam.PropertyTypeArray,
+			Required:    true,
+			Description: "Policy rules granted to the component's ServiceAccount.",
 			Items: &oam.PropertySchema{
 				Type:                 oam.PropertyTypeObject,
 				AdditionalProperties: true,
+				Description:          "A single RBAC policy rule.",
 				Properties: map[string]oam.PropertySchema{
-					"apiGroups": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
-					"resources": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
-					"verbs":     {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString}},
+					"apiGroups": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "An API group the rule applies to."}, Description: "API groups the rule applies to."},
+					"resources": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A resource type the rule applies to."}, Description: "Resource types the rule applies to."},
+					"verbs":     {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A verb the rule permits."}, Description: "Verbs the rule permits on the listed resources."},
 				},
 			},
 		},
-		"clusterWide": {Type: oam.PropertyTypeBoolean},
+		"clusterWide": {Type: oam.PropertyTypeBoolean, Description: "When true, also generate a ClusterRole and ClusterRoleBinding for cluster-wide permissions."},
 	}
 }
 

--- a/pkg/oam/builtin/traits/scaler.go
+++ b/pkg/oam/builtin/traits/scaler.go
@@ -29,11 +29,11 @@ func (h *ScalerHandler) PropertySchema() map[string]oam.PropertySchema {
 		// minReplicas/maxReplicas are not schema-required: an EnvironmentPolicy may
 		// supply them via DefaultScalerMinReplicas/DefaultScalerMaxReplicas. When
 		// neither the trait nor a policy default provides a value, ApplyPolicy errors.
-		"minReplicas":       {Type: oam.PropertyTypeInteger},
-		"maxReplicas":       {Type: oam.PropertyTypeInteger},
-		"cpuUtilization":    {Type: oam.PropertyTypeInteger, Default: 80},
-		"memoryUtilization": {Type: oam.PropertyTypeInteger},
-		"enablePDB":         {Type: oam.PropertyTypeBoolean, Default: false},
+		"minReplicas":       {Type: oam.PropertyTypeInteger, Description: "Minimum replica count for the HorizontalPodAutoscaler; may instead come from an EnvironmentPolicy scaler default."},
+		"maxReplicas":       {Type: oam.PropertyTypeInteger, Description: "Maximum replica count for the HorizontalPodAutoscaler; may instead come from an EnvironmentPolicy scaler default."},
+		"cpuUtilization":    {Type: oam.PropertyTypeInteger, Default: 80, Description: "Target average CPU utilization percentage (1-100) that triggers scaling."},
+		"memoryUtilization": {Type: oam.PropertyTypeInteger, Description: "Target average memory utilization percentage (1-100) that triggers scaling."},
+		"enablePDB":         {Type: oam.PropertyTypeBoolean, Default: false, Description: "When true, also generate a PodDisruptionBudget (requires minReplicas >= 2)."},
 	}
 }
 

--- a/pkg/oam/builtin/traits/schema.go
+++ b/pkg/oam/builtin/traits/schema.go
@@ -10,15 +10,18 @@ import "github.com/go-kure/launcher/pkg/oam"
 // schemaNetworkPolicy describes the platform-reserved `networkPolicy` property.
 func schemaNetworkPolicy() oam.PropertySchema {
 	return oam.PropertySchema{
-		Type: oam.PropertyTypeObject,
+		Type:        oam.PropertyTypeObject,
+		Description: "Platform-reserved network policy configuration derived from cluster capabilities.",
 		Properties: map[string]oam.PropertySchema{
 			"trafficSources": {
-				Type: oam.PropertyTypeArray,
+				Type:        oam.PropertyTypeArray,
+				Description: "Sources allowed to reach this workload.",
 				Items: &oam.PropertySchema{
-					Type: oam.PropertyTypeObject,
+					Type:        oam.PropertyTypeObject,
+					Description: "A single allowed traffic source.",
 					Properties: map[string]oam.PropertySchema{
-						"namespace":   {Type: oam.PropertyTypeString, Required: true},
-						"podSelector": {Type: oam.PropertyTypeObject, AdditionalProperties: true},
+						"namespace":   {Type: oam.PropertyTypeString, Required: true, Description: "Namespace the traffic originates from."},
+						"podSelector": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Label selector narrowing which pods in the namespace are allowed."},
 					},
 				},
 			},

--- a/pkg/oam/builtin/traits/security_context.go
+++ b/pkg/oam/builtin/traits/security_context.go
@@ -36,13 +36,13 @@ func (h *SecurityContextHandler) CanHandle(traitType string) bool {
 // PropertySchema declares the security-context trait's user-facing properties.
 func (h *SecurityContextHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"psaLevel":                 {Type: oam.PropertyTypeString, Required: true, Enum: []any{"restricted", "baseline", "privileged"}},
-		"runAsNonRoot":             {Type: oam.PropertyTypeBoolean},
-		"allowPrivilegeEscalation": {Type: oam.PropertyTypeBoolean},
-		"readOnlyRootFilesystem":   {Type: oam.PropertyTypeBoolean},
-		"runAsUser":                {Type: oam.PropertyTypeInteger},
-		"runAsGroup":               {Type: oam.PropertyTypeInteger},
-		"fsGroup":                  {Type: oam.PropertyTypeInteger},
+		"psaLevel":                 {Type: oam.PropertyTypeString, Required: true, Enum: []any{"restricted", "baseline", "privileged"}, Description: "Pod Security Admission level the workload requires (restricted, baseline, or privileged)."},
+		"runAsNonRoot":             {Type: oam.PropertyTypeBoolean, Description: "Whether containers must run as a non-root user."},
+		"allowPrivilegeEscalation": {Type: oam.PropertyTypeBoolean, Description: "Whether a container process may gain more privileges than its parent."},
+		"readOnlyRootFilesystem":   {Type: oam.PropertyTypeBoolean, Description: "Whether the container root filesystem is mounted read-only."},
+		"runAsUser":                {Type: oam.PropertyTypeInteger, Description: "UID to run the container process as."},
+		"runAsGroup":               {Type: oam.PropertyTypeInteger, Description: "GID to run the container process as."},
+		"fsGroup":                  {Type: oam.PropertyTypeInteger, Description: "Supplemental group applied to ownership of mounted volumes."},
 	}
 }
 

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -32,19 +32,20 @@ func (h *VolSyncHandler) ValidateAndApplyDefaults(rendering map[string]any) (map
 // PropertySchema declares the volsync trait's user-facing properties.
 func (h *VolSyncHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
-		"sourcePVC":               {Type: oam.PropertyTypeString, Required: true},
-		"schedule":                {Type: oam.PropertyTypeString, Required: true},
-		"repository":              {Type: oam.PropertyTypeString},
-		"copyMethod":              {Type: oam.PropertyTypeString, Default: "Snapshot", Enum: []any{"Snapshot", "Direct", "Clone"}},
-		"storageClassName":        {Type: oam.PropertyTypeString},
-		"volumeSnapshotClassName": {Type: oam.PropertyTypeString},
-		"pruneIntervalDays":       {Type: oam.PropertyTypeInteger, Default: 14},
+		"sourcePVC":               {Type: oam.PropertyTypeString, Required: true, Description: "Name of the PersistentVolumeClaim to back up."},
+		"schedule":                {Type: oam.PropertyTypeString, Required: true, Description: "Cron schedule controlling when backups run."},
+		"repository":              {Type: oam.PropertyTypeString, Description: "Name of the Secret holding restic repository credentials (defaults to <component>-volsync-secret)."},
+		"copyMethod":              {Type: oam.PropertyTypeString, Default: "Snapshot", Enum: []any{"Snapshot", "Direct", "Clone"}, Description: "How the source volume is captured for backup (Snapshot, Direct, or Clone)."},
+		"storageClassName":        {Type: oam.PropertyTypeString, Description: "StorageClass used for the point-in-time copy of the source volume."},
+		"volumeSnapshotClassName": {Type: oam.PropertyTypeString, Description: "VolumeSnapshotClass used when copyMethod is Snapshot."},
+		"pruneIntervalDays":       {Type: oam.PropertyTypeInteger, Default: 14, Description: "How often, in days, restic prunes the backup repository."},
 		"retain": {
-			Type: oam.PropertyTypeObject,
+			Type:        oam.PropertyTypeObject,
+			Description: "Restic retention policy for backup snapshots.",
 			Properties: map[string]oam.PropertySchema{
-				"daily":   {Type: oam.PropertyTypeInteger, Default: 7},
-				"weekly":  {Type: oam.PropertyTypeInteger, Default: 4},
-				"monthly": {Type: oam.PropertyTypeInteger, Default: 3},
+				"daily":   {Type: oam.PropertyTypeInteger, Default: 7, Description: "Number of daily backups to retain."},
+				"weekly":  {Type: oam.PropertyTypeInteger, Default: 4, Description: "Number of weekly backups to retain."},
+				"monthly": {Type: oam.PropertyTypeInteger, Default: 3, Description: "Number of monthly backups to retain."},
 			},
 		},
 	}

--- a/pkg/oam/schema.go
+++ b/pkg/oam/schema.go
@@ -26,6 +26,9 @@ const (
 type PropertySchema struct {
 	// Type is the value type. Required.
 	Type PropertyType `json:"type"`
+	// Description is human-facing prose for the property, surfaced in generated
+	// API references (e.g. crane's Handler API Reference). Optional.
+	Description string `json:"description,omitempty"`
 	// Required marks the property as mandatory.
 	Required bool `json:"required,omitempty"`
 	// Default is the value applied when the property is absent.


### PR DESCRIPTION
## Why

Crane's auto-generated **Handler API Reference** renders each handler's `PropertySchema()` as a `Property | Type | Required | Default | Enum | Description` table, recursing into nested objects and array items. The `Description` column had no source: `oam.PropertySchema` carried no description field. This adds it and populates it everywhere, keeping prose and structure co-located.

Refs #189. Follows #163 (schema model) and #182 (`PropertySchema()` on public built-ins).

## What

- **Field**: added `Description string \`json:"description,omitempty"\`` to `oam.PropertySchema` (`pkg/oam/schema.go`). Flows through `Transformer.HandlerSchemas()` unchanged — no validator change. Backward-compatible (optional).
- **Descriptions**: a non-empty description on **every** built-in property at **every depth** — top-level, nested object fields, and array item schemas — across all 27 built-ins (11 components + 16 traits, `prune-protection` excepted as it exposes no properties) and the shared `schema.go` fragments in both builtin packages.
- **Reused-local handling**: open shapes reused across semantically different keys (`postgresql`, `helmchart`, `httproute` `matches`/`backendRefs`/`filters`, `networkpolicy` `peerList`) now use per-key description helpers; shared locals keep a single description only where meaning is identical (`labelSelector`, `peer`, `port`, `external_secret` `remoteRef`).
- **Completeness test**: `TestBuiltinHandlerSchemaDescriptions` (`pkg/cmd/kurel`) walks every registered handler's schema recursively and fails on any blank (`strings.TrimSpace`-empty) `Description` at any depth, with deterministic dotted-path failure output (e.g. `networkpolicy.ingress[].from[].ipBlock.except[]`).
- **Docs**: `pkg/oam/README.md` (field list) and the builtin component/trait READMEs.

## Verification

- `mise run build`, `mise run test`, `mise run lint`, `mise run verify` — all green.
- Proved the completeness test bites: temporarily blanking one nested item description fails the test with the correct path; restored.
- `check-doc-gate.sh origin/main .` and `check-links.sh` — OK.
- Spot-checked JSON marshaling of a deep handler (`networkpolicy`): `description` serializes at every depth including scalar array items.

## Remaining (not in this PR)

Per issue #189, crane's docgen runs `GOWORK=off` and resolves the released module, so descriptions only render once a tagged release is bumped. The release (`v0.1.0-alpha.12`) is triggered **separately post-merge** (`mise run release -- --do-it`) — the issue stays open until that tag exists and crane bumps to it.