### PR TITLE
feat(oam/expose): external-auth (oauth2-proxy) ingress annotations

### DIFF
--- a/pkg/oam/builtin/README.md
+++ b/pkg/oam/builtin/README.md
@@ -8,9 +8,11 @@ handlers (e.g. `CertificateRendering`, `ExposeRendering`, `ExternalSecretRenderi
 `DecodeStrict[T]` helper used by handlers to decode capability properties.
 
 `ExposeRendering` additionally carries `certManagerClusterIssuer` (platform-managed TLS on
-the ingress path), `allowedHostnameWildcard` (hostname constraint for both paths), and the
+the ingress path), `allowedHostnameWildcard` (hostname constraint for both paths), the
 ingress-only `sslRedirect` / `forceSslRedirect` platform defaults (author-overridable via the
-matching inline expose properties).
+matching inline expose properties), and the ingress-only external-auth facts `authURL` /
+`authSigninURL` / `authResponseHeaders` (consumed when an expose trait authors `allowedGroups`;
+`authSigninURL` is override-able inline).
 
 These are internal schema types used by [`builtin/components`](components) and
 [`builtin/traits`](traits); they are not a user-facing API. See

--- a/pkg/oam/builtin/expose.go
+++ b/pkg/oam/builtin/expose.go
@@ -40,4 +40,16 @@ type ExposeRendering struct {
 	// nginx.ingress.kubernetes.io/force-ssl-redirect annotation. Ingress-only. A
 	// component may override it via the inline forceSslRedirect property.
 	ForceSSLRedirect *bool `yaml:"forceSslRedirect,omitempty" json:"forceSslRedirect,omitempty"`
+
+	// AuthURL is the nginx external-auth endpoint base (the oauth2-proxy /oauth2/auth
+	// URL). Ingress-only. When set, an expose trait enables ext-auth by authoring
+	// allowedGroups; must be a bare base URL (no query string).
+	AuthURL string `yaml:"authURL,omitempty" json:"authURL,omitempty"`
+
+	// AuthSigninURL is the platform default for the nginx auth-signin annotation.
+	// Ingress-only; a component may override it inline via the authSigninURL property.
+	AuthSigninURL string `yaml:"authSigninURL,omitempty" json:"authSigninURL,omitempty"`
+
+	// AuthResponseHeaders is the nginx auth-response-headers value. Ingress-only.
+	AuthResponseHeaders string `yaml:"authResponseHeaders,omitempty" json:"authResponseHeaders,omitempty"`
 }

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -82,6 +82,11 @@ not the app — chooses the implementation:
   hosts are still wildcard-validated). Platform-default `ssl-redirect` / `force-ssl-redirect`
   come from the `sslRedirect` / `forceSslRedirect` capability fields (author-overridable via
   the same inline properties; the typed value wins over a raw same-key annotation).
+  External-auth (oauth2-proxy): authoring `allowedGroups: [...]` on an ingress expose emits the
+  nginx `auth-url` / `auth-signin` / `auth-response-headers` annotations from the capability's
+  `authURL` / `authSigninURL` / `authResponseHeaders` (`authSigninURL` is override-able inline;
+  `authURL` must be a bare base URL). `allowedGroups` must be non-empty, and the capability must
+  supply `authURL` or the trait is rejected.
 - **certificate** → `issuerRef` (cert-manager issuer/cluster-issuer).
 - **external-secret** → `secretStoreRef` (or the inline `provider` shorthand).
 

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -3,6 +3,7 @@ package traits
 import (
 	"maps"
 	"strconv"
+	"strings"
 
 	"github.com/go-kure/kure/pkg/stack"
 
@@ -41,6 +42,12 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 		if r.GatewayName != "" || r.GatewayNamespace != "" {
 			return nil, errors.New("expose rendering: gatewayName and gatewayNamespace are only valid when controllerType is \"gateway\"")
 		}
+		if strings.Contains(r.AuthURL, "?") {
+			return nil, errors.New("expose rendering: authURL must be a base URL without a query string")
+		}
+		if (r.AuthSigninURL != "" || r.AuthResponseHeaders != "") && r.AuthURL == "" {
+			return nil, errors.New("expose rendering: authSigninURL and authResponseHeaders require authURL")
+		}
 	case "gateway":
 		if r.GatewayName == "" {
 			return nil, errors.New("expose rendering: gatewayName is required when controllerType is \"gateway\"")
@@ -53,6 +60,9 @@ func (h *ExposeHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[
 		}
 		if r.SSLRedirect != nil || r.ForceSSLRedirect != nil {
 			return nil, errors.New("expose rendering: sslRedirect and forceSslRedirect are only valid when controllerType is \"ingress\"")
+		}
+		if r.AuthURL != "" || r.AuthSigninURL != "" || r.AuthResponseHeaders != "" {
+			return nil, errors.New("expose rendering: authURL, authSigninURL and authResponseHeaders are only valid when controllerType is \"ingress\"")
 		}
 		if r.GatewayNamespace == "" {
 			rendering["gatewayNamespace"] = "gateway-system"
@@ -84,6 +94,10 @@ func (h *ExposeHandler) PropertySchema() map[string]oam.PropertySchema {
 		"ingressClassName":         {Type: oam.PropertyTypeString, Description: "IngressClass to use (ingress controllerType only)."},
 		"sslRedirect":              {Type: oam.PropertyTypeBoolean, Description: "nginx ssl-redirect annotation (ingress controllerType only); platform default via capability rendering, override-able inline."},
 		"forceSslRedirect":         {Type: oam.PropertyTypeBoolean, Description: "nginx force-ssl-redirect annotation (ingress controllerType only); platform default via capability rendering, override-able inline."},
+		"allowedGroups":            {Type: oam.PropertyTypeArray, Description: "oauth2-proxy allowed groups; enables external-auth on the route (ingress controllerType only). Order is preserved.", Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "An allowed oauth2-proxy group."}},
+		"authURL":                  {Type: oam.PropertyTypeString, Description: "Capability-injected nginx external-auth endpoint base (ingress controllerType only)."},
+		"authSigninURL":            {Type: oam.PropertyTypeString, Description: "nginx auth-signin URL (ingress controllerType only); platform default via capability rendering, override-able inline."},
+		"authResponseHeaders":      {Type: oam.PropertyTypeString, Description: "Capability-injected nginx auth-response-headers value (ingress controllerType only)."},
 		"servicePort":              {Type: oam.PropertyTypeInteger, Description: "Service port to route to when the component does not expose one."},
 		"serviceName":              {Type: oam.PropertyTypeString, Description: "Service name to route to; requires servicePort to also be set."},
 		"name":                     {Type: oam.PropertyTypeString, Description: "Overrides the sub-application name, allowing multiple expose traits per component."},
@@ -140,11 +154,16 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 		// ssl-redirect / force-ssl-redirect: typed property (capability default or
 		// inline override) wins over a same-key raw annotation.
 		setSSLRedirectAnnotations(props)
+		// external-auth: when the trait authors allowedGroups, inject the nginx
+		// auth-* annotations from the capability rendering.
+		if err := setAuthAnnotations(props, app.Name); err != nil {
+			return err
+		}
 		return (&IngressHandler{}).Apply(&oam.Trait{Type: "expose", Properties: props}, app, bundle)
 	case "gateway":
-		// ssl-redirect is nginx-ingress-specific; reject the inline properties on the
+		// These properties are nginx-ingress-specific; reject them inline on the
 		// gateway path (the rendering guard only covers the capability-supplied form).
-		for _, k := range []string{"sslRedirect", "forceSslRedirect"} {
+		for _, k := range []string{"sslRedirect", "forceSslRedirect", "allowedGroups", "authSigninURL"} {
 			if _, ok := props[k]; ok {
 				return &errors.ValidationError{
 					Field:     k,
@@ -266,6 +285,72 @@ func setSSLRedirectAnnotations(props map[string]any) {
 func boolProp(props map[string]any, key string) (val, ok bool) {
 	val, ok = props[key].(bool)
 	return val, ok
+}
+
+// setAuthAnnotations writes the nginx external-auth annotations (auth-url, auth-signin,
+// auth-response-headers) when the expose trait authors allowedGroups. The auth-url base,
+// signin default, and response-headers come from the capability rendering (authURL and
+// authResponseHeaders are platform-reserved; authSigninURL is override-able inline);
+// allowedGroups is authored, order preserved. The typed values win over same-key raw
+// annotations. All auth-* keys are consumed here so they never reach IngressHandler.
+func setAuthAnnotations(props map[string]any, component string) error {
+	rawGroups, hasGroups := props["allowedGroups"]
+	authURL, _ := props["authURL"].(string)
+	signin, _ := props["authSigninURL"].(string)
+	respHeaders, _ := props["authResponseHeaders"].(string)
+	delete(props, "allowedGroups")
+	delete(props, "authURL")
+	delete(props, "authSigninURL")
+	delete(props, "authResponseHeaders")
+
+	if !hasGroups {
+		return nil // no ext-auth requested; discard any capability-injected auth-* keys
+	}
+	groups := stringList(rawGroups)
+	if len(groups) == 0 {
+		return &errors.ValidationError{
+			Field:     "allowedGroups",
+			Component: component,
+			Message:   "allowedGroups must not be empty (ext-auth requires at least one group)",
+		}
+	}
+	if authURL == "" {
+		return &errors.ValidationError{
+			Field:     "allowedGroups",
+			Component: component,
+			Message:   "ext-auth is not offered on this platform (the expose capability has no authURL)",
+		}
+	}
+
+	anns, _ := props["annotations"].(map[string]any)
+	if anns == nil {
+		anns = map[string]any{}
+	}
+	anns[authURLAnnotation] = authURL + "?allowed_groups=" + strings.Join(groups, ",")
+	if signin != "" {
+		anns[authSigninAnnotation] = signin
+	}
+	if respHeaders != "" {
+		anns[authResponseHeadersAnnotation] = respHeaders
+	}
+	props["annotations"] = anns
+	return nil
+}
+
+// stringList converts an OAM array value ([]any of strings) to []string, preserving
+// order and dropping empty entries.
+func stringList(v any) []string {
+	raw, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, e := range raw {
+		if s, ok := e.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
 }
 
 // synthesizedIngressTLS builds the single managed TLS entry: all hosts under one

--- a/pkg/oam/builtin/traits/expose_ext_auth_test.go
+++ b/pkg/oam/builtin/traits/expose_ext_auth_test.go
@@ -1,0 +1,157 @@
+package traits_test
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	pkgerrors "github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+const (
+	kAuthURL      = "nginx.ingress.kubernetes.io/auth-url"
+	kAuthSignin   = "nginx.ingress.kubernetes.io/auth-signin"
+	kAuthRespHdrs = "nginx.ingress.kubernetes.io/auth-response-headers"
+)
+
+// capability auth-* values, as they'd arrive merged into the trait props.
+func withCapAuth(props map[string]any) map[string]any {
+	props["authURL"] = "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:4180/oauth2/auth"
+	props["authSigninURL"] = "https://auth-proxy.example.net/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+	props["authResponseHeaders"] = "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Groups"
+	props["hostnames"] = []any{"a.apps.example.com"}
+	return props
+}
+
+func TestExposeHandler_Ingress_ExtAuth_Default(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("web", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(withCapAuth(map[string]any{"allowedGroups": []any{"ginsys-admins"}}))
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if got := ing.Annotations[kAuthURL]; got != "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:4180/oauth2/auth?allowed_groups=ginsys-admins" {
+		t.Errorf("auth-url = %q", got)
+	}
+	if got := ing.Annotations[kAuthSignin]; got != "https://auth-proxy.example.net/oauth2/start?rd=$scheme://$host$escaped_request_uri" {
+		t.Errorf("auth-signin = %q", got)
+	}
+	if got := ing.Annotations[kAuthRespHdrs]; got != "X-Auth-Request-User,X-Auth-Request-Email,X-Auth-Request-Groups" {
+		t.Errorf("auth-response-headers = %q", got)
+	}
+}
+
+func TestExposeHandler_Ingress_ExtAuth_CSVOrderPreserved(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(withCapAuth(map[string]any{"allowedGroups": []any{"home-users", "home-admins"}}))
+	if err := h.Apply(trait, newWebApp("web", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if got := ing.Annotations[kAuthURL]; got != "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:4180/oauth2/auth?allowed_groups=home-users,home-admins" {
+		t.Errorf("auth-url CSV order = %q, want home-users,home-admins", got)
+	}
+}
+
+func TestExposeHandler_Ingress_ExtAuth_SigninOverride(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	props := withCapAuth(map[string]any{"allowedGroups": []any{"home-users"}})
+	// inline override wins over the capability default (resolveCapability merges
+	// rendering first, then trait props) — set it after the capability default.
+	props["authSigninURL"] = "https://video.home.example.be/oauth2/start?rd=$scheme://$host$escaped_request_uri"
+	if err := h.Apply(exposeIngress(props), newWebApp("web", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if got := ing.Annotations[kAuthSignin]; got != "https://video.home.example.be/oauth2/start?rd=$scheme://$host$escaped_request_uri" {
+		t.Errorf("auth-signin override = %q", got)
+	}
+}
+
+func TestExposeHandler_Ingress_ExtAuth_TypedBeatsAnnotation(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	props := withCapAuth(map[string]any{
+		"allowedGroups": []any{"ginsys-admins"},
+		"annotations":   map[string]any{kAuthURL: "http://evil.example/auth?allowed_groups=everyone"},
+	})
+	if err := h.Apply(exposeIngress(props), newWebApp("web", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if got := ing.Annotations[kAuthURL]; got != "http://oauth2-proxy.oauth2-proxy.svc.cluster.local:4180/oauth2/auth?allowed_groups=ginsys-admins" {
+		t.Errorf("typed auth-url must beat authored annotation, got %q", got)
+	}
+}
+
+func TestExposeHandler_Ingress_ExtAuth_MissingURL_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	// allowedGroups but no capability authURL.
+	trait := exposeIngress(map[string]any{
+		"allowedGroups": []any{"ginsys-admins"},
+		"hostnames":     []any{"a.apps.example.com"},
+	})
+	err := h.Apply(trait, newWebApp("web", "default"), bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("want *ValidationError (ext-auth not offered), got %v", err)
+	}
+}
+
+func TestExposeHandler_Ingress_ExtAuth_EmptyGroups_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	trait := exposeIngress(withCapAuth(map[string]any{"allowedGroups": []any{}}))
+	err := h.Apply(trait, newWebApp("web", "default"), bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("want *ValidationError for empty allowedGroups, got %v", err)
+	}
+}
+
+func TestExposeHandler_ExtAuth_AuthURLWithQuery_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{
+		"controllerType":   "ingress",
+		"ingressClassName": "nginx",
+		"authURL":          "http://oauth2-proxy/oauth2/auth?already=here",
+	})
+	if err == nil {
+		t.Fatal("want error: authURL with a query string")
+	}
+}
+
+func TestExposeHandler_ExtAuth_GatewayRendering_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	_, err := h.ValidateAndApplyDefaults(map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "public-gateway",
+		"authURL":        "http://oauth2-proxy/oauth2/auth",
+	})
+	if err == nil {
+		t.Fatal("want error: authURL not valid for gateway rendering")
+	}
+}
+
+func TestExposeHandler_Gateway_InlineAllowedGroups_Rejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{Type: "expose", Properties: map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "public-gateway",
+		"allowedGroups":  []any{"ginsys-admins"},
+	}}
+	err := h.Apply(trait, newWebApp("web", "default"), bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("want *ValidationError for inline allowedGroups on gateway, got %v", err)
+	}
+}

--- a/pkg/oam/builtin/traits/hostname.go
+++ b/pkg/oam/builtin/traits/hostname.go
@@ -19,6 +19,14 @@ const (
 	forceSSLRedirectAnnotation = "nginx.ingress.kubernetes.io/force-ssl-redirect"
 )
 
+// nginx external-auth (oauth2-proxy) annotations the expose trait writes from its
+// allowedGroups / authSigninURL properties plus the capability auth-url / auth-response-headers.
+const (
+	authURLAnnotation             = "nginx.ingress.kubernetes.io/auth-url"
+	authSigninAnnotation          = "nginx.ingress.kubernetes.io/auth-signin"
+	authResponseHeadersAnnotation = "nginx.ingress.kubernetes.io/auth-response-headers"
+)
+
 // matchHostnameWildcard reports whether host is permitted by pattern. An empty
 // pattern permits everything. A pattern without a leading "*." must match host
 // exactly. A "*.suffix" pattern matches exactly one DNS label in place of the


### PR DESCRIPTION
Closes go-kure/launcher#193. Companion to crane#323 (phase-1). Ext-auth as an `expose` ingress sub-feature, mirroring the ssl-redirect / cluster-issuer injection.

## What
- `ExposeRendering`: flat ingress-only `authURL` / `authSigninURL` / `authResponseHeaders`. `ValidateAndApplyDefaults` rejects them on gateway, rejects signin/response-headers without `authURL`, and rejects an `authURL` with a query string.
- expose `PropertySchema`: `allowedGroups` (array), `authSigninURL` (authored override), + capability-injected `authURL` / `authResponseHeaders` (all with Descriptions).
- `setAuthAnnotations` (ingress branch): `auth-url` = `<authURL>?allowed_groups=<csv, authored order preserved>`, `auth-signin` = inline override else capability default, `auth-response-headers`. Typed values win over same-key raw annotations; absent `allowedGroups` → passthrough; empty `allowedGroups` + missing capability `authURL` → `ValidationError`; gateway branch rejects inline `allowedGroups`/`authSigninURL`.

## Tests (`expose_ext_auth_test.go`)
default-from-capability, CSV order preserved, signin override (frigate), typed-beats-annotation, missing-authURL error, empty-groups error, authURL-with-query error, gateway-rendering reject, inline-allowedGroups-on-gateway reject. Full `go test ./...`, `go vet`, `golangci-lint` all green; doc-gate OK (READMEs updated).

Held for review + release; crane#323 phase-1 wiring (reserve authURL/authResponseHeaders + opsmaster wiring, golden-neutral) bumps the pin once this ships.