### PR TITLE
chore: bump Go toolchain 1.26.4 -> 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kure/launcher
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/backube/volsync v0.16.0

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 # Use exact versions for reproducibility across environments
-go = "1.26.4"
+go = "1.26.5"
 golangci-lint = "2.10.1"
 git-cliff = "2.7.0"
 goreleaser = "2.14.3"


### PR DESCRIPTION
Clears **GO-2026-5856** (Go stdlib `crypto/tls` vulnerability, *Found in go1.26.4, Fixed in go1.26.5*) which govulncheck now flags in the Security gate on every branch.

Verified locally: building/testing under go1.26.5 succeeds, and `govulncheck ./...` then reports only the already-allowlisted GO-2026-5377 (GO-2026-5856 gone).

Updates `go.mod` (`go 1.26.5`) and `mise.toml` (`go = "1.26.5"`, from which CI derives the Go version). Separate from the ext-auth PR (#194) so main ships a clean stdlib baseline; #194 picks it up on rebase.