### PR TITLE
feat(oam): expose ComponentName() accessor on sub-app configs

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -51,6 +51,7 @@ parse → resolve parameters → transform (component + trait handlers) → mani
 | `CapabilityAware` | Mark a handler as requiring a `ClusterProfile` capability. |
 | `PropertySchemaProvider` | Declare a `PropertySchema` for the handler's user-facing properties (see below). |
 | `SourceDeduplicatable` | Collapse duplicate sources (e.g. shared OCI/Helm repos). |
+| `ComponentNamed` | Expose the owning OAM component (`ComponentName() string`) on a trait/component sub-app config, so consumers can attribute each emitted resource to its component without re-deriving it from sub-app names. |
 
 ## Property schemas
 

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -58,6 +58,8 @@ share these fields: `image` (validated — no untagged/`latest`), `env` (with
   (precedence: authored > policy default `storageSize` > `1Gi`), `replicas`,
   `backup.*`, `monitoring.enabled`, `pooler.enabled`, `managedRoles`, `databases`.
 - **passthrough** — `object` (full apiVersion/kind/metadata/spec), `clusterScoped`.
+  Its config exposes `ComponentName() string` (the `oam.ComponentNamed` interface) so
+  consumers can attribute the emitted resource to its owning OAM component.
 - **crd / manifests** — `inline` xor `url`; `manifests` adds `scopeOverrides`
   (`apiVersion`/`kind`/`scope`) for unknown kinds.
 

--- a/pkg/oam/builtin/components/component_name_test.go
+++ b/pkg/oam/builtin/components/component_name_test.go
@@ -1,0 +1,31 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+// TestPassthroughConfig_ComponentName verifies the passthrough component config
+// exposes its owning OAM component through the oam.ComponentNamed accessor.
+func TestPassthroughConfig_ComponentName(t *testing.T) {
+	h := &components.PassthroughHandler{}
+	cfg, err := h.ToApplicationConfig(passthroughComponent(map[string]any{
+		"object": map[string]any{
+			"apiVersion": "sparkoperator.k8s.io/v1beta2",
+			"kind":       "SparkApplication",
+			"spec":       map[string]any{"mode": "cluster"},
+		},
+	}), "data")
+	if err != nil {
+		t.Fatalf("ToApplicationConfig: %v", err)
+	}
+	named, ok := cfg.(oam.ComponentNamed)
+	if !ok {
+		t.Fatalf("%T does not implement oam.ComponentNamed", cfg)
+	}
+	if got := named.ComponentName(); got != "my-res" {
+		t.Errorf("ComponentName() = %q, want \"my-res\"", got)
+	}
+}

--- a/pkg/oam/builtin/components/passthrough.go
+++ b/pkg/oam/builtin/components/passthrough.go
@@ -85,7 +85,7 @@ func (h *PassthroughHandler) ToApplicationConfig(component *oam.Component, names
 	}
 
 	return &PassthroughConfig{
-		ComponentName: component.Name,
+		componentName: component.Name,
 		Namespace:     namespace,
 		ClusterScoped: clusterScoped,
 		Object:        object,
@@ -96,11 +96,15 @@ func (h *PassthroughHandler) ToApplicationConfig(component *oam.Component, names
 // It emits the declared object verbatim, defaulting metadata.name to the component
 // name and (for namespaced objects) metadata.namespace to the build namespace.
 type PassthroughConfig struct {
-	ComponentName string
+	componentName string
 	Namespace     string
 	ClusterScoped bool
 	Object        map[string]any
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *PassthroughConfig) ComponentName() string { return c.componentName }
 
 // Generate emits the declared object as an unstructured resource. It deep-copies
 // the object first so the metadata fixup — and any later in-place mutation of
@@ -115,7 +119,7 @@ func (c *PassthroughConfig) Generate(_ *stack.Application) ([]*client.Object, er
 		obj["metadata"] = meta
 	}
 	if name, ok := meta["name"].(string); !ok || name == "" {
-		meta["name"] = c.ComponentName
+		meta["name"] = c.componentName
 	}
 	if !c.ClusterScoped {
 		if ns, ok := meta["namespace"].(string); !ok || ns == "" {

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -105,6 +105,16 @@ See [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/
 for the full config-field reference, the [OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam)
 for the interfaces, and `examples/` for runnable applications.
 
+## Component attribution
+
+Every trait sub-app config exposes the OAM component it was emitted for via
+`ComponentName() string` (the `oam.ComponentNamed` interface) — always the component
+name, never the sub-app or K8s Service name. Consumers use it to stamp per-resource
+provenance (e.g. a `wharf.zone/component` label) without re-deriving the component
+from sub-app names, which several handlers author from properties rather than
+`<component>-<suffix>`. The routing traits' existing `TargetComponentName()` (used by
+auto-NetworkPolicy synthesis) delegates to the same accessor.
+
 ## Conventions
 
 Handlers use `k8s.io/api` constants for well-known Kubernetes enum values (access

--- a/pkg/oam/builtin/traits/certificate.go
+++ b/pkg/oam/builtin/traits/certificate.go
@@ -98,7 +98,7 @@ func (h *CertificateHandler) Apply(trait *oam.Trait, app *stack.Application, bun
 
 func (h *CertificateHandler) parseProperties(props map[string]any, app *stack.Application) (*CertificateConfig, error) {
 	config := &CertificateConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 		Duration:      "2160h",
 		RenewBefore:   "360h",
 	}
@@ -226,7 +226,7 @@ func validatePrivateKeySize(algorithm string, size int) error {
 // CertificateConfig implements stack.ApplicationConfig for certificate traits.
 type CertificateConfig struct {
 	SecretName    string
-	ComponentName string
+	componentName string
 	IssuerName    string
 	IssuerKind    string
 	DNSNames      []string
@@ -239,6 +239,10 @@ type CertificateConfig struct {
 	PKEncoding       string
 	PKRotationPolicy string
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *CertificateConfig) ComponentName() string { return c.componentName }
 
 // ApplyPolicy is a no-op: certificates have no enforceable policy fields.
 func (c *CertificateConfig) ApplyPolicy(_ oam.Policy) error { return nil }

--- a/pkg/oam/builtin/traits/cilium_networkpolicy.go
+++ b/pkg/oam/builtin/traits/cilium_networkpolicy.go
@@ -58,9 +58,10 @@ func (h *CiliumNetworkPolicyHandler) Apply(trait *oam.Trait, app *stack.Applicat
 	return nil
 }
 
-// app is reserved for future component-aware policy synthesis (defaulting
-// endpointSelector from component labels, scoping rules to service ports).
-func (h *CiliumNetworkPolicyHandler) parseProperties(props map[string]any, _ *stack.Application) (*CiliumNetworkPolicyConfig, error) {
+// app supplies the owning component name (componentName); deeper component-aware
+// policy synthesis (defaulting endpointSelector from component labels, scoping rules
+// to service ports) remains future work.
+func (h *CiliumNetworkPolicyHandler) parseProperties(props map[string]any, app *stack.Application) (*CiliumNetworkPolicyConfig, error) {
 	name, ok := props["name"].(string)
 	if !ok || name == "" {
 		return nil, errors.New("required property 'name' missing or not a string")
@@ -74,6 +75,7 @@ func (h *CiliumNetworkPolicyHandler) parseProperties(props map[string]any, _ *st
 
 	return &CiliumNetworkPolicyConfig{
 		Name:             name,
+		componentName:    app.Name,
 		EndpointSelector: props["endpointSelector"],
 		Egress:           props["egress"],
 		Ingress:          props["ingress"],
@@ -83,10 +85,15 @@ func (h *CiliumNetworkPolicyHandler) parseProperties(props map[string]any, _ *st
 // CiliumNetworkPolicyConfig implements stack.ApplicationConfig for cilium-networkpolicy traits.
 type CiliumNetworkPolicyConfig struct {
 	Name             string
+	componentName    string
 	EndpointSelector any
 	Egress           any
 	Ingress          any
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *CiliumNetworkPolicyConfig) ComponentName() string { return c.componentName }
 
 // Generate creates a cilium.io/v2 CiliumNetworkPolicy via JSON round-trip.
 func (c *CiliumNetworkPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {

--- a/pkg/oam/builtin/traits/component_name_test.go
+++ b/pkg/oam/builtin/traits/component_name_test.go
@@ -1,0 +1,135 @@
+package traits_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// TestTraitConfigs_ComponentName verifies every trait sub-app config exposes the
+// owning OAM component through the oam.ComponentNamed accessor, and that the value
+// is the component name (app.Name) — never a sub-app or K8s Service name.
+func TestTraitConfigs_ComponentName(t *testing.T) {
+	const component = "api"
+
+	cases := []struct {
+		name    string
+		handler oam.TraitHandler
+		app     *stack.Application
+		trait   *oam.Trait
+	}{
+		{
+			name:    "configmap",
+			handler: &traits.ConfigMapHandler{},
+			app:     newApp(component, "default"),
+			trait:   &oam.Trait{Type: "configmap", Properties: map[string]any{"name": "cfg"}},
+		},
+		{
+			name:    "scaler",
+			handler: &traits.ScalerHandler{},
+			app:     newApp(component, "default"),
+			trait:   &oam.Trait{Type: "scaler", Properties: map[string]any{"minReplicas": 2, "maxReplicas": 10}},
+		},
+		{
+			name:    "networkpolicy",
+			handler: &traits.NetworkPolicyHandler{},
+			app:     newApp(component, "default"),
+			trait: &oam.Trait{Type: "networkpolicy", Properties: map[string]any{
+				"egress": []any{map[string]any{
+					"to": []any{map[string]any{"podSelector": map[string]any{"matchLabels": map[string]any{"app": "backend"}}}},
+				}},
+			}},
+		},
+		{
+			name:    "cilium-networkpolicy",
+			handler: &traits.CiliumNetworkPolicyHandler{},
+			app:     newApp(component, "default"),
+			trait: &oam.Trait{Type: "cilium-networkpolicy", Properties: map[string]any{
+				"name":    "test-policy",
+				"ingress": []any{map[string]any{"fromEndpoints": []any{map[string]any{"matchLabels": map[string]any{"app": "frontend"}}}}},
+			}},
+		},
+		{
+			name:    "ingress",
+			handler: &traits.IngressHandler{},
+			app:     newWebApp(component, "default"),
+			trait:   ingressTrafficSourcesTrait(nil),
+		},
+		{
+			name:    "httproute",
+			handler: &traits.HTTPRouteHandler{},
+			app:     newWebApp(component, "default"),
+			trait:   httprouteTrait(map[string]any{"gatewayName": "public"}),
+		},
+		{
+			name:    "certificate",
+			handler: &traits.CertificateHandler{},
+			app:     newApp(component, "default"),
+			trait: &oam.Trait{Type: "certificate", Properties: map[string]any{
+				"secretName": "my-tls",
+				"issuerRef":  map[string]any{"name": "letsencrypt-prod", "kind": "ClusterIssuer"},
+				"dnsNames":   []any{"example.com"},
+			}},
+		},
+		{
+			name:    "pvc",
+			handler: &traits.PVCHandler{},
+			app:     newApp(component, "default"),
+			trait:   &oam.Trait{Type: "pvc", Properties: map[string]any{"name": "shared-data", "size": "5Gi"}},
+		},
+		{
+			name:    "external-secret",
+			handler: &traits.ExternalSecretHandler{},
+			app:     newApp(component, "default"),
+			trait: &oam.Trait{Type: "external-secret", Properties: map[string]any{
+				"secretName":     "my-secret",
+				"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+				"data": []any{map[string]any{
+					"secretKey": "DB_PASS",
+					"remoteRef": map[string]any{"key": "prod/db", "property": "password"},
+				}},
+			}},
+		},
+		{
+			name:    "rbac",
+			handler: &traits.RBACHandler{},
+			app:     newApp(component, "default"),
+			trait: &oam.Trait{Type: "rbac", Properties: map[string]any{
+				"rules": []any{map[string]any{
+					"apiGroups": []any{""},
+					"resources": []any{"pods"},
+					"verbs":     []any{"get", "list"},
+				}},
+			}},
+		},
+		{
+			name:    "volsync",
+			handler: &traits.VolSyncHandler{},
+			app:     newApp(component, "default"),
+			trait:   &oam.Trait{Type: "volsync", Properties: map[string]any{"sourcePVC": "data", "schedule": "@daily"}},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bundle := newBundle()
+			if err := tc.handler.Apply(tc.trait, tc.app, bundle); err != nil {
+				t.Fatalf("Apply: %v", err)
+			}
+			if len(bundle.Applications) == 0 {
+				t.Fatal("handler appended no sub-application")
+			}
+			cfg := bundle.Applications[len(bundle.Applications)-1].Config
+			named, ok := cfg.(oam.ComponentNamed)
+			if !ok {
+				t.Fatalf("%T does not implement oam.ComponentNamed", cfg)
+			}
+			if got := named.ComponentName(); got != component {
+				t.Errorf("ComponentName() = %q, want %q", got, component)
+			}
+		})
+	}
+}

--- a/pkg/oam/builtin/traits/configmap.go
+++ b/pkg/oam/builtin/traits/configmap.go
@@ -78,7 +78,7 @@ func (h *ConfigMapHandler) Apply(trait *oam.Trait, app *stack.Application, bundl
 
 	cmConfig := &ConfigMapConfig{
 		Name:          name,
-		ComponentName: app.Name,
+		componentName: app.Name,
 		Data:          data,
 	}
 	cmApp := stack.NewApplication(name, app.Namespace, cmConfig)
@@ -98,14 +98,18 @@ func (h *ConfigMapHandler) Apply(trait *oam.Trait, app *stack.Application, bundl
 // ConfigMapConfig implements stack.ApplicationConfig for configmap traits.
 type ConfigMapConfig struct {
 	Name          string
-	ComponentName string
+	componentName string
 	Data          map[string]string
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *ConfigMapConfig) ComponentName() string { return c.componentName }
 
 // Generate creates a Kubernetes ConfigMap resource.
 func (c *ConfigMapConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	cm := kubernetes.CreateConfigMap(app.Name, app.Namespace)
-	kubernetes.SetConfigMapLabels(cm, map[string]string{"app": c.ComponentName})
+	kubernetes.SetConfigMapLabels(cm, map[string]string{"app": c.componentName})
 	cm.Annotations = nil
 	if len(c.Data) > 0 {
 		kubernetes.AddConfigMapDataMap(cm, c.Data)

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -128,7 +128,7 @@ func (h *ExternalSecretHandler) PropertySchema() map[string]oam.PropertySchema {
 
 func (h *ExternalSecretHandler) parseProperties(props map[string]any, app *stack.Application) (*ExternalSecretConfig, error) {
 	config := &ExternalSecretConfig{
-		ComponentName:   app.Name,
+		componentName:   app.Name,
 		RefreshInterval: "1h",
 	}
 
@@ -378,7 +378,7 @@ type esTemplate struct {
 // ExternalSecretConfig implements stack.ApplicationConfig for external-secret traits.
 type ExternalSecretConfig struct {
 	SecretName       string
-	ComponentName    string
+	componentName    string
 	StoreRefName     string
 	StoreRefKind     string
 	RefreshInterval  string
@@ -389,6 +389,10 @@ type ExternalSecretConfig struct {
 	Data             []esDataEntry
 	DataFrom         []esDataFromEntry
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *ExternalSecretConfig) ComponentName() string { return c.componentName }
 
 // Generate creates an ExternalSecret CRD resource.
 func (c *ExternalSecretConfig) Generate(app *stack.Application) ([]*client.Object, error) {
@@ -405,7 +409,7 @@ func (c *ExternalSecretConfig) Generate(app *stack.Application) ([]*client.Objec
 			Kind: c.StoreRefKind,
 		},
 	})
-	externalsecrets.AddExternalSecretLabel(es, "app", c.ComponentName)
+	externalsecrets.AddExternalSecretLabel(es, "app", c.componentName)
 	externalsecrets.SetRefreshInterval(es, metav1.Duration{Duration: dur})
 
 	target := esv1.ExternalSecretTarget{Name: c.TargetSecretName}

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -114,7 +114,7 @@ func (h *HTTPRouteHandler) PropertySchema() map[string]oam.PropertySchema {
 func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Application) (*HTTPRouteConfig, error) {
 	defaultPort := resolveDefaultPort(app)
 	config := &HTTPRouteConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 	}
 
 	// Trait-level explicit backend — same semantics as ingress: servicePort first,
@@ -901,7 +901,7 @@ func isAllowedRedirectStatus(code int) bool {
 type HTTPRouteConfig struct {
 	Name          string // optional, overrides sub-app name for multi-httproute components
 	Scope         string // optional; sub-app name becomes {component}-httproute-{scope} when set and Name is empty
-	ComponentName string
+	componentName string
 	ParentRefs    []ParentRef
 	Hostnames     []string
 	Rules         []HTTPRouteRule
@@ -915,9 +915,13 @@ type HTTPRouteConfig struct {
 // TrafficSources implements the cluster-level trafficSourceCollector contract.
 func (c *HTTPRouteConfig) TrafficSources() []netpol.TrafficSource { return c.sources }
 
+// ComponentName returns the OAM component this sub-app belongs to — always the OAM
+// component name, not the K8s Service name — for resource provenance attribution.
+func (c *HTTPRouteConfig) ComponentName() string { return c.componentName }
+
 // TargetComponentName returns the OAM component label (not the K8s Service name),
 // so the synthesized NetworkPolicy selects the component's pods via {app: <name>}.
-func (c *HTTPRouteConfig) TargetComponentName() string { return c.ComponentName }
+func (c *HTTPRouteConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.
 func (c *HTTPRouteConfig) BackendPorts() []intstr.IntOrString { return c.ports }
@@ -1075,7 +1079,7 @@ type BackendRef struct {
 // Generate creates a Gateway API HTTPRoute resource.
 func (c *HTTPRouteConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	route := kubernetes.CreateHTTPRoute(app.Name, app.Namespace)
-	route.Labels = map[string]string{"app": c.ComponentName}
+	route.Labels = map[string]string{"app": c.componentName}
 	route.Annotations = nil
 
 	for _, ref := range c.ParentRefs {

--- a/pkg/oam/builtin/traits/httproute_test.go
+++ b/pkg/oam/builtin/traits/httproute_test.go
@@ -156,7 +156,7 @@ func TestHTTPRouteHandler_Apply_Scope(t *testing.T) {
 
 func TestHTTPRouteConfig_Generate_Basic(t *testing.T) {
 	cfg := &HTTPRouteConfig{
-		ComponentName: "web",
+		componentName: "web",
 		ParentRefs:    []ParentRef{{Name: "my-gateway"}},
 		Rules: []HTTPRouteRule{
 			{BackendRefs: []BackendRef{{Name: "web", Port: 80}}},

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -151,7 +151,7 @@ func (h *IngressHandler) Apply(trait *oam.Trait, app *stack.Application, bundle 
 func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Application) (*IngressConfig, error) {
 	defaultPort := resolveDefaultPort(app)
 	config := &IngressConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 		ServiceName:   resolveServiceName(app),
 	}
 
@@ -348,7 +348,7 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 type IngressConfig struct {
 	Name             string
 	Scope            string // optional; sub-app name becomes {component}-ingress-{scope} when set and Name is empty
-	ComponentName    string // label value — always the OAM component name, not the K8s Service name
+	componentName    string
 	Annotations      map[string]string
 	IngressClassName string
 	Rules            []IngressRule
@@ -364,9 +364,13 @@ type IngressConfig struct {
 // TrafficSources implements the cluster-level trafficSourceCollector contract.
 func (c *IngressConfig) TrafficSources() []netpol.TrafficSource { return c.sources }
 
+// ComponentName returns the OAM component this sub-app belongs to — always the OAM
+// component name, not the K8s Service name — for resource provenance attribution.
+func (c *IngressConfig) ComponentName() string { return c.componentName }
+
 // TargetComponentName returns the OAM component label (not the K8s Service name),
 // so the synthesized NetworkPolicy selects the component's pods via {app: <name>}.
-func (c *IngressConfig) TargetComponentName() string { return c.ComponentName }
+func (c *IngressConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.
 func (c *IngressConfig) BackendPorts() []intstr.IntOrString { return c.ports }
@@ -395,7 +399,7 @@ type IngressTLS struct {
 // Generate creates a Kubernetes Ingress resource.
 func (c *IngressConfig) Generate(app *stack.Application) ([]*client.Object, error) {
 	labels := map[string]string{
-		"app": c.ComponentName,
+		"app": c.componentName,
 	}
 
 	ingress := kubernetes.CreateIngress(app.Name, app.Namespace, c.IngressClassName)

--- a/pkg/oam/builtin/traits/networkpolicy.go
+++ b/pkg/oam/builtin/traits/networkpolicy.go
@@ -115,7 +115,7 @@ func (h *NetworkPolicyHandler) Apply(trait *oam.Trait, app *stack.Application, b
 
 func (h *NetworkPolicyHandler) parseProperties(props map[string]any, app *stack.Application) (*NetworkPolicyConfig, error) {
 	config := &NetworkPolicyConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 	}
 
 	rawIngress, hasIngress := props["ingress"]
@@ -322,10 +322,14 @@ func parseNPPort(raw any, path string) (npPort, error) {
 
 // NetworkPolicyConfig implements stack.ApplicationConfig for networkpolicy traits.
 type NetworkPolicyConfig struct {
-	ComponentName string
+	componentName string
 	Ingress       []npIngressRule
 	Egress        []npEgressRule
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *NetworkPolicyConfig) ComponentName() string { return c.componentName }
 
 type npIngressRule struct {
 	From  []npPeer
@@ -350,11 +354,11 @@ type npPort struct {
 
 // Generate creates a Kubernetes NetworkPolicy resource.
 func (c *NetworkPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
-	np := kubernetes.CreateNetworkPolicy(c.ComponentName+"-allow", app.Namespace)
-	np.Labels = map[string]string{"app": c.ComponentName}
+	np := kubernetes.CreateNetworkPolicy(c.componentName+"-allow", app.Namespace)
+	np.Labels = map[string]string{"app": c.componentName}
 	np.Annotations = nil
 	kubernetes.SetNetworkPolicyPodSelector(np, metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": c.ComponentName},
+		MatchLabels: map[string]string{"app": c.componentName},
 	})
 
 	if len(c.Ingress) > 0 {

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -101,7 +101,7 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 
 	return &PVCTraitConfig{
 		Name:          name,
-		ComponentName: app.Name,
+		componentName: app.Name,
 		Size:          size,
 		StorageClass:  storageClass,
 		AccessModes:   accessModes,
@@ -111,11 +111,15 @@ func (h *PVCHandler) parseProperties(props map[string]any, app *stack.Applicatio
 // PVCTraitConfig implements stack.ApplicationConfig for standalone PVC traits.
 type PVCTraitConfig struct {
 	Name          string
-	ComponentName string
+	componentName string
 	Size          string
 	StorageClass  string
 	AccessModes   []string
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *PVCTraitConfig) ComponentName() string { return c.componentName }
 
 // ApplyPolicy defaults the PVC size from the policy when the trait omitted it,
 // validates the effective size, and enforces the policy storage-size limit.
@@ -156,7 +160,7 @@ func (c *PVCTraitConfig) Generate(app *stack.Application) ([]*client.Object, err
 		return nil, err
 	}
 
-	labels := map[string]string{"app": c.ComponentName}
+	labels := map[string]string{"app": c.componentName}
 	pvc, err := components.BuildPVC(components.PVCConfig{
 		Name:         c.Name,
 		Size:         c.Size,

--- a/pkg/oam/builtin/traits/rbac.go
+++ b/pkg/oam/builtin/traits/rbac.go
@@ -80,7 +80,7 @@ func (h *RBACHandler) parseProperties(props map[string]any, app *stack.Applicati
 	}
 
 	return &rbacTraitConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 		Namespace:     app.Namespace,
 		Rules:         rules,
 		ClusterWide:   clusterWide,
@@ -136,16 +136,20 @@ type rbacRule struct {
 }
 
 type rbacTraitConfig struct {
-	ComponentName string
+	componentName string
 	Namespace     string
 	Rules         []rbacRule
 	ClusterWide   bool
 }
 
-func (c *rbacTraitConfig) Generate(app *stack.Application) ([]*client.Object, error) {
-	labels := map[string]string{"app": c.ComponentName}
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *rbacTraitConfig) ComponentName() string { return c.componentName }
 
-	role := kubernetes.CreateRole(c.ComponentName, c.Namespace)
+func (c *rbacTraitConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	labels := map[string]string{"app": c.componentName}
+
+	role := kubernetes.CreateRole(c.componentName, c.Namespace)
 	role.Labels = labels
 	role.Annotations = nil
 	for _, r := range c.Rules {
@@ -156,17 +160,17 @@ func (c *rbacTraitConfig) Generate(app *stack.Application) ([]*client.Object, er
 		})
 	}
 
-	rb := kubernetes.CreateRoleBinding(c.ComponentName, c.Namespace)
+	rb := kubernetes.CreateRoleBinding(c.componentName, c.Namespace)
 	rb.Labels = labels
 	rb.Annotations = nil
 	kubernetes.SetRoleBindingRoleRef(rb, rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "Role",
-		Name:     c.ComponentName,
+		Name:     c.componentName,
 	})
 	kubernetes.AddRoleBindingSubject(rb, rbacv1.Subject{
 		Kind:      rbacv1.ServiceAccountKind,
-		Name:      c.ComponentName,
+		Name:      c.componentName,
 		Namespace: c.Namespace,
 	})
 
@@ -178,7 +182,7 @@ func (c *rbacTraitConfig) Generate(app *stack.Application) ([]*client.Object, er
 		return objects, nil
 	}
 
-	cr := kubernetes.CreateClusterRole(c.ComponentName)
+	cr := kubernetes.CreateClusterRole(c.componentName)
 	cr.Labels = labels
 	cr.Annotations = nil
 	for _, r := range c.Rules {
@@ -189,17 +193,17 @@ func (c *rbacTraitConfig) Generate(app *stack.Application) ([]*client.Object, er
 		})
 	}
 
-	crb := kubernetes.CreateClusterRoleBinding(c.ComponentName)
+	crb := kubernetes.CreateClusterRoleBinding(c.componentName)
 	crb.Labels = labels
 	crb.Annotations = nil
 	kubernetes.SetClusterRoleBindingRoleRef(crb, rbacv1.RoleRef{
 		APIGroup: rbacv1.GroupName,
 		Kind:     "ClusterRole",
-		Name:     c.ComponentName,
+		Name:     c.componentName,
 	})
 	kubernetes.AddClusterRoleBindingSubject(crb, rbacv1.Subject{
 		Kind:      rbacv1.ServiceAccountKind,
-		Name:      c.ComponentName,
+		Name:      c.componentName,
 		Namespace: c.Namespace,
 	})
 

--- a/pkg/oam/builtin/traits/scaler.go
+++ b/pkg/oam/builtin/traits/scaler.go
@@ -55,7 +55,7 @@ func (h *ScalerHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 
 func (h *ScalerHandler) parseProperties(props map[string]any, app *stack.Application) (*ScalerConfig, error) {
 	config := &ScalerConfig{
-		ComponentName: app.Name,
+		componentName: app.Name,
 	}
 
 	// minReplicas/maxReplicas are optional at parse time: a policy default may
@@ -145,7 +145,7 @@ func toInt32ForScaler(v any) (int32, bool) {
 
 // ScalerConfig implements stack.ApplicationConfig for scaler traits.
 type ScalerConfig struct {
-	ComponentName     string
+	componentName     string
 	MinReplicas       int32
 	MaxReplicas       int32
 	CPUUtilization    *int32
@@ -155,6 +155,10 @@ type ScalerConfig struct {
 	explicitMinReplicas bool
 	explicitMaxReplicas bool
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *ScalerConfig) ComponentName() string { return c.componentName }
 
 // ApplyPolicy fills minReplicas/maxReplicas from the policy defaults when the
 // trait omitted them, validates the effective values, and enforces the policy
@@ -199,7 +203,7 @@ func (c *ScalerConfig) Generate(app *stack.Application) ([]*client.Object, error
 		return nil, err
 	}
 
-	labels := map[string]string{"app": c.ComponentName}
+	labels := map[string]string{"app": c.componentName}
 
 	var resources []*client.Object
 
@@ -217,10 +221,10 @@ func (c *ScalerConfig) Generate(app *stack.Application) ([]*client.Object, error
 }
 
 func (c *ScalerConfig) buildHPA(app *stack.Application, labels map[string]string) *autoscalingv2.HorizontalPodAutoscaler {
-	hpa := kubernetes.CreateHorizontalPodAutoscaler(c.ComponentName+"-hpa", app.Namespace)
+	hpa := kubernetes.CreateHorizontalPodAutoscaler(c.componentName+"-hpa", app.Namespace)
 	hpa.Labels = labels
 	hpa.Annotations = nil
-	kubernetes.SetHPAScaleTargetRef(hpa, "apps/v1", "Deployment", c.ComponentName)
+	kubernetes.SetHPAScaleTargetRef(hpa, "apps/v1", "Deployment", c.componentName)
 	kubernetes.SetHPAMinMaxReplicas(hpa, c.MinReplicas, c.MaxReplicas)
 	if c.CPUUtilization != nil {
 		kubernetes.AddHPACPUMetric(hpa, *c.CPUUtilization)
@@ -232,12 +236,12 @@ func (c *ScalerConfig) buildHPA(app *stack.Application, labels map[string]string
 }
 
 func (c *ScalerConfig) buildPDB(app *stack.Application, labels map[string]string) *policyv1.PodDisruptionBudget {
-	pdb := kubernetes.CreatePodDisruptionBudget(c.ComponentName+"-pdb", app.Namespace)
+	pdb := kubernetes.CreatePodDisruptionBudget(c.componentName+"-pdb", app.Namespace)
 	pdb.Labels = labels
 	pdb.Annotations = nil
 	kubernetes.SetPDBMinAvailable(pdb, intstr.FromString("50%"))
 	kubernetes.SetPDBSelector(pdb, &metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": c.ComponentName},
+		MatchLabels: map[string]string{"app": c.componentName},
 	})
 	return pdb
 }

--- a/pkg/oam/builtin/traits/traits_test.go
+++ b/pkg/oam/builtin/traits/traits_test.go
@@ -1770,13 +1770,19 @@ func TestCiliumNetworkPolicyConfig_Generate(t *testing.T) {
 }
 
 func TestConfigMapConfig_Generate(t *testing.T) {
-	cfg := &traits.ConfigMapConfig{
-		Name:          "my-config",
-		ComponentName: "api",
-		Data:          map[string]string{"KEY": "value"},
+	bundle := newBundle()
+	h := &traits.ConfigMapHandler{}
+	err := h.Apply(&oam.Trait{
+		Type: "configmap",
+		Properties: map[string]any{
+			"name": "my-config",
+			"data": map[string]any{"KEY": "value"},
+		},
+	}, newApp("api", "default"), bundle)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
 	}
-	app := newApp("my-config", "default")
-	objects, err := cfg.Generate(app)
+	objects, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
 	}

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -78,7 +78,7 @@ func (h *VolSyncHandler) parseProperties(props map[string]any, app *stack.Applic
 	}
 
 	config := &VolsyncConfig{
-		ComponentName:     app.Name,
+		componentName:     app.Name,
 		SourcePVC:         sourcePVC,
 		Schedule:          schedule,
 		CopyMethod:        "Snapshot",
@@ -144,7 +144,7 @@ func (h *VolSyncHandler) parseProperties(props map[string]any, app *stack.Applic
 
 // VolsyncConfig implements stack.ApplicationConfig for volsync traits.
 type VolsyncConfig struct {
-	ComponentName           string
+	componentName           string
 	SourcePVC               string
 	Schedule                string
 	Repository              string
@@ -156,6 +156,10 @@ type VolsyncConfig struct {
 	RetainWeekly            int
 	RetainMonthly           int
 }
+
+// ComponentName returns the OAM component this sub-app belongs to, for resource
+// provenance attribution.
+func (c *VolsyncConfig) ComponentName() string { return c.componentName }
 
 // yamlToInt converts a numeric value (int, float64) from YAML to int.
 // Non-integer float values (e.g. 1.5) are rejected.

--- a/pkg/oam/handler.go
+++ b/pkg/oam/handler.go
@@ -43,3 +43,11 @@ type SourceDeduplicatable interface {
 	GetSourceRefName() string
 	SuppressSourceGeneration(refName string)
 }
+
+// ComponentNamed is an optional interface for trait/component sub-app
+// ApplicationConfig types that expose the OAM component they were emitted for.
+// Consumers use it to attribute each emitted resource to its owning component
+// (e.g. a provenance label) without re-deriving the component from sub-app names.
+type ComponentNamed interface {
+	ComponentName() string
+}


### PR DESCRIPTION
Refs #196.

## What
A uniform `ComponentName() string` accessor on every trait/component sub-app config, so consumers can attribute each emitted resource to its owning OAM component without re-deriving it from sub-app names (several handlers author sub-app names from properties, not `<component>-<suffix>`).

## How
- The 11 configs that already carried an exported `ComponentName string` field cannot also declare a method of that name (Go name clash) → the field is unexported to `componentName` and the method reads it. The accessor becomes the single public contract, and the value is sourced only from `app.Name`. Safe: the only readers were in-package label-setting; crane's `.ComponentName` reads are on crane's own structs.
- `cilium_networkpolicy` — the only listed config missing the field — gains it, set from `app.Name`.
- The routing traits' `TargetComponentName()` (used by auto-NetworkPolicy synthesis) now delegates to `ComponentName()`.
- Adds the optional `oam.ComponentNamed` interface.

## Tests
`TestTraitConfigs_ComponentName` (table-driven) applies all 11 trait handlers through the real `Apply` path and asserts through the `oam.ComponentNamed` interface — which also proves the type-assert crane will perform. `TestPassthroughConfig_ComponentName` covers the component. **Accessor-only — no golden change.** build / vet / lint / `go test ./...` / doc-sync / doc-gate all green.

## Downstream & release
- Consumed by **crane#324** (`wharf.zone/component` provenance label). Crane's own `rbac`/`backup` configs have the identical field/method collision — the same unexport-+-method resolution lands in the crane#324 MR.
- **Held for review + release.** Do not tag `alpha.13` until this and the #328 `secretName` change land, so one tag unblocks crane#323 wiring, crane#324, and crane#328.
