### PR TITLE
fix(oam): accept security-context in validTraitTypes

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -38,6 +38,10 @@ parse → resolve parameters → transform (component + trait handlers) → mani
 | `LoadCapabilityDefinitions` | Load `CapabilityDefinition`s for capability validation. |
 | `ParseWithExtraTraitTypes` | Parse allowing additional (custom) trait types. |
 
+Standalone parsing validates each trait's `type` against the built-in handler set
+(the `security-context` trait is included, matching `SecurityContextHandler`);
+`ParseWithExtraTraitTypes` widens that allowlist with caller-supplied custom types.
+
 ## Transform & extension
 
 `NewTransformer(...)` builds a transformer from maps of component/trait handlers;

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -44,6 +44,7 @@ var validTraitTypes = map[string]bool{
 	"scaler":               true,
 	"pvc":                  true,
 	"rbac":                 true,
+	"security-context":     true,
 	"fluxcd-patches":       true,
 	"fluxcd-postbuild":     true,
 	"prune-protection":     true,

--- a/pkg/oam/validate_test.go
+++ b/pkg/oam/validate_test.go
@@ -285,3 +285,29 @@ func TestValidate_NamespaceEmpty(t *testing.T) {
 		t.Errorf("unexpected error for empty namespace: %v", err)
 	}
 }
+
+// TestValidate_SecurityContextTrait guards that standalone validation accepts the
+// security-context trait, which SecurityContextHandler ships (regression for the
+// validTraitTypes allowlist omitting a shipped handler).
+func TestValidate_SecurityContextTrait(t *testing.T) {
+	app := &Application{
+		APIVersion: SupportedAPIVersion,
+		Kind:       "Application",
+		Metadata:   Metadata{Name: "test-app"},
+		Spec: ApplicationSpec{
+			Components: []Component{
+				{
+					Name:       "web",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25"},
+					Traits: []Trait{
+						{Type: "security-context", Properties: map[string]any{"runAsNonRoot": true}},
+					},
+				},
+			},
+		},
+	}
+	if err := validate(app); err != nil {
+		t.Errorf("unexpected error for security-context trait: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #198.

`SecurityContextHandler` ships and `CanHandle("security-context")`, but the static `validTraitTypes` allowlist (`pkg/oam/validate.go`) omitted it — so launcher's **standalone** validation (`validateWithCustomTraits` with no custom types) rejected a `security-context` trait it can actually handle. Downstream crane is unaffected (it derives its allowlist from registered handlers).

- Add `"security-context": true` to `validTraitTypes`.
- Regression test `TestValidate_SecurityContextTrait` (red→green).
- `backup` correctly stays absent (crane-origin, no launcher handler).

Found in the crane#235 OAM spec review. build / vet / lint / test / doc-gate green.