### PR TITLE
feat(oam): external-secret data[] shorthand (derive remoteRef.key + property)

### DIFF
--- a/docs/oam/design-external-secret-data-shorthand.md
+++ b/docs/oam/design-external-secret-data-shorthand.md
@@ -1,0 +1,92 @@
+# Design spike: external-secret `data[]` shorthand
+
+Status: accepted (launcher#199). Companion downstream: crane external-secret
+migration (crane#235 §7).
+
+## Problem
+
+External-secret `data[]` entries are the single largest authored-OAM boilerplate in
+the opsmaster scenario — ~390 removable lines, 58% of the external-secret volume
+(measured in the crane#235 review, crane@42e3ed4e). Each entry authors 4 lines
+(`secretKey` + `remoteRef.{key,property}`), but the values are near-perfectly
+derivable. Across all 130 `data` entries in opsmaster's 37 external-secret blocks:
+
+- `remoteRef.property == secretKey` — 130/130 (100%)
+- `remoteRef.key == "<namespace>/<secretName>"` — 126/130 (97%)
+
+## Decision
+
+Extend the `data[]` entry with **derivation by absence**, keeping the entry an
+**object** (no new string form, no schema-union). A fully-conforming entry collapses
+to one line:
+
+```yaml
+data:
+  - secretKey: DB_PASSWORD          # derives remoteRef.key + remoteRef.property
+  - secretKey: TOKEN                # key override; property still derived
+    remoteRef: {key: shared/token}
+```
+
+### Derivation rules
+
+| field | required | derived when absent |
+|---|---|---|
+| `secretKey` | yes | — |
+| `remoteRef` | no | synthesized `{}` |
+| `remoteRef.key` | no | `"<app.Namespace>/<secretName>"` |
+| `remoteRef.property` | no | `secretKey` |
+| `remoteRef.version` | no | (none — emitted only when authored) |
+| `remoteRef.decodingStrategy` | no | (none — emitted only when authored) |
+
+`<secretName>` is the ExternalSecret name (`config.SecretName`); the namespace is the
+build namespace (`app.Namespace`). Both are in scope at parse time. The pre-existing
+top-level single-entry `remoteRef` object shorthand and its mutual-exclusion with
+`data`/`dataFrom` are unchanged.
+
+### Strict mode — reject unknown fields
+
+Unknown keys in a `data` entry, or inside `remoteRef`, are **rejected** with an error
+naming the offending field and listing the supported ones (`unsupported field "X"
+(supported: …)`).
+
+This is load-bearing, not house style. Because absence is now meaningful, lenient
+parsing would silently *rewrite meaning*: a typo'd `remteRef:` would be ignored, the
+parser would see `remoteRef` absent, derive `<namespace>/<secretName>`, and the app
+would fetch the **wrong secret path** — discovered at runtime, in-cluster, on auth
+material. Strict rejection is the only safe complement to defaulting-by-absence, and
+it matches the crane strict-mode charter and the #323 reject-over-ignore pins. There
+are no existing users to grandfather; the opsmaster fixtures conform.
+
+The error names the *supported* fields rather than calling the key a "typo", because
+ExternalSecrets' `RemoteRef` carries fields this handler does not model
+(`conversionStrategy`, `metadataPolicy` — unused by opsmaster); an author reaching for
+a real-but-unhandled field gets an accurate message.
+
+### Edge cases (the 4/130 non-conforming)
+
+The 4 entries whose `remoteRef.key` differs from `<namespace>/<secretName>` author
+`remoteRef.key` explicitly; the explicit value wins (no derivation for an authored
+field). Property overrides work the same way. These are the explicit-override test
+cases in `external_secret_test.go`.
+
+## Rejected alternatives
+
+- **String-list form** (`data: [DB_PASSWORD, …]`). The win is the derivation, not the
+  syntax: `- secretKey: DB_PASSWORD` already captures essentially the whole line
+  reduction. A string list buys marginal terseness at the cost of a string-or-object
+  union that exists nowhere else in the trait vocabulary.
+- **`OneOf`/union in `PropertySchema`** to model that union. A cross-repo vocabulary
+  extension (schema + crane validator + docgen rendering) for a single foreseeable
+  user does not pay for itself; if a second union case appears, `OneOf` is an additive
+  extension to add then.
+- **Parser-only string form** (accept string, don't model it in the schema). The
+  schema is the SSOT crane's validator consumes; letting it under-describe accepted
+  input reverses the #235 schema-SSOT direction and makes the generated handler
+  reference narrower than reality.
+
+## Schema impact
+
+`data.Items.remoteRef` becomes **optional** with `key`/`property` optional (a
+`dataRemoteRef` variant); `secretKey` stays required. The top-level `remoteRef`
+shorthand keeps its key-required schema. No `PropertySchema` vocabulary change, so
+crane's validator and docgen are untouched.

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -90,6 +90,13 @@ not the app — chooses the implementation:
 - **certificate** → `issuerRef` (cert-manager issuer/cluster-issuer).
 - **external-secret** → `secretStoreRef` (or the inline `provider` shorthand).
 
+  `data[]` entries derive by absence: a bare `- secretKey: FOO` defaults
+  `remoteRef.key` to `"<namespace>/<secretName>"` and `remoteRef.property` to
+  `secretKey`; author any `remoteRef` field to override. Because absence is meaningful,
+  unknown keys in an entry or its `remoteRef` are rejected (naming the supported
+  fields) rather than silently ignored. See
+  [design-external-secret-data-shorthand](../../../../docs/oam/design-external-secret-data-shorthand.md).
+
 ## Auto-synthesized NetworkPolicy
 
 Routing traits (`ingress`/`httproute`/`expose`) can surface platform-reserved

--- a/pkg/oam/builtin/traits/external_secret.go
+++ b/pkg/oam/builtin/traits/external_secret.go
@@ -2,6 +2,7 @@ package traits
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
@@ -74,8 +75,18 @@ func (h *ExternalSecretHandler) PropertySchema() map[string]oam.PropertySchema {
 			"decodingStrategy": {Type: oam.PropertyTypeString, Description: "How the fetched value is decoded (e.g. Base64, None)."},
 		},
 	}
-	requiredRemoteRef := remoteRef
-	requiredRemoteRef.Required = true
+	// dataRemoteRef is the per-entry remoteRef: optional, and its key/property are
+	// derivable (key ← "<namespace>/<secretName>", property ← secretKey) when absent.
+	dataRemoteRef := oam.PropertySchema{
+		Type:        oam.PropertyTypeObject,
+		Description: "Reference to a key in the external secret store. Optional: when omitted, key defaults to \"<namespace>/<secretName>\" and property to secretKey.",
+		Properties: map[string]oam.PropertySchema{
+			"key":              {Type: oam.PropertyTypeString, Description: "Key or path of the secret in the remote store. Defaults to \"<namespace>/<secretName>\" when omitted."},
+			"property":         {Type: oam.PropertyTypeString, Description: "Specific property within the remote secret to extract. Defaults to secretKey when omitted."},
+			"version":          {Type: oam.PropertyTypeString, Description: "Version of the remote secret to fetch."},
+			"decodingStrategy": {Type: oam.PropertyTypeString, Description: "How the fetched value is decoded (e.g. Base64, None)."},
+		},
+	}
 	return map[string]oam.PropertySchema{
 		"secretName": {Type: oam.PropertyTypeString, Required: true, Description: "Name of the generated ExternalSecret and the default target Secret."},
 		"secretStoreRef": {
@@ -107,13 +118,13 @@ func (h *ExternalSecretHandler) PropertySchema() map[string]oam.PropertySchema {
 		},
 		"data": {
 			Type:        oam.PropertyTypeArray,
-			Description: "Explicit mappings from remote store keys to entries in the target Secret.",
+			Description: "Mappings from remote store keys to entries in the target Secret. A fully-derivable entry is just {secretKey}: remoteRef.key defaults to \"<namespace>/<secretName>\" and remoteRef.property to secretKey; author remoteRef fields to override.",
 			Items: &oam.PropertySchema{
 				Type:        oam.PropertyTypeObject,
 				Description: "A single mapping of a remote reference to a target Secret key.",
 				Properties: map[string]oam.PropertySchema{
 					"secretKey": {Type: oam.PropertyTypeString, Required: true, Description: "Key in the target Secret to populate."},
-					"remoteRef": requiredRemoteRef,
+					"remoteRef": dataRemoteRef,
 				},
 			},
 		},
@@ -213,27 +224,54 @@ func (h *ExternalSecretHandler) parseProperties(props map[string]any, app *stack
 			if !ok {
 				return nil, errors.Errorf("data[%d]: expected object", i)
 			}
+			if bad := unsupportedKeys(entry, "secretKey", "remoteRef"); len(bad) > 0 {
+				return nil, errors.Errorf("data[%d]: unsupported field %q (supported: secretKey, remoteRef)", i, bad[0])
+			}
 			secretKey, _ := entry["secretKey"].(string)
 			if secretKey == "" {
 				return nil, errors.Errorf("data[%d]: required field 'secretKey' missing or empty", i)
 			}
-			rawRef, ok := entry["remoteRef"].(map[string]any)
-			if !ok {
-				return nil, errors.Errorf("data[%d]: required field 'remoteRef' missing or not an object", i)
+			// remoteRef is optional. When a field is absent the value is derived:
+			// key ← "<namespace>/<secretName>", property ← secretKey. Absence is
+			// meaningful, so unknown keys are rejected rather than silently ignored
+			// (a typo would otherwise derive a wrong remote path).
+			var ref esRemoteRef
+			if raw, present := entry["remoteRef"]; present {
+				rawRef, ok := raw.(map[string]any)
+				if !ok {
+					return nil, errors.Errorf("data[%d].remoteRef: must be an object", i)
+				}
+				if bad := unsupportedKeys(rawRef, "key", "property", "version", "decodingStrategy"); len(bad) > 0 {
+					return nil, errors.Errorf("data[%d].remoteRef: unsupported field %q (supported: key, property, version, decodingStrategy)", i, bad[0])
+				}
+				// A present-but-wrong-typed field must error, not fall through to
+				// derivation — else an authored `key: 12345` (YAML int) is silently
+				// discarded and the entry derives the wrong remote path.
+				for _, f := range []struct {
+					name string
+					dst  *string
+				}{
+					{"key", &ref.Key},
+					{"property", &ref.Property},
+					{"version", &ref.Version},
+					{"decodingStrategy", &ref.DecodingStrategy},
+				} {
+					raw, present := rawRef[f.name]
+					if !present {
+						continue
+					}
+					s, ok := raw.(string)
+					if !ok {
+						return nil, errors.Errorf("data[%d].remoteRef.%s: must be a string", i, f.name)
+					}
+					*f.dst = s
+				}
 			}
-			key, _ := rawRef["key"].(string)
-			if key == "" {
-				return nil, errors.Errorf("data[%d].remoteRef: required field 'key' missing or empty", i)
+			if ref.Key == "" {
+				ref.Key = app.Namespace + "/" + config.SecretName
 			}
-			ref := esRemoteRef{Key: key}
-			if p, ok := rawRef["property"].(string); ok {
-				ref.Property = p
-			}
-			if v, ok := rawRef["version"].(string); ok {
-				ref.Version = v
-			}
-			if ds, ok := rawRef["decodingStrategy"].(string); ok {
-				ref.DecodingStrategy = ds
+			if ref.Property == "" {
+				ref.Property = secretKey
 			}
 			config.Data = append(config.Data, esDataEntry{
 				SecretKey: secretKey,
@@ -336,6 +374,23 @@ const (
 	deletionPolicyMerge  deletionPolicy = "Merge"
 	deletionPolicyRetain deletionPolicy = "Retain"
 )
+
+// unsupportedKeys returns the keys of m not in allowed, sorted for a deterministic
+// error message.
+func unsupportedKeys(m map[string]any, allowed ...string) []string {
+	ok := make(map[string]struct{}, len(allowed))
+	for _, a := range allowed {
+		ok[a] = struct{}{}
+	}
+	var bad []string
+	for k := range m {
+		if _, found := ok[k]; !found {
+			bad = append(bad, k)
+		}
+	}
+	slices.Sort(bad)
+	return bad
+}
 
 type esDataEntry struct {
 	SecretKey string

--- a/pkg/oam/builtin/traits/external_secret_data_shorthand_test.go
+++ b/pkg/oam/builtin/traits/external_secret_data_shorthand_test.go
@@ -1,0 +1,221 @@
+package traits_test
+
+import (
+	"strings"
+	"testing"
+
+	esv1 "github.com/external-secrets/external-secrets/apis/externalsecrets/v1"
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// esFromData applies an external-secret trait with the given data entries (in
+// namespace "prod", secretName "app-secrets") and returns the generated ExternalSecret.
+func esFromData(t *testing.T, data []any) *esv1.ExternalSecret {
+	t.Helper()
+	h := &traits.ExternalSecretHandler{}
+	app := stack.NewApplication("app", "prod", nil)
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "app-secrets",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"data":           data,
+		},
+	}
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	esApp := bundle.Applications[0]
+	objs, err := esApp.Config.Generate(esApp)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	es, ok := (*objs[0]).(*esv1.ExternalSecret)
+	if !ok {
+		t.Fatalf("expected *esv1.ExternalSecret, got %T", *objs[0])
+	}
+	return es
+}
+
+// esDataErr applies an external-secret trait with the given data and returns the
+// Apply error (or fails if none).
+func esDataErr(t *testing.T, data []any) string {
+	t.Helper()
+	h := &traits.ExternalSecretHandler{}
+	app := stack.NewApplication("app", "prod", nil)
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "app-secrets",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"data":           data,
+		},
+	}
+	err := h.Apply(trait, app, bundle)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	return err.Error()
+}
+
+func assertData(t *testing.T, d esv1.ExternalSecretData, wantKey, wantProp, wantRef string) {
+	t.Helper()
+	if d.SecretKey != wantKey {
+		t.Errorf("SecretKey = %q, want %q", d.SecretKey, wantKey)
+	}
+	if d.RemoteRef.Key != wantRef {
+		t.Errorf("RemoteRef.Key = %q, want %q", d.RemoteRef.Key, wantRef)
+	}
+	if d.RemoteRef.Property != wantProp {
+		t.Errorf("RemoteRef.Property = %q, want %q", d.RemoteRef.Property, wantProp)
+	}
+}
+
+// Fully-derivable entry: {secretKey} only → key="<ns>/<secretName>", property=secretKey.
+func TestExternalSecret_DataShorthand_FullDerivation(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "DB_PASSWORD"},
+	})
+	if len(es.Spec.Data) != 1 {
+		t.Fatalf("len(Data) = %d, want 1", len(es.Spec.Data))
+	}
+	assertData(t, es.Spec.Data[0], "DB_PASSWORD", "DB_PASSWORD", "prod/app-secrets")
+}
+
+// remoteRef.key authored → key kept, property still derived from secretKey.
+func TestExternalSecret_DataShorthand_KeyOverride(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "TOKEN", "remoteRef": map[string]any{"key": "shared/token"}},
+	})
+	assertData(t, es.Spec.Data[0], "TOKEN", "TOKEN", "shared/token")
+}
+
+// remoteRef.property authored → property kept, key still derived.
+func TestExternalSecret_DataShorthand_PropertyOverride(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "API_KEY", "remoteRef": map[string]any{"property": "apiKey"}},
+	})
+	assertData(t, es.Spec.Data[0], "API_KEY", "apiKey", "prod/app-secrets")
+}
+
+// Fully-explicit entry (back-compat) → nothing derived.
+func TestExternalSecret_DataShorthand_ExplicitBackCompat(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "X", "remoteRef": map[string]any{"key": "k/path", "property": "p"}},
+	})
+	assertData(t, es.Spec.Data[0], "X", "p", "k/path")
+}
+
+// Mixed list mirroring an opsmaster block: derived entries + the outlier with an
+// explicit key that differs from <ns>/<secretName>.
+func TestExternalSecret_DataShorthand_MixedWithOutlier(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "USER"},
+		map[string]any{"secretKey": "PASS"},
+		map[string]any{"secretKey": "LEGACY", "remoteRef": map[string]any{"key": "legacy/vault/path"}},
+	})
+	if len(es.Spec.Data) != 3 {
+		t.Fatalf("len(Data) = %d, want 3", len(es.Spec.Data))
+	}
+	assertData(t, es.Spec.Data[0], "USER", "USER", "prod/app-secrets")
+	assertData(t, es.Spec.Data[1], "PASS", "PASS", "prod/app-secrets")
+	assertData(t, es.Spec.Data[2], "LEGACY", "LEGACY", "legacy/vault/path")
+}
+
+// version/decodingStrategy authored are preserved; still derive key+property.
+func TestExternalSecret_DataShorthand_PreservesOptionalRefFields(t *testing.T) {
+	es := esFromData(t, []any{
+		map[string]any{"secretKey": "K", "remoteRef": map[string]any{"version": "v2", "decodingStrategy": "Base64"}},
+	})
+	d := es.Spec.Data[0]
+	assertData(t, d, "K", "K", "prod/app-secrets")
+	if d.RemoteRef.Version != "v2" {
+		t.Errorf("Version = %q, want v2", d.RemoteRef.Version)
+	}
+	if string(d.RemoteRef.DecodingStrategy) != "Base64" {
+		t.Errorf("DecodingStrategy = %q, want Base64", d.RemoteRef.DecodingStrategy)
+	}
+}
+
+// Unknown key at the entry level is rejected, naming the offending field.
+func TestExternalSecret_DataShorthand_RejectsUnknownEntryKey(t *testing.T) {
+	msg := esDataErr(t, []any{
+		map[string]any{"secretKey": "X", "remteRef": map[string]any{"key": "k"}},
+	})
+	if !strings.Contains(msg, "unsupported field") || !strings.Contains(msg, "remteRef") {
+		t.Errorf("error = %q, want mention of unsupported field 'remteRef'", msg)
+	}
+}
+
+// Unknown key inside remoteRef is rejected, naming the offending field.
+func TestExternalSecret_DataShorthand_RejectsUnknownRemoteRefKey(t *testing.T) {
+	msg := esDataErr(t, []any{
+		map[string]any{"secretKey": "X", "remoteRef": map[string]any{"ky": "typo"}},
+	})
+	if !strings.Contains(msg, "unsupported field") || !strings.Contains(msg, "ky") {
+		t.Errorf("error = %q, want mention of unsupported field 'ky'", msg)
+	}
+}
+
+// A present-but-wrong-typed remoteRef field is rejected, not silently discarded and
+// derived (the failure class strict mode exists to prevent).
+func TestExternalSecret_DataShorthand_RejectsNonStringRefField(t *testing.T) {
+	for _, field := range []string{"key", "property", "version", "decodingStrategy"} {
+		t.Run(field, func(t *testing.T) {
+			msg := esDataErr(t, []any{
+				map[string]any{"secretKey": "X", "remoteRef": map[string]any{field: 12345}},
+			})
+			if !strings.Contains(msg, field) || !strings.Contains(msg, "must be a string") {
+				t.Errorf("error = %q, want '%s: must be a string'", msg, field)
+			}
+		})
+	}
+}
+
+// remoteRef present but not an object is rejected.
+func TestExternalSecret_DataShorthand_RejectsNonObjectRemoteRef(t *testing.T) {
+	msg := esDataErr(t, []any{
+		map[string]any{"secretKey": "X", "remoteRef": "not-an-object"},
+	})
+	if !strings.Contains(msg, "remoteRef") || !strings.Contains(msg, "object") {
+		t.Errorf("error = %q, want remoteRef-must-be-object error", msg)
+	}
+}
+
+// secretKey remains required.
+func TestExternalSecret_DataShorthand_RequiresSecretKey(t *testing.T) {
+	msg := esDataErr(t, []any{
+		map[string]any{"remoteRef": map[string]any{"key": "k"}},
+	})
+	if !strings.Contains(msg, "secretKey") {
+		t.Errorf("error = %q, want secretKey-required error", msg)
+	}
+}
+
+// Guard: the untouched top-level remoteRef shorthand stays mutually exclusive with data.
+func TestExternalSecret_TopLevelRemoteRef_StillExclusiveWithData(t *testing.T) {
+	h := &traits.ExternalSecretHandler{}
+	app := stack.NewApplication("app", "prod", nil)
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{
+		Type: "external-secret",
+		Properties: map[string]any{
+			"secretName":     "app-secrets",
+			"secretStoreRef": map[string]any{"name": "vault", "kind": "ClusterSecretStore"},
+			"remoteRef":      map[string]any{"key": "secret/db"},
+			"data":           []any{map[string]any{"secretKey": "X"}},
+		},
+	}
+	err := h.Apply(trait, app, bundle)
+	if err == nil {
+		t.Fatal("expected mutual-exclusion error for remoteRef + data, got nil")
+	}
+	if !strings.Contains(err.Error(), "cannot be combined") {
+		t.Errorf("error = %q, want 'cannot be combined'", err.Error())
+	}
+}


### PR DESCRIPTION
Refs #199. Spike-first (design spike + impl in one PR since the design was pinned up front).

## What
`external-secret` `data[]` entries derive by absence, collapsing a conforming entry from 4 lines to one `- secretKey: FOO`. Object-only entries — **no string form, no schema union** (the win is derivation, not syntax).

## Derivation
- `secretKey` — required.
- `remoteRef` — optional; absent → synthesized.
- `remoteRef.key` — absent → `"<namespace>/<secretName>"`.
- `remoteRef.property` — absent → `secretKey`.
- `version`/`decodingStrategy` — emitted only when authored. Authored fields always win (the 4/130 opsmaster outliers set `remoteRef.key` explicitly).

## Strict: reject unknown fields
Unknown keys in an entry or its `remoteRef` are rejected, **naming the supported fields** (not "typo" — ESO's RemoteRef carries `conversionStrategy`/`metadataPolicy` this handler doesn't model). Load-bearing: absence is meaningful, so a silently-ignored `remteRef:` typo would derive a **wrong secret path**, caught only at runtime on auth material.

## Schema / scope
`data.Items.remoteRef` + its `key`/`property` become optional; `secretKey` stays required. **No `PropertySchema` vocabulary change** — crane validator/docgen untouched. Top-level `remoteRef` shorthand + its mutual-exclusion unchanged (guard test added). Rejected alternatives (string-list form, `OneOf`, parser-only string) recorded in the spike doc.

## Tests / verify
11 new tests: full derivation, key-only + property-only overrides, explicit back-compat, mixed-with-outlier, preserved version/decodingStrategy, both unknown-key rejections, non-object remoteRef, secretKey-required, and the top-level-shorthand mutual-exclusion guard. build / vet / lint / `go test ./...` / doc-sync / doc-gate green.

## Downstream
crane external-secret migration (separate crane ticket, crane#235 §7). **Held for review.**