### PR TITLE
feat(oam/expose): authored secretName override on ingress TLS

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -72,8 +72,13 @@ not the app — chooses the implementation:
   On the **ingress** path, expose is platform-managed for TLS: it derives `spec.tls[]`
   from the rule hosts under a deterministic `<component>-tls` secret and emits the
   `cert-manager.io/cluster-issuer` annotation from the `certManagerClusterIssuer`
-  capability field (empty ⇒ managed TLS disabled). Users do **not** author TLS on the
-  expose trait (use the low-level `ingress` trait for full TLS control). Both paths
+  capability field (empty ⇒ managed TLS disabled). Users do **not** author the TLS
+  block on the expose trait (use the low-level `ingress` trait for full TLS control),
+  but may author `secretName` to override just the managed secret's name (still
+  ingress-only, hosts stay rule-derived, and it requires the cluster-issuer capability;
+  a `secretName` on the gateway path or without managed TLS is a `ValidationError`).
+  This lets a component carry several expose ingress traits (distinct `name`/`scope`)
+  each naming its own cert secret. Both paths
   validate user hostnames against the `allowedHostnameWildcard` capability field (empty ⇒
   no validation); a violation is a `ValidationError`.
   On the ingress path a bare `hostnames: [...]` shorthand is accepted: when `rules` is

--- a/pkg/oam/builtin/traits/expose.go
+++ b/pkg/oam/builtin/traits/expose.go
@@ -85,6 +85,7 @@ func (h *ExposeHandler) PropertySchema() map[string]oam.PropertySchema {
 		// schema as an optional enum so a value, if present, is type/enum-checked.
 		"controllerType":           {Type: oam.PropertyTypeString, Enum: []any{"ingress", "gateway"}, Description: "Capability-injected controller kind (ingress or gateway) this expose dispatches to."},
 		"certManagerClusterIssuer": {Type: oam.PropertyTypeString, Description: "cert-manager ClusterIssuer used to synthesize TLS (ingress controllerType only)."},
+		"secretName":               {Type: oam.PropertyTypeString, Description: "Overrides the synthesized <component>-tls secret name for platform-managed TLS (ingress controllerType only; requires a cert-manager cluster-issuer capability)."},
 		"allowedHostnameWildcard":  {Type: oam.PropertyTypeString, Description: "Platform-reserved wildcard the hostnames must fall under."},
 		"gatewayName":              {Type: oam.PropertyTypeString, Description: "Gateway name used to synthesize parentRefs (gateway controllerType only)."},
 		"gatewayNamespace":         {Type: oam.PropertyTypeString, Default: "gateway-system", Description: "Namespace of the Gateway (gateway controllerType only)."},
@@ -138,7 +139,22 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 		if err := validateHostnames(uniqueStrings(append(ruleHosts(props), shorthand...)), wildcard, app.Name); err != nil {
 			return err
 		}
-		// expose is platform-managed: the user does not author TLS.
+		// expose is platform-managed: the user does not author the TLS block, only
+		// (optionally) the managed secret's name. Present-but-wrong-typed/empty is an
+		// error, not a silent fallback to <component>-tls (which would name-collide).
+		var secretName string
+		if raw, present := props["secretName"]; present {
+			s, ok := raw.(string)
+			if !ok || s == "" {
+				return &errors.ValidationError{
+					Field:     "secretName",
+					Component: app.Name,
+					Message:   "secretName must be a non-empty string",
+				}
+			}
+			secretName = s
+		}
+		delete(props, "secretName")
 		delete(props, "tls")
 		if issuer != "" {
 			if err := setClusterIssuerAnnotation(props, issuer, app.Name); err != nil {
@@ -148,7 +164,15 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 			// `hostnames` are supplied, `rules` drives routing, so a hostnames entry
 			// that is not routed must not get a synthesized certificate.
 			if routingHosts := uniqueStrings(ruleHosts(props)); len(routingHosts) > 0 {
-				props["tls"] = synthesizedIngressTLS(routingHosts, app.Name)
+				props["tls"] = synthesizedIngressTLS(routingHosts, app.Name, secretName)
+			}
+		} else if secretName != "" {
+			// No cluster-issuer capability → no synthesized TLS, so an authored
+			// secretName would be silently dropped. Reject instead.
+			return &errors.ValidationError{
+				Field:     "secretName",
+				Component: app.Name,
+				Message:   "secretName requires platform-managed TLS (no cert-manager cluster-issuer capability)",
 			}
 		}
 		// ssl-redirect / force-ssl-redirect: typed property (capability default or
@@ -163,7 +187,7 @@ func (h *ExposeHandler) Apply(trait *oam.Trait, app *stack.Application, bundle *
 	case "gateway":
 		// These properties are nginx-ingress-specific; reject them inline on the
 		// gateway path (the rendering guard only covers the capability-supplied form).
-		for _, k := range []string{"sslRedirect", "forceSslRedirect", "allowedGroups", "authSigninURL"} {
+		for _, k := range []string{"sslRedirect", "forceSslRedirect", "allowedGroups", "authSigninURL", "secretName"} {
 			if _, ok := props[k]; ok {
 				return &errors.ValidationError{
 					Field:     k,
@@ -354,14 +378,18 @@ func stringList(v any) []string {
 }
 
 // synthesizedIngressTLS builds the single managed TLS entry: all hosts under one
-// deterministic secretName (<component>-tls), for cert-manager's ingress-shim.
-func synthesizedIngressTLS(hosts []string, component string) []any {
+// secret, for cert-manager's ingress-shim. secretName defaults to the deterministic
+// <component>-tls when the trait does not author an override.
+func synthesizedIngressTLS(hosts []string, component, secretName string) []any {
+	if secretName == "" {
+		secretName = component + "-tls"
+	}
 	anyHosts := make([]any, len(hosts))
 	for i, h := range hosts {
 		anyHosts[i] = h
 	}
 	return []any{map[string]any{
 		"hosts":      anyHosts,
-		"secretName": component + "-tls",
+		"secretName": secretName,
 	}}
 }

--- a/pkg/oam/builtin/traits/expose_secretname_override_test.go
+++ b/pkg/oam/builtin/traits/expose_secretname_override_test.go
@@ -1,0 +1,111 @@
+package traits_test
+
+import (
+	stderrors "errors"
+	"strings"
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+
+	pkgerrors "github.com/go-kure/launcher/pkg/errors"
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// Authored secretName overrides the synthesized <component>-tls name; hosts and the
+// cluster-issuer annotation are unchanged, and secretName does not leak downstream.
+func TestExposeHandler_Ingress_SecretNameOverride(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com")
+	trait.Properties["secretName"] = "custom-tls"
+	if err := h.Apply(trait, app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if len(ing.Spec.TLS) != 1 {
+		t.Fatalf("expected 1 TLS entry, got %d", len(ing.Spec.TLS))
+	}
+	if ing.Spec.TLS[0].SecretName != "custom-tls" {
+		t.Errorf("secretName = %q, want custom-tls", ing.Spec.TLS[0].SecretName)
+	}
+	if got := ing.Annotations["cert-manager.io/cluster-issuer"]; got != "letsencrypt-prod" {
+		t.Errorf("cluster-issuer annotation = %q, want letsencrypt-prod", got)
+	}
+	if len(ing.Spec.TLS[0].Hosts) != 1 || ing.Spec.TLS[0].Hosts[0] != "a.apps.example.com" {
+		t.Errorf("TLS hosts = %v, want [a.apps.example.com]", ing.Spec.TLS[0].Hosts)
+	}
+}
+
+// No secretName → default <component>-tls (regression guard).
+func TestExposeHandler_Ingress_SecretNameDefault(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	if err := h.Apply(exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com"), app, bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	ing := ingressFromBundle(t, bundle)
+	if ing.Spec.TLS[0].SecretName != "my-app-tls" {
+		t.Errorf("secretName = %q, want my-app-tls (default)", ing.Spec.TLS[0].SecretName)
+	}
+}
+
+// secretName on the gateway path is rejected (ingress-only), like sslRedirect/allowedGroups.
+func TestExposeHandler_Gateway_SecretNameRejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := &oam.Trait{Type: "expose", Properties: map[string]any{
+		"controllerType": "gateway",
+		"gatewayName":    "public",
+		"hostnames":      []any{"a.apps.example.com"},
+		"secretName":     "custom-tls",
+	}}
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError for secretName on gateway, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "secretName") {
+		t.Errorf("error = %q, want mention of secretName", err.Error())
+	}
+}
+
+// secretName without a cluster-issuer capability is rejected (else silently dropped).
+func TestExposeHandler_Ingress_SecretNameNoIssuerRejected(t *testing.T) {
+	h := &traits.ExposeHandler{}
+	app := newWebApp("my-app", "default")
+	bundle := &stack.Bundle{}
+	trait := exposeIngressTrait("", "", "a.apps.example.com") // no issuer
+	trait.Properties["secretName"] = "custom-tls"
+	err := h.Apply(trait, app, bundle)
+	var ve *pkgerrors.ValidationError
+	if !stderrors.As(err, &ve) {
+		t.Fatalf("expected *ValidationError for secretName without issuer, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "secretName") {
+		t.Errorf("error = %q, want mention of secretName", err.Error())
+	}
+}
+
+// Present-but-wrong-typed / empty secretName is rejected, not silently defaulted to
+// <component>-tls (the #199 lesson: absence-defaulting + lenient parse hides a typo).
+func TestExposeHandler_Ingress_SecretNameWrongType(t *testing.T) {
+	cases := map[string]any{"int": 12345, "empty": ""}
+	for name, val := range cases {
+		t.Run(name, func(t *testing.T) {
+			h := &traits.ExposeHandler{}
+			app := newWebApp("my-app", "default")
+			bundle := &stack.Bundle{}
+			trait := exposeIngressTrait("letsencrypt-prod", "", "a.apps.example.com")
+			trait.Properties["secretName"] = val
+			err := h.Apply(trait, app, bundle)
+			var ve *pkgerrors.ValidationError
+			if !stderrors.As(err, &ve) {
+				t.Fatalf("expected *ValidationError for secretName=%v, got %v", val, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #202. Downstream consumer: crane#328.

## What
A **scalar** authored `secretName` override on the expose **ingress** path. Today expose synthesizes a single `<component>-tls` secret, so a component with several ingress sub-apps collides on one name. Now the managed secret's *name* is authorable.

## Design (deliberately narrow)
Only the name changes — **not** a reopened `tls` block. Hosts stay derived from the routing rules and the `cert-manager.io/cluster-issuer` annotation stays platform-managed, so the `allowedHostnameWildcard` host-scoping invariant (crane#235 D5 / commit d1c6e9f) is fully preserved. Multiple secrets per component are authored via multiple expose traits, each with its own `name`/`scope` + `secretName`.

- `PropertySchema`: `secretName` (ingress-only, requires cluster-issuer).
- Ingress branch: overrides `<component>-tls`; stripped before delegating to the ingress handler; `synthesizedIngressTLS` gains a param that defaults to `<component>-tls`.
- **Gateway reject**: `secretName` on a gateway-controllerType expose → `ValidationError` (like `sslRedirect`/`allowedGroups`).
- **No-issuer reject**: `secretName` without a `certManagerClusterIssuer` capability → `ValidationError` (else silently dropped).
- **Wrong-typed/empty reject**: `secretName: 123` / `""` → `ValidationError`, not a silent fallback (the #199 lesson).

## Tests (`expose_secretname_override_test.go`)
override, default (regression), gateway-reject, no-issuer-reject, wrong-typed/empty-reject. Existing `IngressUserTLSIgnored` still holds (the `tls` block is still not authorable). build / vet / lint / `go test ./...` / doc-sync / doc-gate green.

## Release
Needs **alpha.14** after merge so crane bumps its pin and runs the crane#328 migration. **Held for review.**