### PR TITLE
refactor(oam): unify schema vocabulary on PropertySchema

### DIFF
--- a/docs/oam/design-capability-schema.md
+++ b/docs/oam/design-capability-schema.md
@@ -4,6 +4,7 @@
 
 | Version | Date | Summary |
 |---|---|---|
+| 1.1 | 2026-07-10 | §3.2: rendering vocabulary is the shared `PropertySchema` type (flat subset; rich fields rejected at decode). adr#33 |
 | 1.0 | 2026-05-16 | Initial — records built-in struct pattern and custom CapabilityDefinition plan |
 
 ---
@@ -226,6 +227,11 @@ at dispatch — the `CapabilityDefinition` does not replace the handler.
 The `CapabilityDefinition` document kind will be added in Phase 2/3. It declares the
 rendering schema for a custom capability in the same vocabulary used by `kurel.yaml`
 parameters (`type`, `required`, `default`, `description`).
+
+> **Schema vocabulary (adr#33).** Internally that vocabulary is the shared `PropertySchema`
+> type, restricted here to its flat subset: the rich fields (`enum`, nested `properties`,
+> `items`, `additionalProperties`) are rejected at decode time, so capability rendering does
+> not silently gain nested or enum semantics. The accepted wire format below is unchanged.
 
 ```yaml
 apiVersion: launcher.gokure.dev/v1alpha1

--- a/docs/oam/design-kurel-package.md
+++ b/docs/oam/design-kurel-package.md
@@ -4,6 +4,7 @@
 
 | Version | Date | Summary |
 |---|---|---|
+| 1.2 | 2026-07-10 | §6.1: unify parameter schema onto the shared `PropertySchema` vocabulary (flat subset; rich fields rejected at decode). adr#33 |
 | 1.1 | 2026-05-14 | Complete §6 (parameter syntax — Option A); fix GVK references; remove `backup` from Phase 1 trait table; fix §5 diagram label |
 | 1.0 | 2026-04-19 | Initial draft — parameter syntax section omitted pending decision |
 
@@ -217,6 +218,13 @@ is parsed or dispatched to handlers. For the full design rationale see
 ### 6.1 Parameter declarations in kurel.yaml
 
 Each parameter has a name, type, required flag, optional default, and optional description.
+
+> **Schema vocabulary (adr#33).** Internally a parameter is `ParameterDecl` = `name` plus the
+> shared `PropertySchema` vocabulary (the same type used by handler properties and capability
+> rendering). Parameters remain an *ordered list* — a default may reference only earlier
+> parameters — and are restricted to the flat subset: the rich `PropertySchema` fields (`enum`,
+> nested `properties`, `items`, `additionalProperties`) are rejected at decode time, and accepted
+> types stay `string`/`integer`/`boolean`. Unifying the type does not change the accepted wire format.
 
 ```yaml
 spec:

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -60,13 +60,17 @@ Standalone parsing validates each trait's `type` against the built-in handler se
 ## Property schemas
 
 Handlers may implement `PropertySchemaProvider` (`PropertySchema() map[string]PropertySchema`)
-to declare a constrained schema for their user-facing properties. `PropertySchema` is the
-richer sibling of `CapabilityPropertySchema`: `Type` (string/integer/boolean/number/array/object),
+to declare a constrained schema for their user-facing properties. `PropertySchema` is launcher's
+single schema vocabulary — the same type also backs `kurel.yaml` parameters (`ParameterDecl`) and
+`CapabilityDefinition` rendering properties. It has `Type` (string/integer/boolean/number/array/object),
 `Description`, `Required`, `Default`, `Enum`, nested `Properties`, `Items`, and `AdditionalProperties`
-(default false; escape-hatch fields set it true). `Transformer.HandlerSchemas()` returns a
-`HandlerSchemaSet{ Components, Traits }` of every registered handler that declares one, so crane's
-validator can check a component/trait's properties before the handler is invoked. Built-in
-examples: the `configmap` trait and the `passthrough` component.
+(default false; escape-hatch fields set it true). The rich fields (`Enum`, `Properties`, `Items`,
+`AdditionalProperties`) are meaningful only for handler properties: the two flat call sites (kurel
+parameters, capability rendering) reject them at decode time, so unifying the type does not widen
+their accepted behavior. `Transformer.HandlerSchemas()` returns a `HandlerSchemaSet{ Components, Traits }`
+of every registered handler that declares one, so crane's validator can check a component/trait's
+properties before the handler is invoked. Built-in examples: the `configmap` trait and the
+`passthrough` component.
 
 `Description` is optional (`json:"description,omitempty"`) but every built-in property populates it —
 including nested object fields and array item schemas at every depth — so crane can surface prose in

--- a/pkg/oam/capability.go
+++ b/pkg/oam/capability.go
@@ -95,13 +95,13 @@ func LoadCapabilityDefinitions(paths []string, definitionsDir string) (map[strin
 		}
 
 		for propName, propSchema := range def.Spec.Rendering.Properties {
-			if propSchema.Type != "" && !acceptedPropertyTypes[propSchema.Type] {
+			if propSchema.Type != "" && !acceptedPropertyTypes[string(propSchema.Type)] {
 				return nil, errors.Errorf(
 					"capability definition file %q: property %q has unsupported type %q (accepted: string, integer, boolean)",
 					filePath, propName, propSchema.Type)
 			}
 			if propSchema.Default != nil {
-				if err := checkCapabilityValueType(propSchema.Default, propSchema.Type); err != nil {
+				if err := checkCapabilityValueType(propSchema.Default, string(propSchema.Type)); err != nil {
 					return nil, errors.Errorf(
 						"capability definition file %q: property %q default value: %s",
 						filePath, propName, err)
@@ -154,7 +154,7 @@ func applyDefinitionSchema(rendering map[string]any, def *CapabilityDefinition) 
 			continue
 		}
 		if propSchema.Type != "" {
-			if err := checkCapabilityValueType(v, propSchema.Type); err != nil {
+			if err := checkCapabilityValueType(v, string(propSchema.Type)); err != nil {
 				return nil, errors.Errorf("rendering property %q: %s", propName, err)
 			}
 		}

--- a/pkg/oam/capability_test.go
+++ b/pkg/oam/capability_test.go
@@ -224,7 +224,7 @@ func TestApplyDefinitionSchema_AppliesDefault(t *testing.T) {
 	def := &CapabilityDefinition{
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"mode": {Type: "string", Default: "auto"},
 				},
 			},
@@ -243,7 +243,7 @@ func TestApplyDefinitionSchema_RequiredMissing(t *testing.T) {
 	def := &CapabilityDefinition{
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"timeout": {Type: "integer", Required: true},
 				},
 			},
@@ -259,7 +259,7 @@ func TestApplyDefinitionSchema_TypeMismatch(t *testing.T) {
 	def := &CapabilityDefinition{
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"enabled": {Type: "boolean"},
 				},
 			},
@@ -275,7 +275,7 @@ func TestApplyDefinitionSchema_UnknownKey(t *testing.T) {
 	def := &CapabilityDefinition{
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"mode": {Type: "string"},
 				},
 			},
@@ -291,7 +291,7 @@ func TestApplyDefinitionSchema_ValidRendering(t *testing.T) {
 	def := &CapabilityDefinition{
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"mode":     {Type: "string"},
 					"timeout":  {Type: "integer"},
 					"enabled":  {Type: "boolean"},

--- a/pkg/oam/flatschema.go
+++ b/pkg/oam/flatschema.go
@@ -1,7 +1,9 @@
 package oam
 
 import (
+	"slices"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -28,6 +30,18 @@ var (
 		"properties": {},
 	}
 )
+
+// allowedFields renders an allow-set as a sorted, comma-joined list for error
+// messages, so each call site names its own accepted keys (e.g. "properties" at
+// the rendering level vs. the flat vocabulary at the property level).
+func allowedFields(allowed map[string]struct{}) string {
+	keys := make([]string, 0, len(allowed))
+	for k := range allowed {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return strings.Join(keys, ", ")
+}
 
 // isYAMLNull reports whether node is a YAML null scalar (e.g. `foo:` with no
 // value, or an explicit `null`). There is no yaml.NullNode; a null resolves to a
@@ -69,8 +83,7 @@ func rejectUnsupportedSchemaKeys(node *yaml.Node, allowed map[string]struct{}, c
 			return errors.Errorf("%s: keys must be scalars", ctx)
 		}
 		if _, ok := allowed[keyNode.Value]; !ok {
-			return errors.Errorf("%s: unsupported field %q (kurel parameters and capability "+
-				"rendering properties accept only type, required, default, description)", ctx, keyNode.Value)
+			return errors.Errorf("%s: unsupported field %q (allowed: %s)", ctx, keyNode.Value, allowedFields(allowed))
 		}
 	}
 	return nil

--- a/pkg/oam/flatschema.go
+++ b/pkg/oam/flatschema.go
@@ -81,11 +81,13 @@ func rejectUnsupportedSchemaKeys(node *yaml.Node, allowed map[string]struct{}, c
 // passes through to a zero value and is caught by validatePackage ("name is
 // required"), preserving prior behavior.
 func (p *ParameterDecl) UnmarshalYAML(node *yaml.Node) error {
+	node = resolveAlias(node)
 	if err := rejectUnsupportedSchemaKeys(node, kurelParamKeys, "kurel parameter"); err != nil {
 		return err
 	}
 	// Named local (not a `type raw ParameterDecl` alias) to keep the inline embed
-	// unambiguous and avoid recursing back into this method.
+	// unambiguous and avoid recursing back into this method. Decode the resolved
+	// node so an aliased parameter item (`- *anchor`) decodes like plain yaml.v3.
 	var y struct {
 		Name           string `yaml:"name"`
 		PropertySchema `yaml:",inline"`

--- a/pkg/oam/flatschema.go
+++ b/pkg/oam/flatschema.go
@@ -37,13 +37,26 @@ func isYAMLNull(node *yaml.Node) bool {
 	return node.Kind == yaml.ScalarNode && node.Tag == "!!null"
 }
 
+// resolveAlias follows a YAML alias (`*anchor`) to the node it references, so alias
+// nodes are handled like the value they point at. Plain yaml.v3 struct/map decoding
+// resolves aliases transparently; the custom unmarshalers must do the same before
+// inspecting node kind so `*anchor` inputs are not rejected as "not a mapping".
+func resolveAlias(node *yaml.Node) *yaml.Node {
+	for node != nil && node.Kind == yaml.AliasNode {
+		node = node.Alias
+	}
+	return node
+}
+
 // rejectUnsupportedSchemaKeys enforces allowed as the exact accepted key-set on a
 // schema mapping node. Node-shape handling preserves prior decoding behavior:
+//   - alias node → resolved to its target first
 //   - null node → nil (pass through to a zero value; tolerated / caught later)
 //   - mapping node → error on any key outside allowed
 //   - any other node (non-null scalar, sequence) → error (this already failed
 //     before as a yaml TypeError when decoded into a struct; only the message changes)
 func rejectUnsupportedSchemaKeys(node *yaml.Node, allowed map[string]struct{}, ctx string) error {
+	node = resolveAlias(node)
 	if isYAMLNull(node) {
 		return nil
 	}
@@ -51,10 +64,13 @@ func rejectUnsupportedSchemaKeys(node *yaml.Node, allowed map[string]struct{}, c
 		return errors.Errorf("%s must be a mapping", ctx)
 	}
 	for i := 0; i+1 < len(node.Content); i += 2 {
-		key := node.Content[i].Value
-		if _, ok := allowed[key]; !ok {
+		keyNode := node.Content[i]
+		if keyNode.Kind != yaml.ScalarNode {
+			return errors.Errorf("%s: keys must be scalars", ctx)
+		}
+		if _, ok := allowed[keyNode.Value]; !ok {
 			return errors.Errorf("%s: unsupported field %q (kurel parameters and capability "+
-				"rendering properties accept only type, required, default, description)", ctx, key)
+				"rendering properties accept only type, required, default, description)", ctx, keyNode.Value)
 		}
 	}
 	return nil
@@ -88,6 +104,8 @@ func (p *ParameterDecl) UnmarshalYAML(node *yaml.Node) error {
 // empty schema; a null property value (`foo: null`) is retained as an empty
 // PropertySchema so the property stays known to applyDefinitionSchema.
 func (r *CapabilityRenderingSchema) UnmarshalYAML(node *yaml.Node) error {
+	r.Properties = nil // reset so decoding into a reused value is correct
+	node = resolveAlias(node)
 	if isYAMLNull(node) {
 		return nil
 	}
@@ -102,6 +120,7 @@ func (r *CapabilityRenderingSchema) UnmarshalYAML(node *yaml.Node) error {
 			break
 		}
 	}
+	propsNode = resolveAlias(propsNode)
 	if propsNode == nil || isYAMLNull(propsNode) {
 		return nil
 	}
@@ -111,8 +130,12 @@ func (r *CapabilityRenderingSchema) UnmarshalYAML(node *yaml.Node) error {
 
 	props := make(map[string]PropertySchema, len(propsNode.Content)/2)
 	for i := 0; i+1 < len(propsNode.Content); i += 2 {
-		name := propsNode.Content[i].Value
-		valNode := propsNode.Content[i+1]
+		keyNode := propsNode.Content[i]
+		if keyNode.Kind != yaml.ScalarNode {
+			return errors.Errorf("rendering.properties keys must be scalars")
+		}
+		name := keyNode.Value
+		valNode := resolveAlias(propsNode.Content[i+1])
 		ctx := "rendering property " + strconv.Quote(name)
 		if err := rejectUnsupportedSchemaKeys(valNode, capabilityPropKeys, ctx); err != nil {
 			return err

--- a/pkg/oam/flatschema.go
+++ b/pkg/oam/flatschema.go
@@ -1,0 +1,130 @@
+package oam
+
+import (
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+// The two flat call sites (kurel parameters, capability rendering properties)
+// share the PropertySchema vocabulary but support only its flat subset. Since
+// PropertySchema is now YAML-decodable, its rich fields (enum/properties/items/
+// additionalProperties) would decode silently at these sites — where strict
+// KnownFields(true) parsing previously rejected them as unknown. A custom
+// UnmarshalYAML bypasses the parent decoder's KnownFields, so these allow-sets
+// restore that strictness by key presence (not by decoded value, which cannot
+// distinguish an omitted field from a zero value like `additionalProperties: false`).
+// See adr#33.
+var (
+	kurelParamKeys = map[string]struct{}{
+		"name": {}, "type": {}, "required": {}, "default": {}, "description": {},
+	}
+	capabilityPropKeys = map[string]struct{}{
+		"type": {}, "required": {}, "default": {}, "description": {},
+	}
+	renderingKeys = map[string]struct{}{
+		"properties": {},
+	}
+)
+
+// isYAMLNull reports whether node is a YAML null scalar (e.g. `foo:` with no
+// value, or an explicit `null`). There is no yaml.NullNode; a null resolves to a
+// scalar node tagged !!null. Callers treat null as "absent" to preserve the
+// pre-unification tolerance of empty/zero values.
+func isYAMLNull(node *yaml.Node) bool {
+	return node.Kind == yaml.ScalarNode && node.Tag == "!!null"
+}
+
+// rejectUnsupportedSchemaKeys enforces allowed as the exact accepted key-set on a
+// schema mapping node. Node-shape handling preserves prior decoding behavior:
+//   - null node → nil (pass through to a zero value; tolerated / caught later)
+//   - mapping node → error on any key outside allowed
+//   - any other node (non-null scalar, sequence) → error (this already failed
+//     before as a yaml TypeError when decoded into a struct; only the message changes)
+func rejectUnsupportedSchemaKeys(node *yaml.Node, allowed map[string]struct{}, ctx string) error {
+	if isYAMLNull(node) {
+		return nil
+	}
+	if node.Kind != yaml.MappingNode {
+		return errors.Errorf("%s must be a mapping", ctx)
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if _, ok := allowed[key]; !ok {
+			return errors.Errorf("%s: unsupported field %q (kurel parameters and capability "+
+				"rendering properties accept only type, required, default, description)", ctx, key)
+		}
+	}
+	return nil
+}
+
+// UnmarshalYAML decodes a kurel parameter, rejecting any field outside the flat
+// vocabulary before delegating to the embedded PropertySchema. A null list item
+// passes through to a zero value and is caught by validatePackage ("name is
+// required"), preserving prior behavior.
+func (p *ParameterDecl) UnmarshalYAML(node *yaml.Node) error {
+	if err := rejectUnsupportedSchemaKeys(node, kurelParamKeys, "kurel parameter"); err != nil {
+		return err
+	}
+	// Named local (not a `type raw ParameterDecl` alias) to keep the inline embed
+	// unambiguous and avoid recursing back into this method.
+	var y struct {
+		Name           string `yaml:"name"`
+		PropertySchema `yaml:",inline"`
+	}
+	if err := node.Decode(&y); err != nil {
+		return err
+	}
+	p.Name = y.Name
+	p.PropertySchema = y.PropertySchema
+	return nil
+}
+
+// UnmarshalYAML decodes a capability rendering schema, validating both levels: the
+// rendering mapping accepts only `properties`, and each property accepts only the
+// flat vocabulary. Absent/empty/null rendering and `properties: null` yield an
+// empty schema; a null property value (`foo: null`) is retained as an empty
+// PropertySchema so the property stays known to applyDefinitionSchema.
+func (r *CapabilityRenderingSchema) UnmarshalYAML(node *yaml.Node) error {
+	if isYAMLNull(node) {
+		return nil
+	}
+	if err := rejectUnsupportedSchemaKeys(node, renderingKeys, "rendering"); err != nil {
+		return err
+	}
+
+	var propsNode *yaml.Node
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == "properties" {
+			propsNode = node.Content[i+1]
+			break
+		}
+	}
+	if propsNode == nil || isYAMLNull(propsNode) {
+		return nil
+	}
+	if propsNode.Kind != yaml.MappingNode {
+		return errors.Errorf("rendering.properties must be a mapping")
+	}
+
+	props := make(map[string]PropertySchema, len(propsNode.Content)/2)
+	for i := 0; i+1 < len(propsNode.Content); i += 2 {
+		name := propsNode.Content[i].Value
+		valNode := propsNode.Content[i+1]
+		ctx := "rendering property " + strconv.Quote(name)
+		if err := rejectUnsupportedSchemaKeys(valNode, capabilityPropKeys, ctx); err != nil {
+			return err
+		}
+		var ps PropertySchema
+		if !isYAMLNull(valNode) {
+			if err := valNode.Decode(&ps); err != nil {
+				return err
+			}
+		}
+		props[name] = ps
+	}
+	r.Properties = props
+	return nil
+}

--- a/pkg/oam/flatschema_test.go
+++ b/pkg/oam/flatschema_test.go
@@ -1,0 +1,244 @@
+package oam
+
+import (
+	stderrors "errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+// --- kurel parameters: rich fields rejected by key presence (adr#33) ---
+
+// packageWithParamField builds a Package document with a single string parameter
+// carrying one extra field line (e.g. `enum: []`).
+func packageWithParamField(extra string) string {
+	return `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - name: mode
+    type: string
+    ` + extra + `
+`
+}
+
+func TestParsePackage_RejectsRichParamFields(t *testing.T) {
+	// Includes zero-value cases (enum: [], properties: {}, items: null,
+	// additionalProperties: false) that a decoded-value check could not distinguish
+	// from "omitted". They must be rejected by key presence at decode time.
+	cases := map[string]string{
+		"enum":                       `enum: ["dev", "prod"]`,
+		"enum-empty":                 `enum: []`,
+		"properties-empty":           `properties: {}`,
+		"items-null":                 `items: null`,
+		"additionalProperties-false": `additionalProperties: false`,
+		"additionalProperties-true":  `additionalProperties: true`,
+	}
+	for name, extra := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParsePackage([]byte(packageWithParamField(extra)))
+			if err == nil {
+				t.Fatalf("expected error for kurel param with %s, got nil", name)
+			}
+			var parseErr *errors.ParseError
+			if !stderrors.As(err, &parseErr) {
+				t.Errorf("expected *errors.ParseError, got %T: %v", err, err)
+			}
+		})
+	}
+}
+
+func TestParsePackage_RejectsUnknownParamField(t *testing.T) {
+	// An unknown/misspelled field is no longer caught by KnownFields (the custom
+	// unmarshaler bypasses it); the allow-set must reproduce that strictness.
+	_, err := ParsePackage([]byte(packageWithParamField("bogusfield: x")))
+	if err == nil {
+		t.Fatal("expected error for unknown param field, got nil")
+	}
+	var parseErr *errors.ParseError
+	if !stderrors.As(err, &parseErr) {
+		t.Errorf("expected *errors.ParseError, got %T: %v", err, err)
+	}
+}
+
+func TestParsePackage_NamelessParamItem_ValidationError(t *testing.T) {
+	// An empty-mapping list item (`- {}`) passes the key guard (no keys) and decodes
+	// to a zero ParameterDecl, which validatePackage rejects as "name is required" —
+	// a ValidationError, not a ParseError. This proves the guard forwards a nameless
+	// param to semantic validation rather than turning it into a parse error.
+	// (A truly null item, `- null`, is dropped entirely by yaml.v3 both before and
+	// after this change — preserved behavior, nothing to assert.)
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - {}
+`
+	_, err := ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected error for nameless parameter list item, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Fatalf("expected *errors.ValidationError, got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error should mention the missing name, got: %v", err)
+	}
+}
+
+// --- capability rendering: rich fields rejected at both levels ---
+
+// loadCapDef writes a CapabilityDefinition YAML to a temp file and loads it.
+func loadCapDef(t *testing.T, spec string) (map[string]*CapabilityDefinition, error) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cap.yaml")
+	writeFile(t, path, `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: CapabilityDefinition
+metadata:
+  name: my-trait
+spec:
+`+spec)
+	return LoadCapabilityDefinitions([]string{path}, "")
+}
+
+func TestLoadCapabilityDefinitions_RejectsRichPropFields(t *testing.T) {
+	cases := map[string]string{
+		"enum":                       `        enum: ["a", "b"]`,
+		"enum-empty":                 `        enum: []`,
+		"properties-empty":           `        properties: {}`,
+		"items-null":                 `        items: null`,
+		"additionalProperties-false": `        additionalProperties: false`,
+		"additionalProperties-true":  `        additionalProperties: true`,
+	}
+	for name, extra := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := loadCapDef(t, `  rendering:
+    properties:
+      mode:
+        type: string
+`+extra+"\n")
+			if err == nil {
+				t.Fatalf("expected load error for capability prop with %s, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "unsupported field") {
+				t.Errorf("error should name the unsupported field, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadCapabilityDefinitions_RejectsUnknownRenderingField(t *testing.T) {
+	_, err := loadCapDef(t, `  rendering:
+    bogusfield:
+      mode:
+        type: string
+`)
+	if err == nil {
+		t.Fatal("expected load error for unknown rendering field, got nil")
+	}
+}
+
+func TestLoadCapabilityDefinitions_RejectsUnknownPropertyField(t *testing.T) {
+	_, err := loadCapDef(t, `  rendering:
+    properties:
+      mode:
+        type: string
+        bogusfield: auto
+`)
+	if err == nil {
+		t.Fatal("expected load error for unknown property field, got nil")
+	}
+}
+
+func TestLoadCapabilityDefinitions_RejectsMalformedProperties(t *testing.T) {
+	cases := map[string]string{
+		"sequence": `  rendering:
+    properties: []
+`,
+		"scalar-property": `  rendering:
+    properties:
+      mode: hello
+`,
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := loadCapDef(t, spec); err == nil {
+				t.Fatalf("expected load error for %s, got nil", name)
+			}
+		})
+	}
+}
+
+// --- capability rendering: null/empty tolerance preserved ---
+
+func TestLoadCapabilityDefinitions_NullEmptyRenderingTolerated(t *testing.T) {
+	cases := map[string]string{
+		"rendering-null":   `  rendering:` + "\n",
+		"rendering-empty":  `  rendering: {}` + "\n",
+		"properties-null":  "  rendering:\n    properties:\n",
+		"properties-empty": "  rendering:\n    properties: {}\n",
+		"no-rendering":     "  description: x\n",
+	}
+	for name, spec := range cases {
+		t.Run(name, func(t *testing.T) {
+			defs, err := loadCapDef(t, spec)
+			if err != nil {
+				t.Fatalf("expected no error for %s, got: %v", name, err)
+			}
+			if len(defs["my-trait"].Spec.Rendering.Properties) != 0 {
+				t.Errorf("expected empty Properties for %s", name)
+			}
+		})
+	}
+}
+
+func TestLoadCapabilityDefinitions_NullPropertyRetainedAsKnown(t *testing.T) {
+	// `foo:` (null value) must remain a KNOWN, unconstrained property — decoded to
+	// an empty PropertySchema whose key is retained. If it were skipped,
+	// applyDefinitionSchema would treat a supplied `foo` as an unknown property.
+	defs, err := loadCapDef(t, "  rendering:\n    properties:\n      foo:\n")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	def := defs["my-trait"]
+	if _, ok := def.Spec.Rendering.Properties["foo"]; !ok {
+		t.Fatal("expected 'foo' to be retained as a known property")
+	}
+	if _, err := applyDefinitionSchema(map[string]any{"foo": "anything"}, def); err != nil {
+		t.Errorf("supplying a value for the null-schema property 'foo' should be accepted, got: %v", err)
+	}
+}
+
+// --- PropertySchema is now YAML-decodable ---
+
+func TestPropertySchema_YAMLDecode(t *testing.T) {
+	const doc = `
+type: string
+description: a mode
+required: true
+default: dev
+`
+	var ps PropertySchema
+	if err := yaml.Unmarshal([]byte(doc), &ps); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ps.Type != PropertyTypeString {
+		t.Errorf("Type = %q, want string", ps.Type)
+	}
+	if ps.Description != "a mode" || !ps.Required || ps.Default != "dev" {
+		t.Errorf("fields not preserved: %+v", ps)
+	}
+}

--- a/pkg/oam/flatschema_test.go
+++ b/pkg/oam/flatschema_test.go
@@ -180,6 +180,23 @@ func TestLoadCapabilityDefinitions_RejectsUnknownRenderingField(t *testing.T) {
 	}
 }
 
+func TestLoadCapabilityDefinitions_RenderingLevelErrorNamesCorrectKeys(t *testing.T) {
+	// A flat-vocabulary field placed at the rendering level (not inside a property)
+	// must report the rendering allow-set ("properties"), not the property-level
+	// vocabulary — otherwise the message self-contradicts ("unsupported field
+	// \"type\" … accept only type, …").
+	_, err := loadCapDef(t, "  rendering:\n    type: string\n")
+	if err == nil {
+		t.Fatal("expected load error for flat field at rendering level, got nil")
+	}
+	if !strings.Contains(err.Error(), "allowed: properties") {
+		t.Errorf("rendering-level error should name 'properties' as allowed, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "required, default") {
+		t.Errorf("rendering-level error must not claim the property vocabulary, got: %v", err)
+	}
+}
+
 func TestLoadCapabilityDefinitions_RejectsUnknownPropertyField(t *testing.T) {
 	_, err := loadCapDef(t, `  rendering:
     properties:

--- a/pkg/oam/flatschema_test.go
+++ b/pkg/oam/flatschema_test.go
@@ -97,6 +97,35 @@ spec:
 	}
 }
 
+func TestParsePackage_ResolvesParamAlias(t *testing.T) {
+	// An aliased parameter item (`- *base`) must resolve to its mapping and decode
+	// like plain yaml.v3 — reaching semantic validation (here: duplicate name),
+	// not being rejected as a parse error for "not a mapping".
+	input := `
+apiVersion: launcher.gokure.dev/v1alpha1
+kind: Package
+metadata:
+  name: my-app
+spec:
+  parameters:
+  - &base
+    name: a
+    type: string
+  - *base
+`
+	_, err := ParsePackage([]byte(input))
+	if err == nil {
+		t.Fatal("expected duplicate-name error for aliased param, got nil")
+	}
+	var valErr *errors.ValidationError
+	if !stderrors.As(err, &valErr) {
+		t.Fatalf("expected *errors.ValidationError (proving the alias decoded), got %T: %v", err, err)
+	}
+	if !strings.Contains(err.Error(), "duplicate") {
+		t.Errorf("expected duplicate-name error, got: %v", err)
+	}
+}
+
 // --- capability rendering: rich fields rejected at both levels ---
 
 // loadCapDef writes a CapabilityDefinition YAML to a temp file and loads it.
@@ -197,6 +226,25 @@ func TestLoadCapabilityDefinitions_ResolvesPropertyAlias(t *testing.T) {
 	props := defs["my-trait"].Spec.Rendering.Properties
 	if props["base"].Type != PropertyTypeString || props["copy"].Type != PropertyTypeString {
 		t.Errorf("alias not resolved: %+v", props)
+	}
+}
+
+func TestLoadCapabilityDefinitions_RejectsMergeKey(t *testing.T) {
+	// Intentional tightening: a YAML merge key (`<<`) is not expanded — it is a key
+	// outside the flat allow-set, so it is rejected. (Plain yaml.v3 would merge it.)
+	_, err := loadCapDef(t, `  rendering:
+    properties:
+      base: &b
+        type: string
+      merged:
+        <<: *b
+        required: true
+`)
+	if err == nil {
+		t.Fatal("expected load error for merge key, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported field") {
+		t.Errorf("expected unsupported-field error for merge key, got: %v", err)
 	}
 }
 

--- a/pkg/oam/flatschema_test.go
+++ b/pkg/oam/flatschema_test.go
@@ -182,6 +182,37 @@ func TestLoadCapabilityDefinitions_RejectsMalformedProperties(t *testing.T) {
 	}
 }
 
+func TestLoadCapabilityDefinitions_ResolvesPropertyAlias(t *testing.T) {
+	// A YAML alias (`*scalar`) must resolve like plain yaml.v3 decode would, not be
+	// rejected as "not a mapping".
+	defs, err := loadCapDef(t, `  rendering:
+    properties:
+      base: &scalar
+        type: string
+      copy: *scalar
+`)
+	if err != nil {
+		t.Fatalf("unexpected error resolving alias: %v", err)
+	}
+	props := defs["my-trait"].Spec.Rendering.Properties
+	if props["base"].Type != PropertyTypeString || props["copy"].Type != PropertyTypeString {
+		t.Errorf("alias not resolved: %+v", props)
+	}
+}
+
+func TestLoadCapabilityDefinitions_RejectsComplexPropertyKey(t *testing.T) {
+	// A non-scalar property key would silently read as "" via Content[i].Value;
+	// map[string]... decode would have errored, so reject it.
+	_, err := loadCapDef(t, `  rendering:
+    properties:
+      ? [a, b]
+      : {type: string}
+`)
+	if err == nil {
+		t.Fatal("expected load error for non-scalar property key, got nil")
+	}
+}
+
 // --- capability rendering: null/empty tolerance preserved ---
 
 func TestLoadCapabilityDefinitions_NullEmptyRenderingTolerated(t *testing.T) {

--- a/pkg/oam/package.go
+++ b/pkg/oam/package.go
@@ -22,11 +22,14 @@ type PackageSpec struct {
 	Parameters []ParameterDecl `yaml:"parameters,omitempty"`
 }
 
-// ParameterDecl declares a single package parameter with its type, default, and constraints.
+// ParameterDecl declares a single package parameter: an ordered, named entry over
+// the shared PropertySchema vocabulary. The ordered list (PackageSpec.Parameters)
+// drives default resolution — a default may reference only earlier parameters — so
+// this stays a list, not a map. The embedded PropertySchema is restricted to the
+// flat vocabulary (type/required/default/description); the rich fields are rejected
+// at decode time by UnmarshalYAML (flatschema.go). Accepted types are gated to
+// string/integer/boolean by validatePackage (array/object are not yet substitutable).
 type ParameterDecl struct {
-	Name        string `yaml:"name"`
-	Type        string `yaml:"type"` // string, integer, boolean, array, object
-	Required    bool   `yaml:"required,omitempty"`
-	Default     any    `yaml:"default,omitempty"`
-	Description string `yaml:"description,omitempty"`
+	Name           string `yaml:"name"`
+	PropertySchema `yaml:",inline"`
 }

--- a/pkg/oam/resolver.go
+++ b/pkg/oam/resolver.go
@@ -98,7 +98,7 @@ func coerceSuppliedValues(supplied map[string]any, schema map[string]*ParameterD
 }
 
 func coerceValue(v any, decl *ParameterDecl) (any, error) {
-	switch decl.Type {
+	switch string(decl.Type) {
 	case "integer":
 		switch tv := v.(type) {
 		case int:
@@ -174,7 +174,7 @@ func buildEffectiveValues(schema []ParameterDecl, coerced map[string]any) (map[s
 
 		if !placeholderRE.MatchString(defStr) {
 			// Plain string default, no placeholders — coerce to the declared type.
-			val, err := coerceStringToType(defStr, p.Type, p.Name)
+			val, err := coerceStringToType(defStr, string(p.Type), p.Name)
 			if err != nil {
 				return nil, err
 			}
@@ -207,7 +207,7 @@ func buildEffectiveValues(schema []ParameterDecl, coerced map[string]any) (map[s
 				"default for parameter %q contains unresolved placeholder after substitution: %q", p.Name, resolved)
 		}
 
-		val, err := coerceStringToType(resolved, p.Type, p.Name)
+		val, err := coerceStringToType(resolved, string(p.Type), p.Name)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/oam/resolver_test.go
+++ b/pkg/oam/resolver_test.go
@@ -30,7 +30,7 @@ func mustUnmarshal(t *testing.T, data []byte) map[string]any {
 }
 
 func TestResolveParameters_Scalar_Integer(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Required: true}}}
 	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": 2})
 
 	m := mustUnmarshal(t, out)
@@ -43,7 +43,7 @@ func TestResolveParameters_Scalar_Integer(t *testing.T) {
 }
 
 func TestResolveParameters_Scalar_String(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "image", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 	out := resolveOK(t, "image: \"${image}\"\n", schema, map[string]any{"image": "myregistry/app:v1.2.3"})
 
 	m := mustUnmarshal(t, out)
@@ -53,7 +53,7 @@ func TestResolveParameters_Scalar_String(t *testing.T) {
 }
 
 func TestResolveParameters_Scalar_Boolean(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "enabled", Type: "boolean", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "enabled", PropertySchema: oam.PropertySchema{Type: "boolean", Required: true}}}
 	out := resolveOK(t, "enabled: ${enabled}\n", schema, map[string]any{"enabled": true})
 
 	m := mustUnmarshal(t, out)
@@ -66,7 +66,7 @@ func TestResolveParameters_Scalar_Boolean(t *testing.T) {
 }
 
 func TestResolveParameters_Inline(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "name", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "name", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 	out := resolveOK(t, "label: \"prefix-${name}-suffix\"\n", schema, map[string]any{"name": "myapp"})
 
 	m := mustUnmarshal(t, out)
@@ -77,8 +77,8 @@ func TestResolveParameters_Inline(t *testing.T) {
 
 func TestResolveParameters_Inline_MultipleParams(t *testing.T) {
 	schema := []oam.ParameterDecl{
-		{Name: "env", Type: "string", Required: true},
-		{Name: "app", Type: "string", Required: true},
+		{Name: "env", PropertySchema: oam.PropertySchema{Type: "string", Required: true}},
+		{Name: "app", PropertySchema: oam.PropertySchema{Type: "string", Required: true}},
 	}
 	out := resolveOK(t, "label: \"${env}-${app}\"\n", schema, map[string]any{
 		"env": "prod",
@@ -92,7 +92,7 @@ func TestResolveParameters_Inline_MultipleParams(t *testing.T) {
 }
 
 func TestResolveParameters_Default_Applied(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Default: 3}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Default: 3}}}
 	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{})
 
 	m := mustUnmarshal(t, out)
@@ -103,8 +103,8 @@ func TestResolveParameters_Default_Applied(t *testing.T) {
 
 func TestResolveParameters_Default_ReferencesEarlierParam(t *testing.T) {
 	schema := []oam.ParameterDecl{
-		{Name: "appName", Type: "string", Required: true},
-		{Name: "tlsSecret", Type: "string", Default: "${appName}-tls"},
+		{Name: "appName", PropertySchema: oam.PropertySchema{Type: "string", Required: true}},
+		{Name: "tlsSecret", PropertySchema: oam.PropertySchema{Type: "string", Default: "${appName}-tls"}},
 	}
 	out := resolveOK(t, "secret: ${tlsSecret}\n", schema, map[string]any{"appName": "myapp"})
 
@@ -115,7 +115,7 @@ func TestResolveParameters_Default_ReferencesEarlierParam(t *testing.T) {
 }
 
 func TestResolveParameters_RequiredMissing(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "image", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{})
 	if err == nil {
 		t.Fatal("expected error for missing required parameter")
@@ -126,7 +126,7 @@ func TestResolveParameters_RequiredMissing(t *testing.T) {
 }
 
 func TestResolveParameters_UnknownSuppliedKey(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "image", Type: "string"}}
+	schema := []oam.ParameterDecl{{Name: "image", PropertySchema: oam.PropertySchema{Type: "string"}}}
 	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{
 		"image": "foo",
 		"extra": "bar",
@@ -140,7 +140,7 @@ func TestResolveParameters_UnknownSuppliedKey(t *testing.T) {
 }
 
 func TestResolveParameters_NodeType_Rejected(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "items", Type: "array"}}
+	schema := []oam.ParameterDecl{{Name: "items", PropertySchema: oam.PropertySchema{Type: "array"}}}
 	_, err := oam.ResolveParameters([]byte("items: ${items}\n"), schema, map[string]any{
 		"items": []any{"a", "b"},
 	})
@@ -153,7 +153,7 @@ func TestResolveParameters_NodeType_Rejected(t *testing.T) {
 }
 
 func TestResolveParameters_SetCoercion_Integer(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Required: true}}}
 	// Simulate --set: CLI value arrives as a string.
 	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": "3"})
 
@@ -164,7 +164,7 @@ func TestResolveParameters_SetCoercion_Integer(t *testing.T) {
 }
 
 func TestResolveParameters_SetCoercion_Boolean(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "enabled", Type: "boolean", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "enabled", PropertySchema: oam.PropertySchema{Type: "boolean", Required: true}}}
 	// Simulate --set: CLI value arrives as a string.
 	out := resolveOK(t, "enabled: ${enabled}\n", schema, map[string]any{"enabled": "true"})
 
@@ -175,7 +175,7 @@ func TestResolveParameters_SetCoercion_Boolean(t *testing.T) {
 }
 
 func TestResolveParameters_SetCoercion_BadInteger(t *testing.T) {
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Required: true}}}
 	_, err := oam.ResolveParameters([]byte("replicas: ${replicas}\n"), schema, map[string]any{"replicas": "notanumber"})
 	if err == nil {
 		t.Fatal("expected error for non-integer value with integer type")
@@ -187,7 +187,7 @@ func TestResolveParameters_SetCoercion_BadInteger(t *testing.T) {
 
 func TestResolveParameters_FloatIntegerRejected(t *testing.T) {
 	// values.yaml float64 like replicas: 2.5 must be rejected, not silently truncated.
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Required: true}}}
 	_, err := oam.ResolveParameters([]byte("replicas: ${replicas}\n"), schema, map[string]any{"replicas": float64(2.5)})
 	if err == nil {
 		t.Fatal("expected error: 2.5 is not a valid integer (would silently truncate to 2)")
@@ -199,7 +199,7 @@ func TestResolveParameters_FloatIntegerRejected(t *testing.T) {
 
 func TestResolveParameters_FloatWholeNumberAccepted(t *testing.T) {
 	// A whole-number float like 2.0 decoded from YAML is acceptable for integer params.
-	schema := []oam.ParameterDecl{{Name: "replicas", Type: "integer", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "replicas", PropertySchema: oam.PropertySchema{Type: "integer", Required: true}}}
 	out := resolveOK(t, "replicas: ${replicas}\n", schema, map[string]any{"replicas": float64(2.0)})
 	m := mustUnmarshal(t, out)
 	if m["replicas"] != 2 {
@@ -209,7 +209,7 @@ func TestResolveParameters_FloatWholeNumberAccepted(t *testing.T) {
 
 func TestResolveParameters_StringParamRejectsMap(t *testing.T) {
 	// image: {repo: ghcr.io/app} in values.yaml must be rejected, not stringified.
-	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "image", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{
 		"image": map[string]any{"repo": "ghcr.io/app"},
 	})
@@ -223,7 +223,7 @@ func TestResolveParameters_StringParamRejectsMap(t *testing.T) {
 
 func TestResolveParameters_StringParamRejectsNull(t *testing.T) {
 	// image: null in values.yaml must be rejected.
-	schema := []oam.ParameterDecl{{Name: "image", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "image", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 	_, err := oam.ResolveParameters([]byte("image: ${image}\n"), schema, map[string]any{"image": nil})
 	if err == nil {
 		t.Fatal("expected error: null is not a valid string parameter")
@@ -262,7 +262,7 @@ func TestResolveParameters_StringWithSpecialChars(t *testing.T) {
 		{"combined", "host: example.com # note \"special\" C:\\path\nnext"},
 	}
 
-	schema := []oam.ParameterDecl{{Name: "text", Type: "string", Required: true}}
+	schema := []oam.ParameterDecl{{Name: "text", PropertySchema: oam.PropertySchema{Type: "string", Required: true}}}
 
 	for _, tc := range cases {
 		t.Run("full-value/"+tc.name, func(t *testing.T) {
@@ -290,8 +290,8 @@ func TestResolveParameters_Default_ForwardReference(t *testing.T) {
 	// 'first' default references 'second' which is declared later and not supplied.
 	// Effective values are built in schema order; 'second' is not yet set when 'first' is processed.
 	schema := []oam.ParameterDecl{
-		{Name: "first", Type: "string", Default: "${second}-suffix"},
-		{Name: "second", Type: "string", Default: "hello"},
+		{Name: "first", PropertySchema: oam.PropertySchema{Type: "string", Default: "${second}-suffix"}},
+		{Name: "second", PropertySchema: oam.PropertySchema{Type: "string", Default: "hello"}},
 	}
 	_, err := oam.ResolveParameters([]byte("val: ${first}\n"), schema, map[string]any{})
 	if err == nil {

--- a/pkg/oam/schema.go
+++ b/pkg/oam/schema.go
@@ -14,32 +14,39 @@ const (
 	PropertyTypeObject  PropertyType = "object"
 )
 
-// PropertySchema is the constrained schema vocabulary describing one handler
-// property. It is the richer sibling of CapabilityPropertySchema (types.go),
-// which models only the custom-trait YAML rendering fields (type/required/
-// default/description). Launcher-origin handlers expose PropertySchema via the
-// PropertySchemaProvider interface (handler.go) so crane can validate a
-// component/trait's user-facing properties before invoking the handler.
+// PropertySchema is the single constrained schema vocabulary describing one
+// declared property across launcher: handler properties (via the
+// PropertySchemaProvider interface, handler.go), kurel package parameters
+// (ParameterDecl, package.go), and capability rendering properties
+// (CapabilityRenderingSchema, types.go). Launcher-origin handlers expose it so
+// crane can validate a component/trait's user-facing properties before invoking
+// the handler.
+//
+// The rich fields (Enum, Properties, Items, AdditionalProperties) express nested
+// and constrained schemas. They are only meaningful for handler properties: the
+// two flat call sites (kurel parameters, capability rendering) reject them at
+// decode time so unifying the type does not silently widen accepted behavior
+// (see rejectUnsupportedSchemaKeys, flatschema.go, and adr#33).
 //
 // AdditionalProperties defaults to false: a handler that accepts arbitrary keys
 // (an escape hatch, e.g. the passthrough component's `object`) sets it true.
 type PropertySchema struct {
 	// Type is the value type. Required.
-	Type PropertyType `json:"type"`
+	Type PropertyType `json:"type" yaml:"type"`
 	// Description is human-facing prose for the property, surfaced in generated
 	// API references (e.g. crane's Handler API Reference). Optional.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Required marks the property as mandatory.
-	Required bool `json:"required,omitempty"`
+	Required bool `json:"required,omitempty" yaml:"required,omitempty"`
 	// Default is the value applied when the property is absent.
-	Default any `json:"default,omitempty"`
+	Default any `json:"default,omitempty" yaml:"default,omitempty"`
 	// Enum, when non-empty, constrains the value to this set.
-	Enum []any `json:"enum,omitempty"`
+	Enum []any `json:"enum,omitempty" yaml:"enum,omitempty"`
 	// Properties describes the fields of a Type==object value.
-	Properties map[string]PropertySchema `json:"properties,omitempty"`
+	Properties map[string]PropertySchema `json:"properties,omitempty" yaml:"properties,omitempty"`
 	// Items describes the element schema of a Type==array value.
-	Items *PropertySchema `json:"items,omitempty"`
+	Items *PropertySchema `json:"items,omitempty" yaml:"items,omitempty"`
 	// AdditionalProperties allows keys beyond those in Properties (object types).
 	// Defaults to false.
-	AdditionalProperties bool `json:"additionalProperties,omitempty"`
+	AdditionalProperties bool `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`
 }

--- a/pkg/oam/transform_test.go
+++ b/pkg/oam/transform_test.go
@@ -831,7 +831,7 @@ func capDefFixture(traitType string) *CapabilityDefinition {
 		Metadata:   Metadata{Name: traitType},
 		Spec: CapabilityDefSpec{
 			Rendering: CapabilityRenderingSchema{
-				Properties: map[string]CapabilityPropertySchema{
+				Properties: map[string]PropertySchema{
 					"timeout": {Type: "integer", Required: true},
 					"mode":    {Type: "string", Default: "auto"},
 				},

--- a/pkg/oam/types.go
+++ b/pkg/oam/types.go
@@ -61,16 +61,11 @@ type CapabilityDefSpec struct {
 	Rendering   CapabilityRenderingSchema `yaml:"rendering,omitempty"`
 }
 
-// CapabilityRenderingSchema lists the accepted rendering properties.
+// CapabilityRenderingSchema lists the accepted rendering properties. Each
+// property is a PropertySchema restricted to the flat vocabulary
+// (type/required/default/description) — the rich fields are rejected at decode
+// time by UnmarshalYAML (flatschema.go). Accepted types: "string", "integer",
+// "boolean" (enforced by LoadCapabilityDefinitions).
 type CapabilityRenderingSchema struct {
-	Properties map[string]CapabilityPropertySchema `yaml:"properties,omitempty"`
-}
-
-// CapabilityPropertySchema describes one rendering property.
-// Accepted types: "string", "integer", "boolean" (same vocabulary as kurel.yaml parameters).
-type CapabilityPropertySchema struct {
-	Type        string `yaml:"type,omitempty"`
-	Required    bool   `yaml:"required,omitempty"`
-	Default     any    `yaml:"default,omitempty"`
-	Description string `yaml:"description,omitempty"`
+	Properties map[string]PropertySchema `yaml:"properties,omitempty"`
 }

--- a/pkg/oam/validate.go
+++ b/pkg/oam/validate.go
@@ -251,7 +251,7 @@ func validatePackage(pkg *Package) error {
 			return packageValidationError("parameters", fmt.Sprintf("duplicate parameter name %q", p.Name))
 		}
 		seenNames[p.Name] = true
-		if !validParamTypes[p.Type] {
+		if !validParamTypes[string(p.Type)] {
 			return packageValidationError("parameters", fmt.Sprintf(
 				"parameter %q has invalid type %q; supported types: string, integer, boolean", p.Name, p.Type))
 		}
@@ -275,7 +275,7 @@ func validateParamDefault(p *ParameterDecl) error {
 		if placeholderRE.MatchString(defStr) {
 			return nil // validated at build time when referenced params are known
 		}
-		switch p.Type {
+		switch string(p.Type) {
 		case "integer":
 			if _, err := strconv.Atoi(defStr); err != nil {
 				return packageValidationError("parameters",
@@ -290,7 +290,7 @@ func validateParamDefault(p *ParameterDecl) error {
 		return nil
 	}
 	// Non-string default: the Go type decoded by yaml.Unmarshal must match the declared type.
-	switch p.Type {
+	switch string(p.Type) {
 	case "integer":
 		switch tv := p.Default.(type) {
 		case int, int64:


### PR DESCRIPTION
Unifies launcher's three OAM "named typed value" schema types onto the single `PropertySchema` vocabulary (adr#33).

## What changed
- **Delete `CapabilityPropertySchema`**; `CapabilityRenderingSchema.Properties` is now `map[string]PropertySchema`.
- **`ParameterDecl` → `Name` + embedded `PropertySchema`.** kurel parameters stay an *ordered list* (a default may reference only earlier params), so this is not a map.
- **`PropertySchema` gains `yaml` tags** (was json/Go-values only), making it YAML-decodable at the two flat call sites.

## Type unification only — behavior unchanged
The kurel text-substitution/coercion engine and the capability/handler map-validation engine stay separate; the accepted-type gates (`validParamTypes`, `acceptedPropertyTypes`) are unchanged.

Because `PropertySchema` is now YAML-decodable, its rich fields (`enum`, nested `properties`, `items`, `additionalProperties`) would decode silently where strict `KnownFields(true)` parsing previously rejected them. Strictness is restored **by key presence** (not decoded value — which can't tell an omitted field from a zero value like `additionalProperties: false`) via custom `UnmarshalYAML` on `ParameterDecl` and `CapabilityRenderingSchema` (`flatschema.go`). Null/empty stays tolerated; YAML aliases (`*anchor`) are resolved; a null capability property is retained as a known empty schema. **No wire-format change.**

### Intentional edge-case tightening
YAML **merge keys** (`<<: *anchor`) inside a kurel parameter or capability rendering property are **rejected** (the `<<` key is outside the flat allow-set), whereas plain yaml.v3 would expand them. This is a deliberate tightening for these flat schema sites — covered by a test. Whole-value aliases are still resolved normally.

## Docs
`pkg/oam/README.md` refreshed; decision notes added to `docs/oam/design-kurel-package.md` and `docs/oam/design-capability-schema.md`. Recorded upstream in ADR-018 (adr repo, autops/wharf/adr!60).

## Verification
> ⚠️ Run with `GOWORK=off` — the workspace `go.work` has an unrelated version mismatch (declares go 1.26.4 but crane requires 1.26.5) that blocks workspace-mode builds.

- `go build ./...`, `go test ./...` — pass
- `golangci-lint run ./pkg/oam/...` — 0 issues
- `check-doc-sync.sh` — OK

## Follow-up
Crane consumes this via a later dependency bump (no crane code change) — tracked as autops/wharf/crane#336, not bundled here.