### PR TITLE
feat(oam/volsync): accept storageClassName + volumeSnapshotClassName via ClusterProfile capability rendering

### DIFF
--- a/pkg/oam/builtin/README.md
+++ b/pkg/oam/builtin/README.md
@@ -4,8 +4,13 @@
 
 Package `builtin` holds the rendering-schema types shared by the built-in capability
 handlers (e.g. `CertificateRendering`, `ExposeRendering`, `ExternalSecretRendering`,
-`NetworkPolicyRendering`, `ConfigmapRendering`, `VolSyncRendering`) and the
+`NetworkPolicyRendering`, `ConfigmapRendering`, `VolSyncRendering`, `PVCRendering`) and the
 `DecodeStrict[T]` helper used by handlers to decode capability properties.
+
+`VolSyncRendering` and `PVCRendering` carry platform-supplied storage-class defaults
+(`storageClassName`, plus `volumeSnapshotClassName` for volsync) that a ClusterProfile capability
+can inject; both are overridable by the matching inline trait property and strict-decoded, so an
+operator typo in the rendering fails at profile-load.
 
 `ExposeRendering` additionally carries `certManagerClusterIssuer` (platform-managed TLS on
 the ingress path), `allowedHostnameWildcard` (hostname constraint for both paths), the

--- a/pkg/oam/builtin/pvc.go
+++ b/pkg/oam/builtin/pvc.go
@@ -1,0 +1,9 @@
+package builtin
+
+// PVCRendering carries the platform-supplied StorageClass default for pvc traits.
+// The class is optional and overridable by an inline OAM trait property, so pvc does
+// not implement CapabilityRequired. ValidateAndApplyDefaults strict-decodes into this
+// struct, so any other rendering key the operator accidentally provides is rejected.
+type PVCRendering struct {
+	StorageClassName string `yaml:"storageClassName,omitempty" json:"storageClassName,omitempty"`
+}

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -48,7 +48,7 @@ preflight reject every valid use of the trait.
 | `type` | Produces | Key properties |
 |--------|----------|----------------|
 | `pvc` | PersistentVolumeClaim | `name`, `size` (optional; policy default `storageSize`), `storageClassName`, `accessModes[]` (policy: `maxStorageSize`) |
-| `volsync` | VolSync ReplicationSource | `sourcePVC`, `schedule`, `copyMethod`, `retain.{daily,weekly,monthly}` |
+| `volsync` | VolSync ReplicationSource | `sourcePVC`, `schedule`, `copyMethod`, `storageClassName`, `volumeSnapshotClassName`, `retain.{daily,weekly,monthly}` (class fields also supplied via capability rendering; injection is `copyMethod`-aware) |
 
 ### Configuration & scaling
 | `type` | Produces | Key properties |

--- a/pkg/oam/builtin/traits/pvc.go
+++ b/pkg/oam/builtin/traits/pvc.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-kure/launcher/pkg/errors"
 	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin"
 	"github.com/go-kure/launcher/pkg/oam/builtin/components"
 )
 
@@ -24,6 +25,17 @@ type PVCHandler struct{}
 // CanHandle returns true for the pvc trait type.
 func (h *PVCHandler) CanHandle(traitType string) bool {
 	return traitType == "pvc"
+}
+
+// ValidateAndApplyDefaults accepts the pvc storageClassName rendering key and rejects
+// any other key, turning an operator typo into a profile-load error instead of a
+// silent pass-through. The class stays optional/overridable, so pvc is not
+// CapabilityRequired.
+func (h *PVCHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
+	if _, err := builtin.DecodeStrict[builtin.PVCRendering](rendering); err != nil {
+		return nil, errors.Wrap(err, "pvc rendering")
+	}
+	return rendering, nil
 }
 
 // PropertySchema declares the pvc trait's user-facing properties.

--- a/pkg/oam/builtin/traits/volsync.go
+++ b/pkg/oam/builtin/traits/volsync.go
@@ -21,7 +21,8 @@ func (h *VolSyncHandler) CanHandle(traitType string) bool {
 	return traitType == "volsync"
 }
 
-// ValidateAndApplyDefaults rejects any rendering key for this no-rendering trait.
+// ValidateAndApplyDefaults accepts the volsync class-default rendering keys
+// (storageClassName, volumeSnapshotClassName) and rejects any other key.
 func (h *VolSyncHandler) ValidateAndApplyDefaults(rendering map[string]any) (map[string]any, error) {
 	if _, err := builtin.DecodeStrict[builtin.VolSyncRendering](rendering); err != nil {
 		return nil, errors.Wrap(err, "volsync rendering")
@@ -195,11 +196,16 @@ func (c *VolsyncConfig) Generate(app *stack.Application) ([]*client.Object, erro
 			Monthly: &monthly,
 		},
 	}
-	if c.StorageClassName != "" {
+	// StorageClassName applies to the copy volume (Snapshot + Clone); Direct writes
+	// the source PVC and has no copy volume. VolumeSnapshotClassName only means
+	// anything for Snapshot; Clone/Direct never snapshot. The guard is source-blind:
+	// on Direct the class is dropped whether it was rendered or authored inline,
+	// because the capability merge precedes this handler and cannot tell them apart.
+	if c.CopyMethod != "Direct" && c.StorageClassName != "" {
 		sc := c.StorageClassName
 		mover.StorageClassName = &sc
 	}
-	if c.VolumeSnapshotClassName != "" {
+	if c.CopyMethod == "Snapshot" && c.VolumeSnapshotClassName != "" {
 		vsc := c.VolumeSnapshotClassName
 		mover.VolumeSnapshotClassName = &vsc
 	}

--- a/pkg/oam/builtin/traits/volsync_pvc_rendering_test.go
+++ b/pkg/oam/builtin/traits/volsync_pvc_rendering_test.go
@@ -1,0 +1,296 @@
+package traits_test
+
+import (
+	"errors"
+	"testing"
+
+	volsyncv1alpha1 "github.com/backube/volsync/api/v1alpha1"
+	"github.com/go-kure/kure/pkg/stack"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// volsyncSourceFromProps applies a volsync trait with the given inline properties
+// and returns the generated ReplicationSource.
+func volsyncSourceFromProps(t *testing.T, props map[string]any) *volsyncv1alpha1.ReplicationSource {
+	t.Helper()
+	h := &traits.VolSyncHandler{}
+	bundle := newBundle()
+	if err := h.Apply(&oam.Trait{Type: "volsync", Properties: props}, newApp("db", "default"), bundle); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	objs, err := bundle.Applications[0].Config.Generate(bundle.Applications[0])
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	rs, ok := (*objs[0]).(*volsyncv1alpha1.ReplicationSource)
+	if !ok {
+		t.Fatalf("expected *ReplicationSource, got %T", *objs[0])
+	}
+	return rs
+}
+
+// --- VolSyncHandler ValidateAndApplyDefaults: class keys accepted ---
+
+func TestVolSyncHandler_ValidateAndApplyDefaults_AcceptsClassKeys(t *testing.T) {
+	h := &traits.VolSyncHandler{}
+	out, err := h.ValidateAndApplyDefaults(map[string]any{
+		"storageClassName":        "fast",
+		"volumeSnapshotClassName": "csi-snapclass",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["storageClassName"] != "fast" || out["volumeSnapshotClassName"] != "csi-snapclass" {
+		t.Errorf("expected class keys preserved, got %v", out)
+	}
+}
+
+// --- copyMethod-aware class injection in Generate ---
+
+func TestVolsyncGenerate_Snapshot_InjectsBothClasses(t *testing.T) {
+	rs := volsyncSourceFromProps(t, map[string]any{
+		"sourcePVC":               "data",
+		"schedule":                "@daily",
+		"copyMethod":              "Snapshot",
+		"storageClassName":        "fast",
+		"volumeSnapshotClassName": "csi-snapclass",
+	})
+	if rs.Spec.Restic.StorageClassName == nil || *rs.Spec.Restic.StorageClassName != "fast" {
+		t.Errorf("Snapshot: expected storageClassName=fast, got %v", rs.Spec.Restic.StorageClassName)
+	}
+	if rs.Spec.Restic.VolumeSnapshotClassName == nil || *rs.Spec.Restic.VolumeSnapshotClassName != "csi-snapclass" {
+		t.Errorf("Snapshot: expected volumeSnapshotClassName=csi-snapclass, got %v", rs.Spec.Restic.VolumeSnapshotClassName)
+	}
+}
+
+func TestVolsyncGenerate_Clone_InjectsStorageClassOnly(t *testing.T) {
+	rs := volsyncSourceFromProps(t, map[string]any{
+		"sourcePVC":               "data",
+		"schedule":                "@daily",
+		"copyMethod":              "Clone",
+		"storageClassName":        "fast",
+		"volumeSnapshotClassName": "csi-snapclass",
+	})
+	if rs.Spec.Restic.StorageClassName == nil || *rs.Spec.Restic.StorageClassName != "fast" {
+		t.Errorf("Clone: expected storageClassName=fast, got %v", rs.Spec.Restic.StorageClassName)
+	}
+	if rs.Spec.Restic.VolumeSnapshotClassName != nil {
+		t.Errorf("Clone: expected volumeSnapshotClassName dropped, got %v", *rs.Spec.Restic.VolumeSnapshotClassName)
+	}
+}
+
+func TestVolsyncGenerate_Direct_DropsBothInlineClasses(t *testing.T) {
+	rs := volsyncSourceFromProps(t, map[string]any{
+		"sourcePVC":               "data",
+		"schedule":                "@daily",
+		"copyMethod":              "Direct",
+		"storageClassName":        "fast",
+		"volumeSnapshotClassName": "csi-snapclass",
+	})
+	if rs.Spec.Restic.StorageClassName != nil {
+		t.Errorf("Direct: expected storageClassName dropped, got %v", *rs.Spec.Restic.StorageClassName)
+	}
+	if rs.Spec.Restic.VolumeSnapshotClassName != nil {
+		t.Errorf("Direct: expected volumeSnapshotClassName dropped, got %v", *rs.Spec.Restic.VolumeSnapshotClassName)
+	}
+}
+
+// --- End-to-end: capability rendering delivers/drops the classes (rendered source) ---
+
+// renderComponentHandler is a trivial component handler used to wire a component
+// carrying a volsync trait through the full Transform pipeline.
+type renderComponentHandler struct{ typ string }
+
+func (h *renderComponentHandler) CanHandle(t string) bool { return t == h.typ }
+func (h *renderComponentHandler) ToApplicationConfig(_ *oam.Component, _ string) (stack.ApplicationConfig, error) {
+	return &emptyGenerateConfig{}, nil
+}
+
+type emptyGenerateConfig struct{}
+
+func (emptyGenerateConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+
+// volsyncSourceFromCluster walks the transformed cluster, finds the volsync
+// sub-app, and returns its generated ReplicationSource.
+func volsyncSourceFromCluster(t *testing.T, cluster *stack.Cluster) *volsyncv1alpha1.ReplicationSource {
+	t.Helper()
+	var apps []*stack.Application
+	var walk func(n *stack.Node)
+	walk = func(n *stack.Node) {
+		if n == nil {
+			return
+		}
+		if n.Bundle != nil {
+			apps = append(apps, n.Bundle.Applications...)
+		}
+		for _, c := range n.Children {
+			walk(c)
+		}
+	}
+	walk(cluster.Node)
+
+	for _, a := range apps {
+		if _, ok := a.Config.(*traits.VolsyncConfig); !ok {
+			continue
+		}
+		objs, err := a.Config.Generate(a)
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		if len(objs) != 1 {
+			t.Fatalf("expected 1 object, got %d", len(objs))
+		}
+		rs, ok := (*objs[0]).(*volsyncv1alpha1.ReplicationSource)
+		if !ok {
+			t.Fatalf("expected *ReplicationSource, got %T", *objs[0])
+		}
+		return rs
+	}
+	t.Fatal("no volsync sub-app found in cluster")
+	return nil
+}
+
+func transformVolsyncWithRendering(t *testing.T, copyMethod string) *volsyncv1alpha1.ReplicationSource {
+	t.Helper()
+	tr := oam.NewTransformer(
+		map[string]oam.ComponentHandler{"webservice": &renderComponentHandler{typ: "webservice"}},
+		map[string]oam.TraitHandler{"volsync": &traits.VolSyncHandler{}},
+	)
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{Components: []oam.Component{{
+			Name: "web",
+			Type: "webservice",
+			Traits: []oam.Trait{{
+				Type: "volsync",
+				Properties: map[string]any{
+					"sourcePVC":  "data",
+					"schedule":   "@daily",
+					"copyMethod": copyMethod,
+				},
+			}},
+		}}},
+	}
+	// storageClassName + volumeSnapshotClassName arrive only via capability rendering,
+	// never authored inline: this exercises the rendered (crane-supplied) source.
+	ctx := oam.TransformContext{Capabilities: map[string]oam.CapabilityBinding{
+		"volsync": {Rendering: map[string]any{
+			"storageClassName":        "fast",
+			"volumeSnapshotClassName": "csi-snapclass",
+		}},
+	}}
+	cluster, err := tr.Transform(app, ctx)
+	if err != nil {
+		t.Fatalf("Transform: %v", err)
+	}
+	return volsyncSourceFromCluster(t, cluster)
+}
+
+func TestVolSync_CapabilityRendering_Clone_InjectsRenderedStorageClass(t *testing.T) {
+	rs := transformVolsyncWithRendering(t, "Clone")
+	if rs.Spec.Restic.StorageClassName == nil || *rs.Spec.Restic.StorageClassName != "fast" {
+		t.Errorf("Clone: expected rendered storageClassName=fast, got %v", rs.Spec.Restic.StorageClassName)
+	}
+	if rs.Spec.Restic.VolumeSnapshotClassName != nil {
+		t.Errorf("Clone: expected volumeSnapshotClassName dropped, got %v", *rs.Spec.Restic.VolumeSnapshotClassName)
+	}
+}
+
+func TestVolSync_CapabilityRendering_Direct_DropsRenderedClasses(t *testing.T) {
+	rs := transformVolsyncWithRendering(t, "Direct")
+	if rs.Spec.Restic.StorageClassName != nil {
+		t.Errorf("Direct: expected rendered storageClassName dropped, got %v", *rs.Spec.Restic.StorageClassName)
+	}
+	if rs.Spec.Restic.VolumeSnapshotClassName != nil {
+		t.Errorf("Direct: expected rendered volumeSnapshotClassName dropped, got %v", *rs.Spec.Restic.VolumeSnapshotClassName)
+	}
+}
+
+// --- EvaluateProfile: real handlers accept valid rendering, reject typos ---
+
+func TestEvaluateProfile_VolSyncRendering_Accepted(t *testing.T) {
+	tr := oam.NewTransformer(nil, map[string]oam.TraitHandler{"volsync": &traits.VolSyncHandler{}})
+	profile := &oam.ClusterProfile{Spec: oam.ClusterProfileSpec{Capabilities: map[string]oam.CapabilityBinding{
+		"volsync": {Rendering: map[string]any{
+			"storageClassName":        "fast",
+			"volumeSnapshotClassName": "csi-snapclass",
+		}},
+	}}}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["volsync"].Rendering["storageClassName"] != "fast" {
+		t.Errorf("expected storageClassName preserved, got %v", got.Spec.Capabilities["volsync"].Rendering)
+	}
+}
+
+func TestEvaluateProfile_VolSyncRendering_RejectsUnknownKey(t *testing.T) {
+	tr := oam.NewTransformer(nil, map[string]oam.TraitHandler{"volsync": &traits.VolSyncHandler{}})
+	profile := &oam.ClusterProfile{Spec: oam.ClusterProfileSpec{Capabilities: map[string]oam.CapabilityBinding{
+		"volsync": {Rendering: map[string]any{"storageClass": "fast"}}, // typo
+	}}}
+	_, err := tr.EvaluateProfile(profile)
+	if err == nil {
+		t.Fatal("expected error for unknown volsync rendering key")
+	}
+	var te *oam.TransformError
+	if !errors.As(err, &te) {
+		t.Errorf("expected *TransformError, got %T: %v", err, err)
+	}
+}
+
+// --- PVCHandler ValidateAndApplyDefaults + EvaluateProfile ---
+
+func TestPVCHandler_ValidateAndApplyDefaults_AcceptsStorageClassName(t *testing.T) {
+	h := &traits.PVCHandler{}
+	out, err := h.ValidateAndApplyDefaults(map[string]any{"storageClassName": "fast"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if out["storageClassName"] != "fast" {
+		t.Errorf("expected storageClassName preserved, got %v", out)
+	}
+}
+
+func TestPVCHandler_ValidateAndApplyDefaults_RejectsUnknownKey(t *testing.T) {
+	h := &traits.PVCHandler{}
+	if _, err := h.ValidateAndApplyDefaults(map[string]any{"storageClas": "fast"}); err == nil {
+		t.Fatal("expected error for unknown pvc rendering key")
+	}
+}
+
+func TestEvaluateProfile_PVCRendering_Accepted(t *testing.T) {
+	tr := oam.NewTransformer(nil, map[string]oam.TraitHandler{"pvc": &traits.PVCHandler{}})
+	profile := &oam.ClusterProfile{Spec: oam.ClusterProfileSpec{Capabilities: map[string]oam.CapabilityBinding{
+		"pvc": {Rendering: map[string]any{"storageClassName": "fast"}},
+	}}}
+	got, err := tr.EvaluateProfile(profile)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Spec.Capabilities["pvc"].Rendering["storageClassName"] != "fast" {
+		t.Errorf("expected storageClassName preserved, got %v", got.Spec.Capabilities["pvc"].Rendering)
+	}
+}
+
+func TestEvaluateProfile_PVCRendering_RejectsUnknownKey(t *testing.T) {
+	tr := oam.NewTransformer(nil, map[string]oam.TraitHandler{"pvc": &traits.PVCHandler{}})
+	profile := &oam.ClusterProfile{Spec: oam.ClusterProfileSpec{Capabilities: map[string]oam.CapabilityBinding{
+		"pvc": {Rendering: map[string]any{"storageClas": "fast"}}, // typo
+	}}}
+	_, err := tr.EvaluateProfile(profile)
+	if err == nil {
+		t.Fatal("expected error for unknown pvc rendering key")
+	}
+	var te *oam.TransformError
+	if !errors.As(err, &te) {
+		t.Errorf("expected *TransformError, got %T: %v", err, err)
+	}
+}

--- a/pkg/oam/builtin/volsync.go
+++ b/pkg/oam/builtin/volsync.go
@@ -1,5 +1,10 @@
 package builtin
 
-// VolSyncRendering holds no rendering keys; ValidateAndApplyDefaults rejects
-// any key the operator accidentally provides (design-capability-schema.md §2.4).
-type VolSyncRendering struct{}
+// VolSyncRendering carries platform-supplied class defaults for volsync backups.
+// Both are overridable by inline OAM trait properties; injection is copyMethod-aware
+// (see traits/volsync.go Generate). ValidateAndApplyDefaults strict-decodes into this
+// struct, so any other rendering key the operator accidentally provides is rejected.
+type VolSyncRendering struct {
+	StorageClassName        string `yaml:"storageClassName,omitempty" json:"storageClassName,omitempty"`
+	VolumeSnapshotClassName string `yaml:"volumeSnapshotClassName,omitempty" json:"volumeSnapshotClassName,omitempty"`
+}


### PR DESCRIPTION
Closes #205. Handoff from crane#332 (re-scoped to ClusterProfile capability rendering).

## What

Let a ClusterProfile `volsync` capability *rendering* supply `storageClassName` / `volumeSnapshotClassName`, and make class injection `copyMethod`-aware. Also add pvc typo-rejection.

### volsync (required)
- `VolSyncRendering` (`pkg/oam/builtin/volsync.go`) expanded from `struct{}` to two `omitempty` string fields — a `volsync` rendering key no longer hard-errors at `EvaluateProfile`; strict decode still rejects any other key.
- Per-field `copyMethod` guard in the volsync `Generate`: inject `StorageClassName` only when `copyMethod != Direct`, `VolumeSnapshotClassName` only when `copyMethod == Snapshot`. **Source-blind** — on `Direct` the class is dropped whether rendered or authored inline, because the capability merge precedes the handler and cannot tell them apart.

### pvc (recommended, included)
- New `PVCRendering{StorageClassName}` + `ValidateAndApplyDefaults` on `PVCHandler` so an operator typo in a `pvc` rendering fails at profile-load instead of being silently ignored. Class stays optional/overridable (no `CapabilityRequired`).
- Compatibility: a `pvc` rendering now accepts only `storageClassName`; a repo scan found no existing profile stashing other keys under `pvc.rendering`.

## Docs
Updated the two mapped READMEs (`pkg/oam/builtin`, `pkg/oam/builtin/traits`).

## Tests
`pkg/oam/builtin/traits/volsync_pvc_rendering_test.go`:
- volsync rendering accepted; class injection matrix asserting `rs.Spec.Restic.{StorageClassName,VolumeSnapshotClassName}` for Snapshot (both), Clone (storage only), Direct (both dropped — inline).
- End-to-end `Transform` with a capability rendering: Clone delivers the rendered storage class, Direct drops both rendered classes.
- Real-handler `EvaluateProfile` accept + typo-reject (`*TransformError`) for both volsync and pvc.

## Follow-up
Tag a release so crane can bump the pin and land the opsmaster fixture reduction (crane#332 Unit C).