### PR TITLE
feat(oam/netpol): synthesize per-component egress NetworkPolicy from a crane-supplied non-authorable input

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -28,6 +28,17 @@ parse → resolve parameters → transform (component + trait handlers) → mani
    `ComponentHandler` and each trait to its `TraitHandler`, merging the
    `ClusterProfile`'s capability choices.
 
+A Phase-4 post-build stage then synthesizes per-component `NetworkPolicy` resources
+in two directions, each a **separate** additive resource (the authored
+`networkpolicy` / `cilium-networkpolicy` traits are unaffected):
+
+- **Inbound** (`{comp}-allow-ingress-traffic`) — routing-derived, from routing traits'
+  platform-reserved `networkPolicy.trafficSources` capability rendering.
+- **Egress** (`{comp}-allow-egress-traffic`) — from `TransformContext.EgressPeers`, a
+  crane-supplied, non-authorable synthesis input (graph-derived dependency peers; never
+  set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a
+  caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op.
+
 ## Parsing
 
 | Function | Purpose |

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -6,10 +6,12 @@ import (
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/go-kure/launcher/pkg/oam"
 	"github.com/go-kure/launcher/pkg/oam/builtin/components"
 	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
 
 func ingressTrafficSourcesTrait(extra map[string]any) *oam.Trait {
@@ -218,4 +220,41 @@ func clusterAppNames(c *stack.Cluster) []string {
 
 func clusterHasApp(c *stack.Cluster, name string) bool {
 	return slices.Contains(clusterAppNames(c), name)
+}
+
+// End-to-end: a webservice with crane-supplied (non-authorable) egress peers on the
+// transform context yields a synthesized {component}-allow-egress-traffic policy, and
+// no inbound policy is synthesized absent trafficSources (additive, distinct paths).
+func TestTransform_EgressPeers_SynthesizesEgressNetworkPolicy(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "web",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+			}},
+		},
+	}
+
+	ctx := oam.TransformContext{
+		Namespace: "default",
+		EgressPeers: map[string][]netpol.EgressPeer{
+			"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, ctx)
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+
+	if !clusterHasApp(cluster, "web-allow-egress-traffic") {
+		t.Errorf("expected synthesized \"web-allow-egress-traffic\"; cluster apps: %v", clusterAppNames(cluster))
+	}
+	if clusterHasApp(cluster, "web-allow-ingress-traffic") {
+		t.Errorf("did not expect inbound synthesis without trafficSources; cluster apps: %v", clusterAppNames(cluster))
+	}
 }

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -2,10 +2,16 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kure/launcher/pkg/oam/netpol.svg)](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/netpol)
 
-Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis —
-primarily `TrafficSource`. It lives outside `pkg/oam` so that both the synthesis
-stage (`pkg/oam`) and the routing trait configs that expose collected sources
-(`pkg/oam/builtin/traits`) can import it without an import cycle.
+Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
+
+- `TrafficSource` — one allowed **inbound** source, collected from routing traits'
+  platform-reserved `networkPolicy.trafficSources`. It lives outside `pkg/oam` so that
+  both the synthesis stage (`pkg/oam`) and the routing trait configs that expose the
+  collected sources (`pkg/oam/builtin/traits`) can import it without an import cycle.
+- `EgressPeer` — one allowed **egress** destination (namespace selector + optional pod
+  selector + ports). Unlike `TrafficSource`, it is a crane-supplied, non-authorable
+  synthesis input carried on `TransformContext.EgressPeers` (never set from OAM YAML or
+  capability rendering); it has no trait-side producer.
 
 Internal support type, not a user-facing API. See
 [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/netpol).

--- a/pkg/oam/netpol/types.go
+++ b/pkg/oam/netpol/types.go
@@ -6,6 +6,7 @@ package netpol
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // TrafficSource represents one allowed ingress traffic source for auto-generated
@@ -14,4 +15,16 @@ import (
 type TrafficSource struct {
 	Namespace   string
 	PodSelector *metav1.LabelSelector // nil = all pods; matchLabels only
+}
+
+// EgressPeer represents one allowed egress destination for an auto-generated
+// per-component egress NetworkPolicy. It is a crane-supplied, non-authorable
+// synthesis input surfaced from crane's dependency graph — OAM authors cannot
+// set it. Namespace is required; PodSelector narrows to specific pods within
+// that namespace (matchLabels only; nil = all pods); Ports are the destination
+// ports (TCP). A peer with no Ports is skipped by synthesis.
+type EgressPeer struct {
+	Namespace   string
+	PodSelector *metav1.LabelSelector // nil = all pods; matchLabels only
+	Ports       []intstr.IntOrString
 }

--- a/pkg/oam/netpol_egress_synthesis_test.go
+++ b/pkg/oam/netpol_egress_synthesis_test.go
@@ -1,0 +1,275 @@
+package oam
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/go-kure/launcher/pkg/oam/netpol"
+)
+
+// --- buildEgressPeers ---
+
+func TestBuildEgressPeers_SkipsEmptyPorts(t *testing.T) {
+	peers := buildEgressPeers([]netpol.EgressPeer{
+		{Namespace: "db", Ports: nil},
+	})
+	if len(peers) != 0 {
+		t.Errorf("expected 0 peers (empty ports), got %d", len(peers))
+	}
+}
+
+func TestBuildEgressPeers_DeduplicatesIdentical(t *testing.T) {
+	mk := func() netpol.EgressPeer {
+		return netpol.EgressPeer{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}
+	}
+	peers := buildEgressPeers([]netpol.EgressPeer{mk(), mk()})
+	if len(peers) != 1 {
+		t.Errorf("expected 1 deduplicated peer, got %d", len(peers))
+	}
+}
+
+func TestBuildEgressPeers_DistinctPeersPreserved(t *testing.T) {
+	peers := buildEgressPeers([]netpol.EgressPeer{
+		{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}},
+		{Namespace: "cache", Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
+	})
+	if len(peers) != 2 {
+		t.Errorf("expected 2 distinct peers, got %d", len(peers))
+	}
+}
+
+// TestBuildEgressPeers_DeterministicOrder verifies that shuffled peer order and
+// shuffled per-peer port order produce byte-identical normalized output.
+func TestBuildEgressPeers_DeterministicOrder(t *testing.T) {
+	a := buildEgressPeers([]netpol.EgressPeer{
+		{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(443), intstr.FromInt32(80)}},
+		{Namespace: "cache", Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
+	})
+	b := buildEgressPeers([]netpol.EgressPeer{
+		{Namespace: "cache", Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
+		{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(80), intstr.FromInt32(443)}},
+	})
+	if len(a) != len(b) {
+		t.Fatalf("length mismatch: %d vs %d", len(a), len(b))
+	}
+	for i := range a {
+		if egressPeerKey(a[i]) != egressPeerKey(b[i]) {
+			t.Errorf("peer %d order/normalization differs:\n a=%s\n b=%s", i, egressPeerKey(a[i]), egressPeerKey(b[i]))
+		}
+	}
+	// db (namespace-sorted after "cache") must carry ports in ascending order.
+	if a[1].Namespace != "db" || a[1].Ports[0].IntVal != 80 || a[1].Ports[1].IntVal != 443 {
+		t.Errorf("expected db peer with ports [80 443], got %+v", a[1])
+	}
+}
+
+// --- componentEgressPolicyConfig.Generate (full shape) ---
+
+func egressPolicyFromGenerate(t *testing.T, cfg *componentEgressPolicyConfig) *networkingv1.NetworkPolicy {
+	t.Helper()
+	app := stack.NewApplication(cfg.ComponentName+"-allow-egress-traffic", "default", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected *NetworkPolicy, got %T", *objs[0])
+	}
+	return np
+}
+
+func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
+	cfg := &componentEgressPolicyConfig{
+		ComponentName: "web",
+		Peers: []netpol.EgressPeer{
+			{
+				Namespace:   "db",
+				PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}},
+				Ports:       []intstr.IntOrString{intstr.FromInt32(5432)},
+			},
+			{
+				Namespace: "cache",
+				Ports:     []intstr.IntOrString{intstr.FromInt32(6379)},
+			},
+		},
+	}
+	np := egressPolicyFromGenerate(t, cfg)
+
+	if np.Name != "web-allow-egress-traffic" {
+		t.Errorf("name = %q, want web-allow-egress-traffic", np.Name)
+	}
+	if np.Labels != nil || np.Annotations != nil {
+		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
+	}
+	if got := np.Spec.PodSelector.MatchLabels["app"]; got != "web" {
+		t.Errorf("podSelector app = %q, want web", got)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
+		t.Errorf("policyTypes = %v, want [Egress]", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Ingress) != 0 {
+		t.Errorf("expected no ingress rules, got %d", len(np.Spec.Ingress))
+	}
+	// One egress rule per peer, in deterministic (namespace-sorted) order:
+	// "cache" before "db".
+	if len(np.Spec.Egress) != 2 {
+		t.Fatalf("expected 2 egress rules (one per peer), got %d", len(np.Spec.Egress))
+	}
+
+	// First peer: cache with no pod selector, port 6379/TCP.
+	r0 := np.Spec.Egress[0]
+	if len(r0.To) != 1 {
+		t.Fatalf("rule 0: expected 1 peer, got %d", len(r0.To))
+	}
+	if got := r0.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; got != "cache" {
+		t.Errorf("rule 0 namespace selector = %q, want cache", got)
+	}
+	if r0.To[0].PodSelector != nil {
+		t.Errorf("rule 0: expected nil pod selector, got %v", r0.To[0].PodSelector)
+	}
+	if len(r0.Ports) != 1 || r0.Ports[0].Port.IntVal != 6379 || *r0.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("rule 0 ports = %v, want [6379/TCP]", r0.Ports)
+	}
+
+	// Second peer: db with pod selector + port 5432/TCP.
+	r1 := np.Spec.Egress[1]
+	if got := r1.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; got != "db" {
+		t.Errorf("rule 1 namespace selector = %q, want db", got)
+	}
+	if r1.To[0].PodSelector == nil || r1.To[0].PodSelector.MatchLabels["app"] != "postgres" {
+		t.Errorf("rule 1 pod selector = %v, want app=postgres", r1.To[0].PodSelector)
+	}
+	if len(r1.Ports) != 1 || r1.Ports[0].Port.IntVal != 5432 || *r1.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("rule 1 ports = %v, want [5432/TCP]", r1.Ports)
+	}
+}
+
+// TestComponentEgressPolicyConfig_Generate_SkipsEmptyPortPeer guards the security
+// invariant at the Generate boundary: a directly-built config with an empty-port
+// peer must not emit an all-ports egress rule.
+func TestComponentEgressPolicyConfig_Generate_SkipsEmptyPortPeer(t *testing.T) {
+	cfg := &componentEgressPolicyConfig{
+		ComponentName: "web",
+		Peers: []netpol.EgressPeer{
+			{Namespace: "db", Ports: nil}, // no derivable ports → must be dropped
+			{Namespace: "cache", Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
+		},
+	}
+	np := egressPolicyFromGenerate(t, cfg)
+	if len(np.Spec.Egress) != 1 {
+		t.Fatalf("expected 1 egress rule (empty-port peer dropped), got %d", len(np.Spec.Egress))
+	}
+	if got := np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; got != "cache" {
+		t.Errorf("surviving rule namespace = %q, want cache", got)
+	}
+}
+
+// --- synthesizeEgressNetworkPolicies ---
+
+// egressFixture builds a single-leaf cluster with one primary component app plus a
+// matching componentMap entry.
+func egressFixture(compName, namespace string) (*stack.Cluster, map[string]componentEntry, *stack.Application) {
+	primary := stack.NewApplication(compName, namespace, &stubAppConfig{})
+	bundle := &stack.Bundle{Applications: []*stack.Application{primary}}
+	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
+	componentMap := map[string]componentEntry{
+		compName: {component: Component{Name: compName}, app: primary},
+	}
+	return cluster, componentMap, primary
+}
+
+func egressAppNames(cluster *stack.Cluster) []string {
+	var names []string
+	walkLeafBundles(cluster.Node, func(b *stack.Bundle) {
+		for _, a := range b.Applications {
+			names = append(names, a.Name)
+		}
+	})
+	return names
+}
+
+func TestSynthesizeEgress_AppendsPolicy(t *testing.T) {
+	cluster, componentMap, primary := egressFixture("web", "default")
+	peers := map[string][]netpol.EgressPeer{
+		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+	}
+
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+
+	leaf := cluster.Node.Bundle
+	if len(leaf.Applications) != 2 {
+		t.Fatalf("expected 2 apps after synthesis, got %d (%v)", len(leaf.Applications), egressAppNames(cluster))
+	}
+	added := leaf.Applications[1]
+	if added.Name != "web-allow-egress-traffic" {
+		t.Errorf("added app name = %q, want web-allow-egress-traffic", added.Name)
+	}
+	if added.Namespace != primary.Namespace {
+		t.Errorf("added app namespace = %q, want %q", added.Namespace, primary.Namespace)
+	}
+	if _, ok := added.Config.(*componentEgressPolicyConfig); !ok {
+		t.Errorf("expected *componentEgressPolicyConfig, got %T", added.Config)
+	}
+}
+
+func TestSynthesizeEgress_NoOpWhenNoPeers(t *testing.T) {
+	cluster, componentMap, _ := egressFixture("web", "default")
+	synthesizeEgressNetworkPolicies(cluster, componentMap, nil)
+	if n := len(cluster.Node.Bundle.Applications); n != 1 {
+		t.Errorf("expected no synthesis for nil peers, got %d apps", n)
+	}
+}
+
+func TestSynthesizeEgress_NoOpWhenNoComponentMatch(t *testing.T) {
+	cluster, componentMap, _ := egressFixture("web", "default")
+	// Peers keyed by a component that is not present in the bundle/componentMap.
+	peers := map[string][]netpol.EgressPeer{
+		"other": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+	}
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+	if n := len(cluster.Node.Bundle.Applications); n != 1 {
+		t.Errorf("expected no synthesis for unmatched component, got %d apps", n)
+	}
+}
+
+// TestSynthesizeEgress_IdentityGuard ensures a trait sub-app whose Name collides
+// with a component name does NOT receive the egress policy: only the primary
+// entry.app matches, by pointer identity.
+func TestSynthesizeEgress_IdentityGuard(t *testing.T) {
+	primary := stack.NewApplication("web", "app-ns", &stubAppConfig{})
+	// A different application that happens to share the component's name.
+	collider := stack.NewApplication("web", "other-ns", &stubAppConfig{})
+	bundle := &stack.Bundle{Applications: []*stack.Application{collider, primary}}
+	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
+	componentMap := map[string]componentEntry{
+		"web": {component: Component{Name: "web"}, app: primary},
+	}
+	peers := map[string][]netpol.EgressPeer{
+		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+	}
+
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+
+	var policies []*stack.Application
+	for _, a := range bundle.Applications {
+		if a.Name == "web-allow-egress-traffic" {
+			policies = append(policies, a)
+		}
+	}
+	if len(policies) != 1 {
+		t.Fatalf("expected exactly 1 egress policy, got %d", len(policies))
+	}
+	// It must be scoped to the primary app's namespace, not the collider's.
+	if policies[0].Namespace != "app-ns" {
+		t.Errorf("egress policy namespace = %q, want app-ns (primary), not the collider's", policies[0].Namespace)
+	}
+}

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -189,3 +189,163 @@ func trafficRuleKey(sources []netpol.TrafficSource, ports []intstr.IntOrString) 
 
 	return fmt.Sprintf("src:%s;ports:%s", strings.Join(srcKeys, "|"), strings.Join(portKeys, "|"))
 }
+
+// --- Egress synthesis (crane-supplied, non-authorable peers) ---
+
+// componentEgressPolicyConfig is the ApplicationConfig for an auto-generated
+// NetworkPolicy that allows egress from a component's pods to crane-supplied
+// dependency-graph peers. The resource name is {component}-allow-egress-traffic,
+// distinct from the inbound synthesis and the explicit networkpolicy trait, so it
+// is purely additive.
+type componentEgressPolicyConfig struct {
+	ComponentName string
+	Peers         []netpol.EgressPeer
+}
+
+// ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy
+// fields. Synthesis runs after the trait Enforceable.ApplyPolicy pass, so these
+// configs are intentionally never policy-checked (matching the inbound path).
+func (c *componentEgressPolicyConfig) ApplyPolicy(_ Policy) error { return nil }
+
+func (c *componentEgressPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	np := kubernetes.CreateNetworkPolicy(c.ComponentName+"-allow-egress-traffic", app.Namespace)
+	np.Labels = nil
+	np.Annotations = nil
+	kubernetes.SetNetworkPolicyPodSelector(np, metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": c.ComponentName},
+	})
+	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress})
+
+	// Protocol is a deliberate TCP constant: the per-peer signal carries no
+	// protocol, and UDP/DNS egress is owned by crane's namespace-level
+	// allow-dns-egress baseline, not component-scoped synthesis.
+	proto := corev1.ProtocolTCP
+	// Normalize here too (not just on the synthesis path) so a config built
+	// directly can never emit an all-ports rule from an empty-port peer.
+	for _, peer := range buildEgressPeers(c.Peers) {
+		// One egress rule per peer: a NetworkPolicyEgressRule is (any To) AND (any
+		// Ports), so grouping peers with differing ports would cross-product them
+		// (one peer reachable on another's ports).
+		rule := networkingv1.NetworkPolicyEgressRule{}
+		to := networkingv1.NetworkPolicyPeer{
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"kubernetes.io/metadata.name": peer.Namespace,
+				},
+			},
+		}
+		if peer.PodSelector != nil {
+			to.PodSelector = peer.PodSelector
+		}
+		kubernetes.AddNetworkPolicyEgressPeer(&rule, to)
+		for _, p := range peer.Ports {
+			port := p
+			kubernetes.AddNetworkPolicyEgressPort(&rule, networkingv1.NetworkPolicyPort{
+				Port:     &port,
+				Protocol: &proto,
+			})
+		}
+		kubernetes.AddNetworkPolicyEgressRule(np, rule)
+	}
+
+	obj := client.Object(np)
+	return []*client.Object{&obj}, nil
+}
+
+// synthesizeEgressNetworkPolicies traverses all leaf bundles and, for each primary
+// component application with crane-supplied egress peers, appends a
+// componentEgressPolicyConfig application emitting a per-component egress
+// NetworkPolicy. The signal is non-authorable (TransformContext.EgressPeers), so
+// this is a no-op on the kurel path where no peers are supplied.
+//
+// Runs as a cluster post-build stage (Phase 4), after trait application — so the
+// synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
+func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, egressPeers map[string][]netpol.EgressPeer) {
+	if cluster == nil || len(egressPeers) == 0 {
+		return
+	}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		var autoApps []*stack.Application
+		for _, app := range bundle.Applications {
+			// Match the primary component app by identity, not just by name: a
+			// trait sub-app whose name collides with a component name would match
+			// componentMap[app.Name] and could otherwise attach the policy beside
+			// the wrong app in the wrong bundle.
+			entry, ok := componentMap[app.Name]
+			if !ok || app != entry.app {
+				continue
+			}
+			peers := buildEgressPeers(egressPeers[app.Name])
+			if len(peers) == 0 {
+				continue
+			}
+			autoApps = append(autoApps, stack.NewApplication(
+				app.Name+"-allow-egress-traffic",
+				app.Namespace,
+				&componentEgressPolicyConfig{ComponentName: app.Name, Peers: peers},
+			))
+		}
+		bundle.Applications = append(bundle.Applications, autoApps...)
+	})
+}
+
+// buildEgressPeers normalizes crane-supplied egress peers for deterministic output:
+// it drops peers with no ports (an all-ports egress rule would over-permit; an
+// underivable-port peer stays authored via the escape hatch), copies and sorts each
+// surviving peer's ports, then deduplicates and sorts peers by a canonical key so
+// the emitted NetworkPolicy is byte-stable regardless of the graph's iteration order.
+func buildEgressPeers(peers []netpol.EgressPeer) []netpol.EgressPeer {
+	seen := map[string]struct{}{}
+	out := make([]netpol.EgressPeer, 0, len(peers))
+	for _, p := range peers {
+		if len(p.Ports) == 0 {
+			continue // no derivable destination ports; peer stays authored
+		}
+		ports := make([]intstr.IntOrString, len(p.Ports))
+		copy(ports, p.Ports)
+		sortIntOrStringPorts(ports)
+		peer := netpol.EgressPeer{Namespace: p.Namespace, PodSelector: p.PodSelector, Ports: ports}
+		key := egressPeerKey(peer)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, peer)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return egressPeerKey(out[i]) < egressPeerKey(out[j]) })
+	return out
+}
+
+// egressPeerKey returns a canonical dedup/ordering key for an egress peer. Ports
+// include their Type so Int(80) and String("80") do not collide.
+func egressPeerKey(p netpol.EgressPeer) string {
+	k := p.Namespace
+	if p.PodSelector != nil && len(p.PodSelector.MatchLabels) > 0 {
+		labelParts := make([]string, 0, len(p.PodSelector.MatchLabels))
+		for lk, lv := range p.PodSelector.MatchLabels {
+			labelParts = append(labelParts, lk+"="+lv)
+		}
+		sort.Strings(labelParts)
+		k += "/" + strings.Join(labelParts, ",")
+	}
+	portKeys := make([]string, 0, len(p.Ports))
+	for _, pt := range p.Ports {
+		portKeys = append(portKeys, fmt.Sprintf("%d:%s", pt.Type, pt.String()))
+	}
+	return fmt.Sprintf("ns:%s;ports:%s", k, strings.Join(portKeys, "|"))
+}
+
+// sortIntOrStringPorts orders ports numeric-ascending then named-lexical, matching
+// the inbound synthesis convention.
+func sortIntOrStringPorts(ports []intstr.IntOrString) {
+	sort.SliceStable(ports, func(i, j int) bool {
+		a, b := ports[i], ports[j]
+		if a.Type != b.Type {
+			return a.Type == intstr.Int // numeric ports before named ports
+		}
+		if a.Type == intstr.Int {
+			return a.IntVal < b.IntVal
+		}
+		return a.StrVal < b.StrVal
+	})
+}

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -185,5 +187,35 @@ func TestComponentAllowPolicyConfig_Generate(t *testing.T) {
 	}
 	if len(objs) != 1 {
 		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+
+	np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected *NetworkPolicy, got %T", *objs[0])
+	}
+	if np.Name != "web-allow-ingress-traffic" {
+		t.Errorf("name = %q, want web-allow-ingress-traffic", np.Name)
+	}
+	if np.Labels != nil || np.Annotations != nil {
+		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
+	}
+	if got := np.Spec.PodSelector.MatchLabels["app"]; got != "web" {
+		t.Errorf("podSelector app = %q, want web", got)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+		t.Errorf("policyTypes = %v, want [Ingress]", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Egress) != 0 {
+		t.Errorf("expected no egress rules, got %d", len(np.Spec.Egress))
+	}
+	if len(np.Spec.Ingress) != 1 {
+		t.Fatalf("expected 1 ingress rule, got %d", len(np.Spec.Ingress))
+	}
+	r := np.Spec.Ingress[0]
+	if len(r.From) != 1 || r.From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "ingress-nginx" {
+		t.Errorf("ingress peer = %v, want namespace ingress-nginx", r.From)
+	}
+	if len(r.Ports) != 1 || r.Ports[0].Port.IntVal != 80 || *r.Ports[0].Protocol != corev1.ProtocolTCP {
+		t.Errorf("ingress ports = %v, want [80/TCP]", r.Ports)
 	}
 }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
 
 // ValidateAndApplyDefaults is implemented by built-in TraitHandlers that accept
@@ -28,6 +30,11 @@ type TransformContext struct {
 	FluxNamespace string // Flux control-plane namespace; "" means use component namespace
 	Policy        Policy
 	Capabilities  map[string]CapabilityBinding
+	// EgressPeers carries crane-supplied, graph-derived egress destinations keyed
+	// by OAM component name. Non-authorable: never sourced from OAM YAML or
+	// capability rendering, and never merged into trait properties. nil on the
+	// kurel path, where egress synthesis is a no-op.
+	EgressPeers map[string][]netpol.EgressPeer
 }
 
 // fluxNamespaceSettable is implemented by ApplicationConfig types that emit
@@ -338,6 +345,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides, ctx.FluxNamespace)
 	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
 	synthesizeNetworkPolicies(cluster)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers)
 	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
 
 	return cluster, policyResult, nil


### PR DESCRIPTION
Closes #206. Handoff from crane#333 Phase 2. Canonical contract: crane `docs/design/networkpolicy-synthesis.md` (MR !357).

## What
Adds a per-component **egress** NetworkPolicy synthesis path to the Phase-4 cluster post-build stage, mirroring the shipped routing-derived **inbound** synthesis (crane#228).

### Signal — non-authorable, not capability rendering
App→infra / app→app egress peers are request-specific dependency-graph output, not a ClusterProfile capability fact. So the signal is a **crane-supplied, non-authorable synthesis input** on a new `TransformContext.EgressPeers` field (keyed by OAM component name):
- not capability rendering, not a rendered reserved key, not overridable-inline;
- no OAM key lets an app inject or redirect an egress peer;
- nil on the kurel path → synthesis is a no-op;
- authored `networkpolicy` / `cilium-networkpolicy` remain the additive escape hatch (unchanged).

### Output
- Separate per-component egress K8s `NetworkPolicy` (`{comp}-allow-egress-traffic`), distinct from the inbound `{comp}-allow-ingress-traffic` and the authored `{comp}-allow` — purely additive.
- **K8s NetworkPolicy only — no Cilium.** Per-peer shape: namespace selector + optional pod selector + ports.
- **One egress rule per peer** (a `NetworkPolicyEgressRule` is `To AND Ports`; grouping peers with differing ports would cross-product them).
- Protocol is a deliberate **TCP** constant (UDP/DNS egress is crane's namespace-level `allow-dns-egress` baseline).

### Determinism & safety
- `buildEgressPeers` skips empty-port peers (an all-ports rule over-permits), copies + sorts each peer's ports, and dedups + sorts peers by a canonical key (port key includes `Type`) → byte-stable output regardless of the graph's iteration order.
- `Generate` normalizes through the same helper, so a directly-built config can't emit an all-ports rule either.
- `synthesizeEgressNetworkPolicies` matches the primary component app by **pointer identity** (not just name), so a colliding sub-app name can't misplace the policy.

## Docs
Updated `pkg/oam/README.md` (both synthesis directions) and `pkg/oam/netpol/README.md` (`EgressPeer`).

## Tests
`pkg/oam/netpol_egress_synthesis_test.go`: `buildEgressPeers` (skip/dedup/distinct/determinism), full-shape `Generate` (incl. empty-port-peer skip), `synthesizeEgressNetworkPolicies` (append / no-op / identity guard); e2e `Transform` driving `ctx.EgressPeers`. Plus a shape-assertion backfill on the inbound `Generate` test.

## Scope / follow-up
- **Inert in production** until crane#333 Phase 2 derives the peers from typed edges (`AppInfraInferred`/`AppApp`) and copies them into the launcher ctx in `toLauncherCtx` — separate crane MR. This is the launcher half of the contract.
- Out of scope (stay authored): Cilium/CCNP, L7/FQDN/entity synthesis, kube-apiserver egress, merging authored+synthesized; the namespace DNS baseline is crane-owned; external-secret/backup egress derivation is crane's signal-derivation limit.