### PR TITLE
fix(release): honest dry-run tag checks + clearer --do-it flow

### DIFF
--- a/scripts/release-trigger.sh
+++ b/scripts/release-trigger.sh
@@ -24,6 +24,7 @@ ARG=""
 for _arg in "$@"; do
     case "$_arg" in
         --do-it) DO_IT=1 ;;
+        --) ;;  # tolerate a stray separator (e.g. `mise run release -- --do-it`)
         promote|bump)
             if [ -n "$SUBCOMMAND" ]; then
                 echo "ERROR: unexpected argument: $_arg" >&2; exit 1
@@ -60,6 +61,12 @@ fi
 
 # ── Show dry-run preview ────────────────────────────────────────────────
 
+if [ "$DO_IT" = "1" ]; then
+    echo "NOTE: showing a dry-run preview first (no changes are made here);"
+    echo "      the REAL release is then dispatched to CI below."
+    echo ""
+fi
+
 if [ "$SUBCOMMAND" = "bump" ]; then
     echo "=== Version Bump Preview ==="
     echo ""
@@ -81,19 +88,21 @@ if [ "$DO_IT" != "1" ]; then
     echo "---"
     if [ "$SUBCOMMAND" = "bump" ]; then
         echo "To execute, run:"
-        echo "  mise run release bump $ARG -- --do-it"
+        echo "  mise run release bump $ARG --do-it"
     elif [ "$SUBCOMMAND" = "promote" ]; then
         echo "To execute, run:"
-        echo "  mise run release promote $ARG -- --do-it"
+        echo "  mise run release promote $ARG --do-it"
     else
         echo "To execute, run:"
-        echo "  mise run release -- --do-it"
+        echo "  mise run release --do-it"
     fi
     exit 0
 fi
 
 # ── Trigger CI ───────────────────────────────────────────────────────────
 
+echo "Preview above made NO changes. Dispatching the REAL release to CI now…"
+echo ""
 echo "=== Triggering CI ==="
 echo ""
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -316,10 +316,15 @@ To restart from $target_type, use release-bump to advance to the next cycle firs
     log_info "Next dev version: $next_version"
     echo ""
 
+    # Tag-collision checks run even in DRY_RUN so the preview fails loudly instead of
+    # printing a false "complete" while the real CI run dies on the collision.
+    check_tag_exists "$release_version"
+    # Invariant: a release must never leave VERSION pointing at an existing tag
+    # (mirrors release_bump) — guards a stale VERSION or an out-of-band tag.
+    check_tag_exists "$next_version"
     if [ "$DRY_RUN" != "1" ]; then
         validate_git_state
         check_local_replaces
-        check_tag_exists "$release_version"
     fi
 
     # Write release version if different from current
@@ -369,10 +374,15 @@ release_stable() {
     log_info "Next dev version: $next_version"
     echo ""
 
+    # Tag-collision checks run even in DRY_RUN so the preview fails loudly instead of
+    # printing a false "complete" while the real CI run dies on the collision.
+    check_tag_exists "$release_version"
+    # Invariant: a release must never leave VERSION pointing at an existing tag
+    # (mirrors release_bump) — guards a stale VERSION or an out-of-band tag.
+    check_tag_exists "$next_version"
     if [ "$DRY_RUN" != "1" ]; then
         validate_git_state
         check_local_replaces
-        check_tag_exists "$release_version"
     fi
 
     write_version "$release_version"
@@ -431,10 +441,11 @@ release_bump() {
     log_info "Next dev version: $next_version"
     echo ""
 
+    # Invariant (checked even in DRY_RUN so the preview catches collisions): a bump
+    # must never leave VERSION equal to an existing tag.
+    check_tag_exists "$next_version"
     if [ "$DRY_RUN" != "1" ]; then
         validate_git_state
-        # Invariant: a bump must never leave VERSION equal to an existing tag.
-        check_tag_exists "$next_version"
     fi
 
     write_version "$next_version"


### PR DESCRIPTION
Track A release-tooling hardening (mirrors the pkg fix; launcher already has the `mise run release` task).

- Run `check_tag_exists` in `DRY_RUN` too so the `release-trigger.sh` preview **errors loudly** on an existing tag instead of printing a false `OK: Release … complete!` (the failure mode that hid pkg's wedged release).
- Add the `next_version` invariant to `release_prerelease`/`release_stable` (mirrors `release_bump`): never leave `VERSION` pointing at an existing tag.
- `release-trigger.sh` `--do-it` UX: pre-frame the dry-run preview, print a transition line before dispatching the real release to CI, tolerate a stray `--`, and fix the echoed `-- --do-it` hints.

Verified: healthy preview (alpha.17) still exits 0; `shellcheck` clean apart from a pre-existing SC2001 in `base_part`.