### PR TITLE
fix(docs): publish external-secret shorthand design doc and fix traits link

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -100,7 +100,7 @@ not the app — chooses the implementation:
   `secretKey`; author any `remoteRef` field to override. Because absence is meaningful,
   unknown keys in an entry or its `remoteRef` are rejected (naming the supported
   fields) rather than silently ignored. See
-  [design-external-secret-data-shorthand](../../../../docs/oam/design-external-secret-data-shorthand.md).
+  [External Secret Shorthand](/concepts/oam-external-secret-shorthand/).
 
 ## Auto-synthesized NetworkPolicy
 

--- a/site/docs-map.yaml
+++ b/site/docs-map.yaml
@@ -73,6 +73,7 @@ extra_mounts:
   - {source: docs/oam/options-policy-interface.md, target: concepts/oam-policy-interface.md, title: Policy Interface, weight: 60}
   - {source: docs/oam/options-package-composition.md, target: concepts/oam-package-composition.md, title: Package Composition, weight: 70}
   - {source: docs/oam/design-capability-schema.md, target: concepts/oam-capability-schema.md, title: Capability Schema, weight: 55}
+  - {source: docs/oam/design-external-secret-data-shorthand.md, target: concepts/oam-external-secret-shorthand.md, title: External Secret Shorthand, weight: 80}
   - {source: DEVELOPMENT.md, target: contributing/guide.md, title: Development Guide, weight: 10}
   - {source: docs/github-workflows.md, target: contributing/github-workflows.md, title: GitHub Workflows, weight: 20}
   - {source: CHANGELOG.md, target: changelog/releases.md, title: Releases, weight: 10}


### PR DESCRIPTION
## Problem

The docs crawler reported `https://www.gokure.dev/docs/oam/design-external-secret-data-shorthand.md` as a 404. The doc exists at `docs/oam/design-external-secret-data-shorthand.md` but — unlike its `design-*.md` siblings — was never mounted into the site, and `pkg/oam/builtin/traits/README.md` linked to it with a repo-relative `.md` path, so the link dangles on the rendered site.

## Fix

- Mount the doc via `extra_mounts` in `site/docs-map.yaml` as `concepts/oam-external-secret-shorthand` (consistent with the other OAM design docs).
- Repoint the traits README link to the published slug `/concepts/oam-external-secret-shorthand/`.

No custom render-link hook was added: the Relearn theme already version-prefixes the root-absolute link to `/launcher/dev/concepts/oam-external-secret-shorthand/` on its own. (An earlier plan to copy kure's hook was dropped after simulation showed it would replace Relearn's page-ref resolution and break existing relative links, while being unnecessary here.)

## Verification

- `bash site/scripts/check-doc-sync.sh` → OK (source exists, target unique).
- Real-baseURL build (`hugo --baseURL https://www.gokure.dev/launcher/dev/`): `concepts/oam-external-secret-shorthand/` is published; the traits page link renders as `/launcher/dev/concepts/oam-external-secret-shorthand/`.
- `bash site/scripts/check-links.sh` → 0 errors (no regressions).