### PR TITLE
feat(oam/netpol): target wharf.zone/component in synthesized NetworkPolicies

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -39,6 +39,16 @@ in two directions, each a **separate** additive resource (the authored
   set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a
   caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op.
 
+Both families select the component's own pods (the ingress recipients / the egress
+source pods) via the **`wharf.zone/component`** label by default, overridable per
+transform through `TransformContext.ComponentLabelKey`. This is a **platform contract**:
+`trafficSources` (inbound) and `EgressPeers` (egress) are platform inputs, so a caller
+that injects them must ensure its pods carry that label — crane stamps
+`wharf.zone/component` on every crane-rendered workload and helm-rendered pod — or set
+`ComponentLabelKey` to a label its pods do carry (e.g. `"app"`). A non-crane caller that
+injects `trafficSources`/`EgressPeers` without either will synthesize a policy that
+selects nothing.
+
 ## Parsing
 
 | Function | Purpose |

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -122,10 +122,12 @@ for the interfaces, and `examples/` for runnable applications.
 Every trait sub-app config exposes the OAM component it was emitted for via
 `ComponentName() string` (the `oam.ComponentNamed` interface) — always the component
 name, never the sub-app or K8s Service name. Consumers use it to stamp per-resource
-provenance (e.g. a `wharf.zone/component` label) without re-deriving the component
+provenance (the `wharf.zone/component` label) without re-deriving the component
 from sub-app names, which several handlers author from properties rather than
 `<component>-<suffix>`. The routing traits' existing `TargetComponentName()` (used by
-auto-NetworkPolicy synthesis) delegates to the same accessor.
+auto-NetworkPolicy synthesis) delegates to the same accessor; auto-synthesized
+NetworkPolicies target that `wharf.zone/component` label by default
+(`TransformContext.ComponentLabelKey`-overridable).
 
 ## Conventions
 

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -919,8 +919,9 @@ func (c *HTTPRouteConfig) TrafficSources() []netpol.TrafficSource { return c.sou
 // component name, not the K8s Service name — for resource provenance attribution.
 func (c *HTTPRouteConfig) ComponentName() string { return c.componentName }
 
-// TargetComponentName returns the OAM component label (not the K8s Service name),
-// so the synthesized NetworkPolicy selects the component's pods via {app: <name>}.
+// TargetComponentName returns the OAM component label (not the K8s Service name), so the
+// synthesized NetworkPolicy selects the component's pods via the configured component
+// label key (default {wharf.zone/component: <name>}).
 func (c *HTTPRouteConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -368,8 +368,9 @@ func (c *IngressConfig) TrafficSources() []netpol.TrafficSource { return c.sourc
 // component name, not the K8s Service name — for resource provenance attribution.
 func (c *IngressConfig) ComponentName() string { return c.componentName }
 
-// TargetComponentName returns the OAM component label (not the K8s Service name),
-// so the synthesized NetworkPolicy selects the component's pods via {app: <name>}.
+// TargetComponentName returns the OAM component label (not the K8s Service name), so the
+// synthesized NetworkPolicy selects the component's pods via the configured component
+// label key (default {wharf.zone/component: <name>}).
 func (c *IngressConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/go-kure/launcher/pkg/oam"
@@ -97,7 +98,8 @@ func TestIngressHandler_TrafficSources_MalformedErrors(t *testing.T) {
 
 // TargetComponentName must be the OAM component label, never the (possibly
 // overridden) K8s Service name, so the synthesized NetworkPolicy selects the
-// component's pods via {app: <component>}.
+// component's pods via the configured component label key (default
+// {wharf.zone/component: <component>}).
 func TestIngressConfig_TargetComponentName_IsComponentNotService(t *testing.T) {
 	app := stack.NewApplication("web", "default", &namedWebConfig{port: 80, serviceName: "web-headless"})
 	trait := ingressTrafficSourcesTrait(map[string]any{
@@ -186,6 +188,10 @@ func TestTransform_IngressTrafficSources_SynthesizesNetworkPolicy(t *testing.T) 
 	if !clusterHasApp(cluster, "web-allow-ingress-traffic") {
 		t.Errorf("expected synthesized app \"web-allow-ingress-traffic\"; cluster apps: %v", clusterAppNames(cluster))
 	}
+	// Default target selector is wharf.zone/component (crane stamps it on every pod).
+	if sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic"); sel["wharf.zone/component"] != "web" {
+		t.Errorf("default ingress podSelector = %v, want wharf.zone/component=web", sel)
+	}
 }
 
 func clusterAppNames(c *stack.Cluster) []string {
@@ -222,6 +228,57 @@ func clusterHasApp(c *stack.Cluster, name string) bool {
 	return slices.Contains(clusterAppNames(c), name)
 }
 
+// synthesizedPodSelector finds the named synthesized app, runs its config's Generate,
+// and returns the emitted NetworkPolicy's top-level podSelector matchLabels — proving
+// the configured ComponentLabelKey is threaded all the way through Phase 4.
+func synthesizedPodSelector(t *testing.T, c *stack.Cluster, name string) map[string]string {
+	t.Helper()
+	var found *stack.Application
+	var visitBundle func(b *stack.Bundle)
+	visitBundle = func(b *stack.Bundle) {
+		if b == nil || found != nil {
+			return
+		}
+		for _, a := range b.Applications {
+			if a.Name == name {
+				found = a
+				return
+			}
+		}
+		for _, ch := range b.Children {
+			visitBundle(ch)
+		}
+	}
+	var visitNode func(n *stack.Node)
+	visitNode = func(n *stack.Node) {
+		if n == nil || found != nil {
+			return
+		}
+		visitBundle(n.Bundle)
+		for _, ch := range n.Children {
+			visitNode(ch)
+		}
+	}
+	if c != nil {
+		visitNode(c.Node)
+	}
+	if found == nil {
+		t.Fatalf("synthesized app %q not found; cluster apps: %v", name, clusterAppNames(c))
+	}
+	objs, err := found.Config.Generate(found)
+	if err != nil {
+		t.Fatalf("Generate %q: %v", name, err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object from %q, got %d", name, len(objs))
+	}
+	np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected *NetworkPolicy from %q, got %T", name, *objs[0])
+	}
+	return np.Spec.PodSelector.MatchLabels
+}
+
 // End-to-end: a webservice with crane-supplied (non-authorable) egress peers on the
 // transform context yields a synthesized {component}-allow-egress-traffic policy, and
 // no inbound policy is synthesized absent trafficSources (additive, distinct paths).
@@ -256,5 +313,76 @@ func TestTransform_EgressPeers_SynthesizesEgressNetworkPolicy(t *testing.T) {
 	}
 	if clusterHasApp(cluster, "web-allow-ingress-traffic") {
 		t.Errorf("did not expect inbound synthesis without trafficSources; cluster apps: %v", clusterAppNames(cluster))
+	}
+	// Default egress source-pod selector is wharf.zone/component.
+	if sel := synthesizedPodSelector(t, cluster, "web-allow-egress-traffic"); sel["wharf.zone/component"] != "web" {
+		t.Errorf("default egress podSelector = %v, want wharf.zone/component=web", sel)
+	}
+}
+
+// End-to-end: TransformContext.ComponentLabelKey overrides the synthesized podSelector
+// key for BOTH inbound and egress families. The "app" case is the escape hatch that
+// restores pre-change behavior for non-crane/kurel callers; a custom key proves the
+// value is passed through verbatim.
+func TestTransform_ComponentLabelKey_Override(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantKey string
+	}{
+		{"escape_hatch_app", "app", "app"},
+		{"custom_key", "example.com/name", "example.com/name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := oam.NewTransformer(nil, nil)
+			tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+			tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+			app := &oam.Application{
+				Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+				Spec: oam.ApplicationSpec{
+					Components: []oam.Component{{
+						Name:       "web",
+						Type:       "webservice",
+						Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+						Traits: []oam.Trait{{
+							Type: "ingress",
+							Properties: map[string]any{
+								"rules": []any{map[string]any{
+									"host":  "example.com",
+									"paths": []any{map[string]any{"path": "/"}},
+								}},
+								"networkPolicy": map[string]any{
+									"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}},
+								},
+							},
+						}},
+					}},
+				},
+			}
+
+			ctx := oam.TransformContext{
+				Namespace:         "default",
+				ComponentLabelKey: tc.key,
+				EgressPeers: map[string][]netpol.EgressPeer{
+					"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+				},
+			}
+			cluster, _, err := tr.TransformWithPolicy(app, ctx)
+			if err != nil {
+				t.Fatalf("TransformWithPolicy: %v", err)
+			}
+
+			for _, npName := range []string{"web-allow-ingress-traffic", "web-allow-egress-traffic"} {
+				sel := synthesizedPodSelector(t, cluster, npName)
+				if sel[tc.wantKey] != "web" {
+					t.Errorf("%s podSelector = %v, want %s=web", npName, sel, tc.wantKey)
+				}
+				if _, hasDefault := sel["wharf.zone/component"]; hasDefault && tc.wantKey != "wharf.zone/component" {
+					t.Errorf("%s podSelector should not carry default key when overridden: %v", npName, sel)
+				}
+			}
+		})
 	}
 }

--- a/pkg/oam/classify.go
+++ b/pkg/oam/classify.go
@@ -5,6 +5,12 @@ import "fmt"
 // TierAnnotation is the OAM component annotation key for overriding the default tier.
 const TierAnnotation = "wharf.zone/tier"
 
+// ComponentLabel is the pod label key crane stamps on every crane-rendered workload
+// pod and helm-rendered pod under crane (webservice via its mutator, helm-rendered
+// pods via a mandatory post-renderer). Synthesized NetworkPolicies target it by default
+// so a single deterministic selector covers both builtin and helm-backed component pods.
+const ComponentLabel = "wharf.zone/component"
+
 // defaultTierMap maps OAM component types to their deployment tier.
 var defaultTierMap = map[string]Tier{
 	"postgresql":  TierServices,

--- a/pkg/oam/netpol_egress_synthesis_test.go
+++ b/pkg/oam/netpol_egress_synthesis_test.go
@@ -110,8 +110,11 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 	if np.Labels != nil || np.Annotations != nil {
 		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
 	}
-	if got := np.Spec.PodSelector.MatchLabels["app"]; got != "web" {
-		t.Errorf("podSelector app = %q, want web", got)
+	if got := np.Spec.PodSelector.MatchLabels["wharf.zone/component"]; got != "web" {
+		t.Errorf("podSelector wharf.zone/component = %q, want web", got)
+	}
+	if _, hasApp := np.Spec.PodSelector.MatchLabels["app"]; hasApp {
+		t.Errorf("podSelector should not carry legacy app key: %v", np.Spec.PodSelector.MatchLabels)
 	}
 	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeEgress {
 		t.Errorf("policyTypes = %v, want [Egress]", np.Spec.PolicyTypes)
@@ -150,6 +153,39 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 	}
 	if len(r1.Ports) != 1 || r1.Ports[0].Port.IntVal != 5432 || *r1.Ports[0].Protocol != corev1.ProtocolTCP {
 		t.Errorf("rule 1 ports = %v, want [5432/TCP]", r1.Ports)
+	}
+}
+
+// TestComponentEgressPolicyConfig_PodSelectorKey verifies the top-level podSelector key
+// (the egress source pods): empty defaults to wharf.zone/component, and a non-empty
+// PodSelectorKey wins (e.g. a non-crane caller opting back to "app").
+func TestComponentEgressPolicyConfig_PodSelectorKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantKey string
+	}{
+		{"default", "", "wharf.zone/component"},
+		{"override_app", "app", "app"},
+		{"override_custom", "example.com/name", "example.com/name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &componentEgressPolicyConfig{
+				ComponentName:  "web",
+				PodSelectorKey: tc.key,
+				Peers: []netpol.EgressPeer{
+					{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}},
+				},
+			}
+			np := egressPolicyFromGenerate(t, cfg)
+			if got := np.Spec.PodSelector.MatchLabels[tc.wantKey]; got != "web" {
+				t.Errorf("podSelector[%q] = %q, want web (labels=%v)", tc.wantKey, got, np.Spec.PodSelector.MatchLabels)
+			}
+			if len(np.Spec.PodSelector.MatchLabels) != 1 {
+				t.Errorf("podSelector should have exactly one label, got %v", np.Spec.PodSelector.MatchLabels)
+			}
+		})
 	}
 }
 
@@ -203,7 +239,7 @@ func TestSynthesizeEgress_AppendsPolicy(t *testing.T) {
 		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
 
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
 
 	leaf := cluster.Node.Bundle
 	if len(leaf.Applications) != 2 {
@@ -223,7 +259,7 @@ func TestSynthesizeEgress_AppendsPolicy(t *testing.T) {
 
 func TestSynthesizeEgress_NoOpWhenNoPeers(t *testing.T) {
 	cluster, componentMap, _ := egressFixture("web", "default")
-	synthesizeEgressNetworkPolicies(cluster, componentMap, nil)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, nil, ComponentLabel)
 	if n := len(cluster.Node.Bundle.Applications); n != 1 {
 		t.Errorf("expected no synthesis for nil peers, got %d apps", n)
 	}
@@ -235,7 +271,7 @@ func TestSynthesizeEgress_NoOpWhenNoComponentMatch(t *testing.T) {
 	peers := map[string][]netpol.EgressPeer{
 		"other": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
 	if n := len(cluster.Node.Bundle.Applications); n != 1 {
 		t.Errorf("expected no synthesis for unmatched component, got %d apps", n)
 	}
@@ -257,7 +293,7 @@ func TestSynthesizeEgress_IdentityGuard(t *testing.T) {
 		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
 
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
 
 	var policies []*stack.Application
 	for _, a := range bundle.Applications {

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -37,6 +37,18 @@ type trafficRule struct {
 type componentAllowPolicyConfig struct {
 	ComponentName string
 	Rules         []trafficRule // one per collector with non-empty ports; deduplicated
+	// PodSelectorKey is the label key selecting the component's own pods (the ingress
+	// recipients). Empty => ComponentLabel ("wharf.zone/component").
+	PodSelectorKey string
+}
+
+// podSelectorKey returns the configured selector key, defaulting to ComponentLabel so a
+// directly-built config never emits an empty-key selector.
+func (c *componentAllowPolicyConfig) podSelectorKey() string {
+	if c.PodSelectorKey == "" {
+		return ComponentLabel
+	}
+	return c.PodSelectorKey
 }
 
 // ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy
@@ -49,7 +61,7 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 	np.Labels = nil
 	np.Annotations = nil
 	kubernetes.SetNetworkPolicyPodSelector(np, metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": c.ComponentName},
+		MatchLabels: map[string]string{c.podSelectorKey(): c.ComponentName},
 	})
 	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress})
 
@@ -90,14 +102,16 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 //
 // Runs as a cluster post-build stage (Phase 4), after trait application — so the
 // synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
-func synthesizeNetworkPolicies(cluster *stack.Cluster) {
+func synthesizeNetworkPolicies(cluster *stack.Cluster, labelKey string) {
 	if cluster == nil {
 		return
 	}
-	walkLeafBundles(cluster.Node, synthesizeForBundle)
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		synthesizeForBundle(bundle, labelKey)
+	})
 }
 
-func synthesizeForBundle(bundle *stack.Bundle) {
+func synthesizeForBundle(bundle *stack.Bundle, labelKey string) {
 	if bundle == nil {
 		return
 	}
@@ -133,7 +147,7 @@ func synthesizeForBundle(bundle *stack.Bundle) {
 		autoApp := stack.NewApplication(
 			compName+"-allow-ingress-traffic",
 			entry.namespace,
-			&componentAllowPolicyConfig{ComponentName: compName, Rules: rules},
+			&componentAllowPolicyConfig{ComponentName: compName, Rules: rules, PodSelectorKey: labelKey},
 		)
 		bundle.Applications = append(bundle.Applications, autoApp)
 	}
@@ -200,6 +214,18 @@ func trafficRuleKey(sources []netpol.TrafficSource, ports []intstr.IntOrString) 
 type componentEgressPolicyConfig struct {
 	ComponentName string
 	Peers         []netpol.EgressPeer
+	// PodSelectorKey is the label key selecting the component's own pods (the egress
+	// source pods this policy allows out). Empty => ComponentLabel ("wharf.zone/component").
+	PodSelectorKey string
+}
+
+// podSelectorKey returns the configured selector key, defaulting to ComponentLabel so a
+// directly-built config never emits an empty-key selector.
+func (c *componentEgressPolicyConfig) podSelectorKey() string {
+	if c.PodSelectorKey == "" {
+		return ComponentLabel
+	}
+	return c.PodSelectorKey
 }
 
 // ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy
@@ -212,7 +238,7 @@ func (c *componentEgressPolicyConfig) Generate(app *stack.Application) ([]*clien
 	np.Labels = nil
 	np.Annotations = nil
 	kubernetes.SetNetworkPolicyPodSelector(np, metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": c.ComponentName},
+		MatchLabels: map[string]string{c.podSelectorKey(): c.ComponentName},
 	})
 	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeEgress})
 
@@ -260,7 +286,7 @@ func (c *componentEgressPolicyConfig) Generate(app *stack.Application) ([]*clien
 //
 // Runs as a cluster post-build stage (Phase 4), after trait application — so the
 // synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
-func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, egressPeers map[string][]netpol.EgressPeer) {
+func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, egressPeers map[string][]netpol.EgressPeer, labelKey string) {
 	if cluster == nil || len(egressPeers) == 0 {
 		return
 	}
@@ -282,7 +308,7 @@ func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[st
 			autoApps = append(autoApps, stack.NewApplication(
 				app.Name+"-allow-egress-traffic",
 				app.Namespace,
-				&componentEgressPolicyConfig{ComponentName: app.Name, Peers: peers},
+				&componentEgressPolicyConfig{ComponentName: app.Name, Peers: peers, PodSelectorKey: labelKey},
 			))
 		}
 		bundle.Applications = append(bundle.Applications, autoApps...)

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -108,7 +108,7 @@ func TestSynthesizeForBundle_AddsNetworkPolicyApp(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle)
+	synthesizeForBundle(bundle, ComponentLabel)
 
 	if len(bundle.Applications) != 2 {
 		t.Fatalf("expected 2 applications after synthesis, got %d", len(bundle.Applications))
@@ -128,7 +128,7 @@ func TestSynthesizeForBundle_NoSynthesisWithoutSources(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle)
+	synthesizeForBundle(bundle, ComponentLabel)
 
 	if len(bundle.Applications) != 1 {
 		t.Errorf("expected no synthesis (no sources), got %d apps", len(bundle.Applications))
@@ -150,7 +150,7 @@ func TestSynthesizeForBundle_TwoCollectorsSameComponent(t *testing.T) {
 	app2 := stack.NewApplication("web-httproute", "default", col2)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app1, app2}}
 
-	synthesizeForBundle(bundle)
+	synthesizeForBundle(bundle, ComponentLabel)
 
 	// One synthesized policy per component (not per collector).
 	count := 0
@@ -199,8 +199,11 @@ func TestComponentAllowPolicyConfig_Generate(t *testing.T) {
 	if np.Labels != nil || np.Annotations != nil {
 		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
 	}
-	if got := np.Spec.PodSelector.MatchLabels["app"]; got != "web" {
-		t.Errorf("podSelector app = %q, want web", got)
+	if got := np.Spec.PodSelector.MatchLabels["wharf.zone/component"]; got != "web" {
+		t.Errorf("podSelector wharf.zone/component = %q, want web", got)
+	}
+	if _, hasApp := np.Spec.PodSelector.MatchLabels["app"]; hasApp {
+		t.Errorf("podSelector should not carry legacy app key: %v", np.Spec.PodSelector.MatchLabels)
 	}
 	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
 		t.Errorf("policyTypes = %v, want [Ingress]", np.Spec.PolicyTypes)
@@ -218,4 +221,59 @@ func TestComponentAllowPolicyConfig_Generate(t *testing.T) {
 	if len(r.Ports) != 1 || r.Ports[0].Port.IntVal != 80 || *r.Ports[0].Protocol != corev1.ProtocolTCP {
 		t.Errorf("ingress ports = %v, want [80/TCP]", r.Ports)
 	}
+}
+
+// TestComponentAllowPolicyConfig_PodSelectorKey verifies the top-level podSelector key:
+// empty defaults to wharf.zone/component, and a non-empty PodSelectorKey wins (e.g. a
+// non-crane caller opting back to "app").
+func TestComponentAllowPolicyConfig_PodSelectorKey(t *testing.T) {
+	cases := []struct {
+		name    string
+		key     string
+		wantKey string
+	}{
+		{"default", "", "wharf.zone/component"},
+		{"override_app", "app", "app"},
+		{"override_custom", "example.com/name", "example.com/name"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &componentAllowPolicyConfig{
+				ComponentName:  "web",
+				PodSelectorKey: tc.key,
+				Rules: []trafficRule{{
+					Sources: []netpol.TrafficSource{{Namespace: "ingress-nginx"}},
+					Ports:   []intstr.IntOrString{intstr.FromInt32(80)},
+				}},
+			}
+			np := generatedNetworkPolicy(t, cfg)
+			if got := np.Spec.PodSelector.MatchLabels[tc.wantKey]; got != "web" {
+				t.Errorf("podSelector[%q] = %q, want web (labels=%v)", tc.wantKey, got, np.Spec.PodSelector.MatchLabels)
+			}
+			if len(np.Spec.PodSelector.MatchLabels) != 1 {
+				t.Errorf("podSelector should have exactly one label, got %v", np.Spec.PodSelector.MatchLabels)
+			}
+		})
+	}
+}
+
+// generatedNetworkPolicy runs an ApplicationConfig's Generate and returns the single
+// emitted *NetworkPolicy, failing the test on any deviation.
+func generatedNetworkPolicy(t *testing.T, cfg interface {
+	Generate(*stack.Application) ([]*client.Object, error)
+}) *networkingv1.NetworkPolicy {
+	t.Helper()
+	app := stack.NewApplication("np", "default", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if len(objs) != 1 {
+		t.Fatalf("expected 1 object, got %d", len(objs))
+	}
+	np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected *NetworkPolicy, got %T", *objs[0])
+	}
+	return np
 }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -35,6 +35,13 @@ type TransformContext struct {
 	// capability rendering, and never merged into trait properties. nil on the
 	// kurel path, where egress synthesis is a no-op.
 	EgressPeers map[string][]netpol.EgressPeer
+	// ComponentLabelKey overrides the pod-label key that synthesized NetworkPolicies
+	// target (the component's own pods: ingress recipients / egress sources). Empty
+	// => ComponentLabel ("wharf.zone/component"). Non-authorable platform input, like
+	// EgressPeers: a caller that injects trafficSources/EgressPeers must ensure its
+	// pods carry this label (crane stamps wharf.zone/component) or set this to a key
+	// its pods do carry (e.g. "app").
+	ComponentLabelKey string
 }
 
 // fluxNamespaceSettable is implemented by ApplicationConfig types that emit
@@ -344,8 +351,12 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	}
 	applyAutoHealthChecks(cluster, componentMap, policyResult.HealthCheckOverrides, ctx.FluxNamespace)
 	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
-	synthesizeNetworkPolicies(cluster)
-	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers)
+	labelKey := ctx.ComponentLabelKey
+	if labelKey == "" {
+		labelKey = ComponentLabel
+	}
+	synthesizeNetworkPolicies(cluster, labelKey)
+	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey)
 	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
 
 	return cluster, policyResult, nil


### PR DESCRIPTION
## Summary

Retargets the Phase-4 synthesized NetworkPolicy families — `{comp}-allow-ingress-traffic` and `{comp}-allow-egress-traffic` — from the hardcoded `app: <component>` podSelector to **`wharf.zone/component: <component>`**, made configurable per-transform via a new `TransformContext.ComponentLabelKey` (empty ⇒ `wharf.zone/component`).

The old `app:` selector matched crane webservice/worker and builtin pods but **missed helm-backed components** whose pods carry the chart's own labels (`app: holmes`, `app.kubernetes.io/name`, …), so the synthesized policy selected nothing and traffic stayed blocked. crane now stamps a uniform `wharf.zone/component` provenance label on every crane-rendered workload and helm-rendered pod, so a single deterministic selector covers all workloads. This retires the currently-inert synthesized NPs for holmesgpt/headlamp and the per-app authored nginx CNP workarounds (crane#333 Phase 1b, self-service case).

Closes the **original #211 Ask** (inbound `wharf.zone/component`, configurable). Additively also covers **egress** (same hardcoded selector, same fix). Does **not** address the issue comment's `expose.backendRefs` cross-component extension — deferred to a follow-up (see below).

## Compatibility contract (kurel / non-crane)

`trafficSources` (inbound) and `EgressPeers` (egress) are **platform inputs**. A non-crane caller that injects them must ensure its pods carry `wharf.zone/component` (crane stamps it) **or** set `TransformContext.ComponentLabelKey` to a key its pods do carry (e.g. `"app"`). Otherwise the synthesized policy selects nothing. This is the intended contract, documented in `pkg/oam/README.md`. No new kurel CLI flag. **Behavior change** — worth a line in the alpha.17 changelog.

## Scope guard

Authored `networkpolicy` / `cilium-networkpolicy` trait selectors are untouched — the change is confined to the two synthesized config types.

## Tests

- Unit: `PodSelectorKey` default / `app` override / custom key for both ingress and egress configs.
- End-to-end (`TransformWithPolicy`): default selector is `wharf.zone/component` for both families, plus `TestTransform_ComponentLabelKey_Override` proving the key threads through Phase 4 — including the **`app` escape-hatch regression case**.
- `mise run lint` (0 issues), `mise run test` (all pass), `check-doc-sync.sh` + `check-links.sh` OK.

## Coordination with crane#333 Phase 2 (endpoint synthesis)

- **Rebase order:** this lands **first**; the Phase-2 launcher MR (`EndpointProvider` + `{comp}-allow-endpoint-ingress`) rebases on top. Both edit `pkg/oam/netpol_synthesis.go` and `pkg/oam/README.md`.
- The third family (`{comp}-allow-endpoint-ingress`) targets a crane-supplied endpoint selector (e.g. `cnpg.io/cluster: <name>` on operator-created pods that carry **no** `wharf.zone/component`) and must **not** use `ComponentLabelKey`.
- **Downstream crane golden churn** (all synthesized NP podSelectors `app:` → `wharf.zone/component`) lands in crane's launcher-version-bump commit, separate from the Phase-2 feature commit.

## Follow-up (out of scope)

`expose.backendRefs`-derived target selector+port for cross-component backends (issue #211 comment, e.g. the opsmaster `ntfy` case). Needs its own design: resolving a backendRef service name to the owning component + backend port, including external/helm backends launcher does not model.

Refs #211, crane#333. Do not auto-close #211 until the team agrees the `backendRefs` extension is tracked separately.