### PR TITLE
feat(oam): parametrize the platform label/annotation domain (default gokure.dev)

### DIFF
--- a/pkg/cmd/kurel/README.md
+++ b/pkg/cmd/kurel/README.md
@@ -37,6 +37,16 @@ properties, so a component/trait's properties can be validated before dispatch. 
 and [Trait Handlers](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/builtin/traits)
 for the full catalogue; the `security-context` trait was added in this release.
 
+### Platform key domain
+
+kurel derives its platform label/annotation keys under the **`launcher.gokure.dev`**
+domain: the tier-override annotation is `launcher.gokure.dev/tier`, and synthesized
+NetworkPolicies select pods via `launcher.gokure.dev/component`. This is kurel's fixed
+choice over the launcher library default (`gokure.dev`); other embedders set their own
+domain through `TransformContext.Domain`. See the
+[OAM model](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam) for the derivation
+and precedence rules.
+
 | Flag | Description |
 |------|-------------|
 | `--profile` (required) | Path to the `ClusterProfile` YAML. |

--- a/pkg/cmd/kurel/build.go
+++ b/pkg/cmd/kurel/build.go
@@ -19,6 +19,11 @@ import (
 	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
 )
 
+// kurelDomain is the label/annotation domain the kurel CLI stamps into every transform.
+// The library default is oam.DefaultDomain ("gokure.dev"); kurel uses its own subdomain so
+// kurel-rendered manifests are self-describing. Embedders override via TransformContext.Domain.
+const kurelDomain = "launcher.gokure.dev"
+
 type buildOptions struct {
 	profilePath        string
 	outputDir          string
@@ -155,6 +160,7 @@ func runBuild(cmd *cobra.Command, arg string, opts *buildOptions) error {
 		ClusterID:    opts.clusterID,
 		Namespace:    opts.namespace,
 		Capabilities: evaluatedProfile.Spec.Capabilities,
+		Domain:       kurelDomain,
 	}
 
 	cluster, err := transformer.Transform(app, ctx)

--- a/pkg/cmd/kurel/build_test.go
+++ b/pkg/cmd/kurel/build_test.go
@@ -290,6 +290,44 @@ func TestBuildCommand_NamespaceOverride(t *testing.T) {
 	}
 }
 
+// kurel resolves the tier annotation under the launcher.gokure.dev domain (not the library
+// default gokure.dev). A component annotated launcher.gokure.dev/tier with an invalid value
+// must therefore fail the build — proving Domain is wired to kurelDomain. With the default
+// domain, that annotation would be ignored and the build would succeed.
+func TestBuildCommand_KurelDomain_TierAnnotationHonored(t *testing.T) {
+	const appYAML = `apiVersion: launcher.gokure.dev/v1alpha1
+kind: Application
+metadata:
+  name: my-app
+  namespace: default
+spec:
+  components:
+    - name: frontend
+      type: webservice
+      annotations:
+        launcher.gokure.dev/tier: not-a-valid-tier
+      properties:
+        image: ghcr.io/example/frontend:v1.0.0
+        port: 8080
+`
+	dir := t.TempDir()
+	appPath := writeTempFile(t, dir, "app.yaml", appYAML)
+	profilePath := writeTempFile(t, dir, "cluster.yaml", testClusterYAML)
+
+	cmd := NewKurelCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"build", appPath, "--profile", profilePath})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatalf("expected invalid-tier error (proving kurel reads launcher.gokure.dev/tier), got nil\noutput: %s", out.String())
+	}
+	if !strings.Contains(err.Error(), "tier") {
+		t.Errorf("expected a tier-related error, got: %v", err)
+	}
+}
+
 func TestBuildCommand_StaleProfileField_Rejected(t *testing.T) {
 	const staleCraneProfile = `apiVersion: launcher.gokure.dev/v1alpha1
 kind: ClusterProfile

--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -40,14 +40,16 @@ in two directions, each a **separate** additive resource (the authored
   caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op.
 
 Both families select the component's own pods (the ingress recipients / the egress
-source pods) via the **`wharf.zone/component`** label by default, overridable per <!-- allow-term:wharf tracked by #215 -->
-transform through `TransformContext.ComponentLabelKey`. This is a **platform contract**:
-`trafficSources` (inbound) and `EgressPeers` (egress) are platform inputs, so a caller
-that injects them must ensure its pods carry that label — the downstream runtime stamps
-`wharf.zone/component` on every downstream-rendered workload and helm-rendered pod — or set <!-- allow-term:wharf tracked by #215 -->
-`ComponentLabelKey` to a label its pods do carry (e.g. `"app"`). A non-downstream caller that
-injects `trafficSources`/`EgressPeers` without either will synthesize a policy that
-selects nothing.
+source pods) via a **derived `<domain>/component`** label by default — the domain comes
+from `TransformContext.Domain` (empty ⇒ the library default `gokure.dev`; the kurel CLI
+uses `launcher.gokure.dev`). The full key is overridable per transform through
+`TransformContext.ComponentLabelKey` (precedence: `ComponentLabelKey` > `<Domain>/component`
+> `gokure.dev/component`). This is a **platform contract**: `trafficSources` (inbound) and
+`EgressPeers` (egress) are platform inputs, so a caller that injects them must ensure its
+pods carry the derived label — a downstream platform sets its own `Domain` and stamps the
+matching `<domain>/component` on every rendered workload and helm-rendered pod — or set
+`ComponentLabelKey` to a label its pods do carry (e.g. `"app"`). A caller that injects
+`trafficSources`/`EgressPeers` without either will synthesize a policy that selects nothing.
 
 ## Parsing
 

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -122,12 +122,13 @@ for the interfaces, and `examples/` for runnable applications.
 Every trait sub-app config exposes the OAM component it was emitted for via
 `ComponentName() string` (the `oam.ComponentNamed` interface) — always the component
 name, never the sub-app or K8s Service name. Consumers use it to stamp per-resource
-provenance (the `wharf.zone/component` label) without re-deriving the component <!-- allow-term:wharf tracked by #215 -->
+provenance (the derived `<domain>/component` label) without re-deriving the component
 from sub-app names, which several handlers author from properties rather than
 `<component>-<suffix>`. The routing traits' existing `TargetComponentName()` (used by
 auto-NetworkPolicy synthesis) delegates to the same accessor; auto-synthesized
-NetworkPolicies target that `wharf.zone/component` label by default <!-- allow-term:wharf tracked by #215 -->
-(`TransformContext.ComponentLabelKey`-overridable).
+NetworkPolicies target that `<domain>/component` label by default (domain from
+`TransformContext.Domain`, library default `gokure.dev`;
+`TransformContext.ComponentLabelKey`-overridable).
 
 ## Conventions
 

--- a/pkg/oam/builtin/traits/domain_resolution_test.go
+++ b/pkg/oam/builtin/traits/domain_resolution_test.go
@@ -1,0 +1,114 @@
+package traits_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+	"github.com/go-kure/launcher/pkg/oam/builtin/traits"
+)
+
+// ingressTrafficSourcesApp builds a webservice + ingress trait carrying trafficSources,
+// which yields a synthesized {comp}-allow-ingress-traffic policy after transform.
+func ingressTrafficSourcesApp() *oam.Application {
+	return &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "web",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules": []any{map[string]any{
+							"host":  "example.com",
+							"paths": []any{map[string]any{"path": "/"}},
+						}},
+						"networkPolicy": map[string]any{
+							"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}},
+						},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+func domainTestTransformer() *oam.Transformer {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+	return tr
+}
+
+// TransformContext.Domain drives the synthesized podSelector key: <domain>/component.
+func TestTransform_Domain_DrivesIngressSelector(t *testing.T) {
+	tr := domainTestTransformer()
+	cluster, _, err := tr.TransformWithPolicy(ingressTrafficSourcesApp(),
+		oam.TransformContext{Namespace: "default", Domain: "example.com"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic")
+	if sel["example.com/component"] != "web" {
+		t.Errorf("podSelector = %v, want example.com/component=web", sel)
+	}
+	if len(sel) != 1 {
+		t.Errorf("podSelector should have exactly one key, got %v", sel)
+	}
+}
+
+// Empty Domain resolves to the library default gokure.dev.
+func TestTransform_DefaultDomain_IngressSelector(t *testing.T) {
+	tr := domainTestTransformer()
+	cluster, _, err := tr.TransformWithPolicy(ingressTrafficSourcesApp(),
+		oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic")
+	if sel["gokure.dev/component"] != "web" {
+		t.Errorf("podSelector = %v, want gokure.dev/component=web", sel)
+	}
+}
+
+// ComponentLabelKey (full-key override) wins over Domain.
+func TestTransform_ComponentLabelKey_WinsOverDomain(t *testing.T) {
+	tr := domainTestTransformer()
+	cluster, _, err := tr.TransformWithPolicy(ingressTrafficSourcesApp(),
+		oam.TransformContext{Namespace: "default", Domain: "example.com", ComponentLabelKey: "app"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic")
+	if sel["app"] != "web" {
+		t.Errorf("podSelector = %v, want app=web (ComponentLabelKey wins)", sel)
+	}
+	if _, hasDomain := sel["example.com/component"]; hasDomain {
+		t.Errorf("podSelector should not carry the domain key when ComponentLabelKey is set: %v", sel)
+	}
+}
+
+func TestTransform_InvalidDomain_Errors(t *testing.T) {
+	tr := domainTestTransformer()
+	for _, bad := range []string{"https://example.com", "example.com/", "Example.com"} {
+		_, _, err := tr.TransformWithPolicy(ingressTrafficSourcesApp(),
+			oam.TransformContext{Namespace: "default", Domain: bad})
+		if err == nil {
+			t.Errorf("expected error for invalid Domain %q, got nil", bad)
+		}
+	}
+}
+
+func TestTransform_InvalidComponentLabelKey_Errors(t *testing.T) {
+	tr := domainTestTransformer()
+	for _, bad := range []string{"/component", "example.com/", "Upper/Name", "example.com/" + strings.Repeat("a", 64)} {
+		_, _, err := tr.TransformWithPolicy(ingressTrafficSourcesApp(),
+			oam.TransformContext{Namespace: "default", ComponentLabelKey: bad})
+		if err == nil {
+			t.Errorf("expected error for invalid ComponentLabelKey %q, got nil", bad)
+		}
+	}
+}

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -921,7 +921,7 @@ func (c *HTTPRouteConfig) ComponentName() string { return c.componentName }
 
 // TargetComponentName returns the OAM component label (not the K8s Service name), so the
 // synthesized NetworkPolicy selects the component's pods via the configured component
-// label key (default {wharf.zone/component: <name>}).  allow-term:wharf tracked by #215
+// label key (default {<domain>/component: <name>}, domain from TransformContext.Domain).
 func (c *HTTPRouteConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -370,7 +370,7 @@ func (c *IngressConfig) ComponentName() string { return c.componentName }
 
 // TargetComponentName returns the OAM component label (not the K8s Service name), so the
 // synthesized NetworkPolicy selects the component's pods via the configured component
-// label key (default {wharf.zone/component: <name>}).  allow-term:wharf tracked by #215
+// label key (default {<domain>/component: <name>}, domain from TransformContext.Domain).
 func (c *IngressConfig) TargetComponentName() string { return c.ComponentName() }
 
 // BackendPorts implements the cluster-level trafficSourceCollector contract.

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -99,7 +99,7 @@ func TestIngressHandler_TrafficSources_MalformedErrors(t *testing.T) {
 // TargetComponentName must be the OAM component label, never the (possibly
 // overridden) K8s Service name, so the synthesized NetworkPolicy selects the
 // component's pods via the configured component label key (default
-// {wharf.zone/component: <component>}).  allow-term:wharf tracked by #215
+// {gokure.dev/component: <component>}).
 func TestIngressConfig_TargetComponentName_IsComponentNotService(t *testing.T) {
 	app := stack.NewApplication("web", "default", &namedWebConfig{port: 80, serviceName: "web-headless"})
 	trait := ingressTrafficSourcesTrait(map[string]any{
@@ -188,9 +188,9 @@ func TestTransform_IngressTrafficSources_SynthesizesNetworkPolicy(t *testing.T) 
 	if !clusterHasApp(cluster, "web-allow-ingress-traffic") {
 		t.Errorf("expected synthesized app \"web-allow-ingress-traffic\"; cluster apps: %v", clusterAppNames(cluster))
 	}
-	// Default target selector is wharf.zone/component (the downstream runtime stamps it on every pod).  allow-term:wharf tracked by #215
-	if sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic"); sel["wharf.zone/component"] != "web" { // allow-term:wharf tracked by #215
-		t.Errorf("default ingress podSelector = %v, want wharf.zone/component=web", sel) // allow-term:wharf tracked by #215
+	// Default target selector is gokure.dev/component (the downstream runtime stamps it on every pod).
+	if sel := synthesizedPodSelector(t, cluster, "web-allow-ingress-traffic"); sel["gokure.dev/component"] != "web" {
+		t.Errorf("default ingress podSelector = %v, want gokure.dev/component=web", sel)
 	}
 }
 
@@ -314,9 +314,9 @@ func TestTransform_EgressPeers_SynthesizesEgressNetworkPolicy(t *testing.T) {
 	if clusterHasApp(cluster, "web-allow-ingress-traffic") {
 		t.Errorf("did not expect inbound synthesis without trafficSources; cluster apps: %v", clusterAppNames(cluster))
 	}
-	// Default egress source-pod selector is wharf.zone/component.  allow-term:wharf tracked by #215
-	if sel := synthesizedPodSelector(t, cluster, "web-allow-egress-traffic"); sel["wharf.zone/component"] != "web" { // allow-term:wharf tracked by #215
-		t.Errorf("default egress podSelector = %v, want wharf.zone/component=web", sel) // allow-term:wharf tracked by #215
+	// Default egress source-pod selector is gokure.dev/component.
+	if sel := synthesizedPodSelector(t, cluster, "web-allow-egress-traffic"); sel["gokure.dev/component"] != "web" {
+		t.Errorf("default egress podSelector = %v, want gokure.dev/component=web", sel)
 	}
 }
 
@@ -379,7 +379,7 @@ func TestTransform_ComponentLabelKey_Override(t *testing.T) {
 				if sel[tc.wantKey] != "web" {
 					t.Errorf("%s podSelector = %v, want %s=web", npName, sel, tc.wantKey)
 				}
-				if _, hasDefault := sel["wharf.zone/component"]; hasDefault && tc.wantKey != "wharf.zone/component" { // allow-term:wharf tracked by #215
+				if _, hasDefault := sel["gokure.dev/component"]; hasDefault && tc.wantKey != "gokure.dev/component" {
 					t.Errorf("%s podSelector should not carry default key when overridden: %v", npName, sel)
 				}
 			}

--- a/pkg/oam/classify.go
+++ b/pkg/oam/classify.go
@@ -1,17 +1,47 @@
 package oam
 
-import "fmt"
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+
+	"github.com/go-kure/launcher/pkg/errors"
+)
+
+// DefaultDomain is the library default domain for derived platform keys. Callers
+// embedding launcher (e.g. a downstream platform) override it via TransformContext.Domain.
+const DefaultDomain = "gokure.dev"
 
 // TierAnnotation is the OAM component annotation key for overriding the default tier.
-// allow-term:wharf tracked by #215 (domain becomes a parameter; this literal is interim).
-const TierAnnotation = "wharf.zone/tier"
+//
+// Deprecated: use TierAnnotationKey(domain). Retained for source compatibility; this is
+// the library default key (== TierAnnotationKey(DefaultDomain)).
+const TierAnnotation = "gokure.dev/tier"
 
-// ComponentLabel is the pod label key the downstream runtime stamps on every rendered
-// workload pod and helm-rendered pod (webservice via its mutator, helm-rendered pods via a
-// mandatory post-renderer). Synthesized NetworkPolicies target it by default so a single
-// deterministic selector covers both builtin and helm-backed component pods.
-// allow-term:wharf tracked by #215 (domain becomes a parameter; this literal is interim).
-const ComponentLabel = "wharf.zone/component"
+// ComponentLabel is the default pod-selector key synthesized NetworkPolicies target.
+//
+// Deprecated: use ComponentLabelKeyForDomain(domain). The library default key
+// (== ComponentLabelKeyForDomain(DefaultDomain)).
+const ComponentLabel = "gokure.dev/component"
+
+// domainOrDefault returns domain, or DefaultDomain when empty.
+func domainOrDefault(domain string) string {
+	if domain == "" {
+		return DefaultDomain
+	}
+	return domain
+}
+
+// TierAnnotationKey returns the "<domain>/tier" annotation key; empty domain uses
+// DefaultDomain. Pure derivation with no validation — the transform/classification paths
+// validate the domain.
+func TierAnnotationKey(domain string) string { return domainOrDefault(domain) + "/tier" }
+
+// ComponentLabelKeyForDomain returns the "<domain>/component" label key; empty domain uses
+// DefaultDomain. Pure derivation with no validation.
+func ComponentLabelKeyForDomain(domain string) string {
+	return domainOrDefault(domain) + "/component"
+}
 
 // defaultTierMap maps OAM component types to their deployment tier.
 var defaultTierMap = map[string]Tier{
@@ -34,13 +64,29 @@ var validTiers = map[Tier]bool{
 	TierApps:     true,
 }
 
-// ClassifyComponent returns the deployment tier for the given component.
-// It checks the TierAnnotation first, then the defaultTierMap, and falls back to TierApps.
+// ClassifyComponent returns the deployment tier for the given component, using the
+// library default domain (DefaultDomain) for the tier annotation key.
 func ClassifyComponent(c *Component) (Tier, error) {
-	if v, ok := c.Annotations[TierAnnotation]; ok {
+	return ClassifyComponentWithDomain(c, DefaultDomain)
+}
+
+// ClassifyComponentWithDomain returns the deployment tier for the given component, reading
+// the "<domain>/tier" override annotation. It checks that annotation first, then the
+// defaultTierMap, and falls back to TierApps. A nil component is an error; an empty domain
+// uses DefaultDomain; an invalid domain is an error (validated here independently, since
+// this is an exported helper callable outside the transform pipeline).
+func ClassifyComponentWithDomain(c *Component, domain string) (Tier, error) {
+	if c == nil {
+		return "", errors.New("nil component")
+	}
+	domain = domainOrDefault(domain)
+	if errs := validation.IsDNS1123Subdomain(domain); len(errs) > 0 {
+		return "", errors.Errorf("invalid domain %q: %s", domain, strings.Join(errs, "; "))
+	}
+	if v, ok := c.Annotations[TierAnnotationKey(domain)]; ok {
 		tier := Tier(v)
 		if !validTiers[tier] {
-			return "", fmt.Errorf("invalid tier annotation %q on component %q: must be one of infra, services, apps", v, c.Name)
+			return "", errors.Errorf("invalid tier annotation %q on component %q: must be one of infra, services, apps", v, c.Name)
 		}
 		return tier, nil
 	}

--- a/pkg/oam/classify_domain_test.go
+++ b/pkg/oam/classify_domain_test.go
@@ -1,0 +1,110 @@
+package oam
+
+import "testing"
+
+func TestDefaultDomain(t *testing.T) {
+	if DefaultDomain != "gokure.dev" {
+		t.Errorf("DefaultDomain = %q, want gokure.dev", DefaultDomain)
+	}
+}
+
+func TestTierAnnotationKey(t *testing.T) {
+	cases := []struct {
+		domain string
+		want   string
+	}{
+		{"", "gokure.dev/tier"},
+		{"example.com", "example.com/tier"},
+		{"launcher.gokure.dev", "launcher.gokure.dev/tier"},
+	}
+	for _, tc := range cases {
+		if got := TierAnnotationKey(tc.domain); got != tc.want {
+			t.Errorf("TierAnnotationKey(%q) = %q, want %q", tc.domain, got, tc.want)
+		}
+	}
+}
+
+func TestComponentLabelKeyForDomain(t *testing.T) {
+	cases := []struct {
+		domain string
+		want   string
+	}{
+		{"", "gokure.dev/component"},
+		{"example.com", "example.com/component"},
+		{"launcher.gokure.dev", "launcher.gokure.dev/component"},
+	}
+	for _, tc := range cases {
+		if got := ComponentLabelKeyForDomain(tc.domain); got != tc.want {
+			t.Errorf("ComponentLabelKeyForDomain(%q) = %q, want %q", tc.domain, got, tc.want)
+		}
+	}
+}
+
+func TestDeprecatedAliasesUseDefaultDomain(t *testing.T) {
+	if TierAnnotation != "gokure.dev/tier" {
+		t.Errorf("TierAnnotation = %q, want gokure.dev/tier", TierAnnotation)
+	}
+	if ComponentLabel != "gokure.dev/component" {
+		t.Errorf("ComponentLabel = %q, want gokure.dev/component", ComponentLabel)
+	}
+}
+
+// The deprecated aliases + ClassifyComponent must stay exported for source compatibility.
+func TestDeprecatedSymbols_Compile(t *testing.T) {
+	_ = TierAnnotation
+	_ = ComponentLabel
+	_ = ClassifyComponent
+}
+
+func TestClassifyComponentWithDomain_NilComponent(t *testing.T) {
+	if _, err := ClassifyComponentWithDomain(nil, "example.com"); err == nil {
+		t.Error("expected error for nil component, got nil")
+	}
+}
+
+func TestClassifyComponentWithDomain_CustomDomain(t *testing.T) {
+	c := &Component{
+		Name:        "cache",
+		Type:        "unknown",
+		Annotations: map[string]string{"example.com/tier": "infra"},
+	}
+	tier, err := ClassifyComponentWithDomain(c, "example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != TierInfra {
+		t.Errorf("got %q, want %q", tier, TierInfra)
+	}
+	// The default-domain annotation key must NOT be read under a custom domain.
+	tierDefault, err := ClassifyComponentWithDomain(c, DefaultDomain)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tierDefault != TierApps { // unknown type falls back to apps; example.com/tier ignored
+		t.Errorf("default-domain classify read the custom-domain annotation: got %q, want apps", tierDefault)
+	}
+}
+
+func TestClassifyComponentWithDomain_EmptyDomainUsesDefault(t *testing.T) {
+	c := &Component{
+		Name:        "cache",
+		Type:        "unknown",
+		Annotations: map[string]string{"gokure.dev/tier": "services"},
+	}
+	tier, err := ClassifyComponentWithDomain(c, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != TierServices {
+		t.Errorf("got %q, want %q", tier, TierServices)
+	}
+}
+
+func TestClassifyComponentWithDomain_InvalidDomain(t *testing.T) {
+	c := &Component{Name: "cache", Type: "webservice"}
+	for _, bad := range []string{"https://example.com", "example.com/", "Example.com", "a..b"} {
+		if _, err := ClassifyComponentWithDomain(c, bad); err == nil {
+			t.Errorf("expected error for invalid domain %q, got nil", bad)
+		}
+	}
+}

--- a/pkg/oam/netpol_egress_synthesis_test.go
+++ b/pkg/oam/netpol_egress_synthesis_test.go
@@ -110,8 +110,8 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 	if np.Labels != nil || np.Annotations != nil {
 		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
 	}
-	if got := np.Spec.PodSelector.MatchLabels["wharf.zone/component"]; got != "web" { // allow-term:wharf tracked by #215
-		t.Errorf("podSelector wharf.zone/component = %q, want web", got) // allow-term:wharf tracked by #215
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "web" {
+		t.Errorf("podSelector gokure.dev/component = %q, want web", got)
 	}
 	if _, hasApp := np.Spec.PodSelector.MatchLabels["app"]; hasApp {
 		t.Errorf("podSelector should not carry legacy app key: %v", np.Spec.PodSelector.MatchLabels)
@@ -157,7 +157,7 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 }
 
 // TestComponentEgressPolicyConfig_PodSelectorKey verifies the top-level podSelector key
-// (the egress source pods): empty defaults to wharf.zone/component, and a non-empty  allow-term:wharf tracked by #215
+// (the egress source pods): empty defaults to gokure.dev/component, and a non-empty
 // PodSelectorKey wins (e.g. a non-downstream caller opting back to "app").
 func TestComponentEgressPolicyConfig_PodSelectorKey(t *testing.T) {
 	cases := []struct {
@@ -165,7 +165,7 @@ func TestComponentEgressPolicyConfig_PodSelectorKey(t *testing.T) {
 		key     string
 		wantKey string
 	}{
-		{"default", "", "wharf.zone/component"}, // allow-term:wharf tracked by #215
+		{"default", "", "gokure.dev/component"},
 		{"override_app", "app", "app"},
 		{"override_custom", "example.com/name", "example.com/name"},
 	}

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -38,15 +38,17 @@ type componentAllowPolicyConfig struct {
 	ComponentName string
 	Rules         []trafficRule // one per collector with non-empty ports; deduplicated
 	// PodSelectorKey is the label key selecting the component's own pods (the ingress
-	// recipients). Empty => ComponentLabel ("wharf.zone/component").  allow-term:wharf tracked by #215
+	// recipients). Empty => the library default key (ComponentLabelKeyForDomain(DefaultDomain)).
+	// The transform path always passes the resolved, domain-aware key; the default here only
+	// applies to directly-constructed configs (tests), which cannot know the transform domain.
 	PodSelectorKey string
 }
 
-// podSelectorKey returns the configured selector key, defaulting to ComponentLabel so a
+// podSelectorKey returns the configured selector key, defaulting to the library default so a
 // directly-built config never emits an empty-key selector.
 func (c *componentAllowPolicyConfig) podSelectorKey() string {
 	if c.PodSelectorKey == "" {
-		return ComponentLabel
+		return ComponentLabelKeyForDomain(DefaultDomain)
 	}
 	return c.PodSelectorKey
 }
@@ -215,15 +217,17 @@ type componentEgressPolicyConfig struct {
 	ComponentName string
 	Peers         []netpol.EgressPeer
 	// PodSelectorKey is the label key selecting the component's own pods (the egress
-	// source pods this policy allows out). Empty => ComponentLabel ("wharf.zone/component").  allow-term:wharf tracked by #215
+	// source pods this policy allows out). Empty => the library default key
+	// (ComponentLabelKeyForDomain(DefaultDomain)); the transform path always passes the
+	// resolved, domain-aware key, so this default only applies to directly-built configs.
 	PodSelectorKey string
 }
 
-// podSelectorKey returns the configured selector key, defaulting to ComponentLabel so a
+// podSelectorKey returns the configured selector key, defaulting to the library default so a
 // directly-built config never emits an empty-key selector.
 func (c *componentEgressPolicyConfig) podSelectorKey() string {
 	if c.PodSelectorKey == "" {
-		return ComponentLabel
+		return ComponentLabelKeyForDomain(DefaultDomain)
 	}
 	return c.PodSelectorKey
 }

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -199,8 +199,8 @@ func TestComponentAllowPolicyConfig_Generate(t *testing.T) {
 	if np.Labels != nil || np.Annotations != nil {
 		t.Errorf("expected nil Labels/Annotations, got labels=%v annotations=%v", np.Labels, np.Annotations)
 	}
-	if got := np.Spec.PodSelector.MatchLabels["wharf.zone/component"]; got != "web" { // allow-term:wharf tracked by #215
-		t.Errorf("podSelector wharf.zone/component = %q, want web", got) // allow-term:wharf tracked by #215
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "web" {
+		t.Errorf("podSelector gokure.dev/component = %q, want web", got)
 	}
 	if _, hasApp := np.Spec.PodSelector.MatchLabels["app"]; hasApp {
 		t.Errorf("podSelector should not carry legacy app key: %v", np.Spec.PodSelector.MatchLabels)
@@ -224,7 +224,7 @@ func TestComponentAllowPolicyConfig_Generate(t *testing.T) {
 }
 
 // TestComponentAllowPolicyConfig_PodSelectorKey verifies the top-level podSelector key:
-// empty defaults to wharf.zone/component, and a non-empty PodSelectorKey wins (e.g. a  allow-term:wharf tracked by #215
+// empty defaults to gokure.dev/component, and a non-empty PodSelectorKey wins (e.g. a
 // non-downstream caller opting back to "app").
 func TestComponentAllowPolicyConfig_PodSelectorKey(t *testing.T) {
 	cases := []struct {
@@ -232,7 +232,7 @@ func TestComponentAllowPolicyConfig_PodSelectorKey(t *testing.T) {
 		key     string
 		wantKey string
 	}{
-		{"default", "", "wharf.zone/component"}, // allow-term:wharf tracked by #215
+		{"default", "", "gokure.dev/component"},
 		{"override_app", "app", "app"},
 		{"override_custom", "example.com/name", "example.com/name"},
 	}

--- a/pkg/oam/parser_test.go
+++ b/pkg/oam/parser_test.go
@@ -747,7 +747,7 @@ spec:
     properties:
       chart: cert-manager
     annotations:
-      wharf.zone/tier: infra # allow-term:wharf tracked by #215
+      gokure.dev/tier: infra
 `
 	app, err := Parse([]byte(input))
 	if err != nil {
@@ -758,7 +758,7 @@ spec:
 	if comp.Annotations == nil {
 		t.Fatal("expected non-nil Annotations")
 	}
-	if got := comp.Annotations["wharf.zone/tier"]; got != "infra" { // allow-term:wharf tracked by #215
-		t.Errorf("annotations[wharf.zone/tier] = %q, want %q", got, "infra")
+	if got := comp.Annotations["gokure.dev/tier"]; got != "infra" {
+		t.Errorf("annotations[gokure.dev/tier] = %q, want %q", got, "infra")
 	}
 }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -8,7 +8,9 @@ import (
 	"strings"
 
 	"github.com/go-kure/kure/pkg/stack"
+	"k8s.io/apimachinery/pkg/util/validation"
 
+	"github.com/go-kure/launcher/pkg/errors"
 	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
 
@@ -37,11 +39,17 @@ type TransformContext struct {
 	EgressPeers map[string][]netpol.EgressPeer
 	// ComponentLabelKey overrides the pod-label key that synthesized NetworkPolicies
 	// target (the component's own pods: ingress recipients / egress sources). Empty
-	// => ComponentLabel ("wharf.zone/component"). Non-authorable platform input, like  allow-term:wharf tracked by #215
-	// EgressPeers: a caller that injects trafficSources/EgressPeers must ensure its
-	// pods carry this label (the downstream runtime stamps wharf.zone/component) or set this to a key  allow-term:wharf tracked by #215
-	// its pods do carry (e.g. "app").
+	// => the domain-derived key ComponentLabelKeyForDomain(Domain). Takes precedence over
+	// Domain. Validated as a Kubernetes qualified label key. Non-authorable platform input,
+	// like EgressPeers: a caller that injects trafficSources/EgressPeers must ensure its
+	// pods carry this label (the platform stamps the derived component label) or set this
+	// to a key its pods do carry (e.g. "app").
 	ComponentLabelKey string
+	// Domain is the label/annotation domain for derived platform keys (<domain>/tier,
+	// <domain>/component). Empty => DefaultDomain ("gokure.dev"). Non-authorable platform
+	// input; a downstream platform embedding launcher sets its own domain. Validated as a
+	// DNS-1123 subdomain — an invalid value fails the transform.
+	Domain string
 }
 
 // fluxNamespaceSettable is implemented by ApplicationConfig types that emit
@@ -297,6 +305,20 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 		ctx.Policy = &NoopPolicy{}
 	}
 
+	// Validate + normalize the platform domain (and the optional full-key override) once,
+	// fail-fast before building anything. ComponentLabelKey takes precedence over Domain,
+	// so it is validated here too — a behavioral tightening (previously any string was
+	// accepted). ctx is a value copy, so normalizing ctx.Domain here is local to this call.
+	ctx.Domain = domainOrDefault(ctx.Domain)
+	if errs := validation.IsDNS1123Subdomain(ctx.Domain); len(errs) > 0 {
+		return nil, nil, errors.Errorf("invalid TransformContext.Domain %q: %s", ctx.Domain, strings.Join(errs, "; "))
+	}
+	if ctx.ComponentLabelKey != "" {
+		if errs := validation.IsQualifiedName(ctx.ComponentLabelKey); len(errs) > 0 {
+			return nil, nil, errors.Errorf("invalid TransformContext.ComponentLabelKey %q: %s", ctx.ComponentLabelKey, strings.Join(errs, "; "))
+		}
+	}
+
 	namespace := ctx.Namespace
 	if namespace == "" {
 		namespace = app.Metadata.Namespace
@@ -353,7 +375,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	applyReconciliationSettings(cluster, componentMap, policyResult.ReconciliationSettings)
 	labelKey := ctx.ComponentLabelKey
 	if labelKey == "" {
-		labelKey = ComponentLabel
+		labelKey = ComponentLabelKeyForDomain(ctx.Domain)
 	}
 	synthesizeNetworkPolicies(cluster, labelKey)
 	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey)
@@ -383,7 +405,9 @@ func (t *Transformer) createApplications(app *Application, namespace string, ctx
 			}
 		}
 
-		tier, err := ClassifyComponent(&component)
+		// ctx.Domain was validated + normalized at the top of TransformWithPolicy; the
+		// per-component re-validation inside ClassifyComponentWithDomain is idempotent.
+		tier, err := ClassifyComponentWithDomain(&component, ctx.Domain)
 		if err != nil {
 			return nil, &TransformError{Message: fmt.Sprintf("component %q", component.Name), Cause: err}
 		}


### PR DESCRIPTION
Closes #215. Removes the interim `allow-term:wharf` pragmas #216 left on the two live platform keys — #215 is the real, deferred behavioral change.

## What

Make the label/annotation domain a caller-supplied parameter instead of a hardcoded, downstream-specific string.

- `oam.DefaultDomain = "gokure.dev"` — library default.
- Pure derivation helpers `TierAnnotationKey(domain)` / `ComponentLabelKeyForDomain(domain)` (empty ⇒ `DefaultDomain`; no validation).
- **Deprecated, source-compatible aliases**: `TierAnnotation`, `ComponentLabel` — symbols kept, values now `gokure.dev/*`; `ClassifyComponent` preserved (delegates with `DefaultDomain`).
- `TransformContext.Domain` (empty ⇒ `DefaultDomain`), validated as a **DNS-1123 subdomain**; `Transform`/`TransformWithPolicy` fail fast on an invalid value. New exported `ClassifyComponentWithDomain(c, domain)` validates the domain itself and rejects a nil component.
- `ComponentLabelKey` is now validated as a **Kubernetes qualified label key** (a tightening — previously any string) and takes precedence over `Domain`: `ComponentLabelKey` > `<Domain>/component` > `gokure.dev/component`.
- **kurel CLI** stamps `Domain: "launcher.gokure.dev"` (sole `TransformContext` construction; no CLI flag — the library field is the override point).

## Compatibility / behavioral change

Source-compatible via the deprecated aliases; default **values** change from the previous downstream-specific domain to `gokure.dev/*` (kurel: `launcher.gokure.dev/*`) — an intentional alpha-series behavioral change (in the commit body for the release CHANGELOG). Embedders that stamped/consumed the previous keys must set `TransformContext.Domain` when they bump.

## Out of scope

- `SupportedAPIVersion = "launcher.gokure.dev/v1alpha1"` stays (GVK identity, not a label domain).
- Builtin components still do not self-stamp `<domain>/component` on their pods — the platform contract stands (a caller injecting `trafficSources`/`EgressPeers` must stamp the label or set `ComponentLabelKey`). Self-stamping is a possible follow-up.

## Tests (TDD)

- Domain derivation + resolution (empty ⇒ `gokure.dev/*`; custom domain via a neutral `example.com` fixture; `ComponentLabelKey` wins over `Domain`).
- Direct-config fallback ⇒ `gokure.dev/component`.
- Domain validation (reject scheme / trailing-slash / embedded-slash / invalid label) and `ComponentLabelKey` qualified-name validation; `ClassifyComponentWithDomain` nil-component + independent domain validation.
- kurel domain wiring: a `launcher.gokure.dev/tier` override with an invalid value fails the build (proves kurel reads that domain).
- Updated the prior `wharf.zone/component` selector assertions to the new default; deprecated-symbol compile lock.

## Verification

`mise run verify` (tidy + lint 0 issues + tests); `check-forbidden-terms.sh --full-tree` **and** `--diff origin/main` OK with **zero `allow-term` pragmas**; `check-doc-sync.sh`, `check-links.sh`, `check-doc-gate.sh origin/main .` OK.

## Coordination

- Follows #216 (scrub, merged) — this removes its interim pragmas.
- **Downstream adoption** (separate MR): bump launcher to the release carrying this and set `Domain` to the downstream domain in the same MR — a bump **without** setting `Domain` silently retargets tier reads + netpol selectors to `gokure.dev/*` (runtime break, not compile).
- Next release: alpha ≥ .18, so downstream consumers can pin it.

Refs #216.