### PR TITLE
feat(ci): guard against launcher leading kure on shared direct deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,6 +42,15 @@ updates:
       # Flux controllers move together per flux2 release — never bump piecemeal.
       # Grouped so a flux2 upgrade lands as one coordinated PR (also requires a matching
       # kure release first). See the flux2 upgrade tracking issue.
+      #
+      # Ceiling rule for ANY dependency shared with kure (cert-manager, fluxcd/*,
+      # cloudnative-pg, external-secrets/apis, gateway-api, ...): launcher must not lead
+      # the kure release it imports on a shared DIRECT dependency. MVS pulls launcher up to
+      # kure's version automatically, so only the "ahead" direction needs coordination.
+      # Correct sequence: land the matching kure bump → cut a kure release → bump launcher's
+      # go-kure/kure require to it and take the shared-dep bump together. CI enforces this
+      # (diff-scoped, grandfathering existing drift) via site/scripts/check-kure-dep-sync.sh;
+      # see AGENTS.md § "Shared dependencies with kure".
       flux:
         patterns:
           - "github.com/fluxcd/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,8 @@ jobs:
             - 'go.sum'
             - 'Makefile'
             - '.github/workflows/**'
+            - 'site/scripts/check-kure-dep-sync.sh'
+            - 'site/scripts/kuredepsync/**'
           docs:
             - 'site/**'
             - 'docs/**'
@@ -156,6 +158,31 @@ jobs:
 
     - name: Run go vet
       run: make vet
+
+    - name: Check kuredepsync helper module
+      run: |
+        cd site/scripts/kuredepsync
+        GOWORK=off go mod tidy
+        if [ -n "$(git status --porcelain go.mod go.sum)" ]; then
+          echo "::error::kuredepsync go.mod/go.sum not tidy. Run 'go mod tidy' in site/scripts/kuredepsync."
+          git diff go.mod go.sum
+          exit 1
+        fi
+        GOWORK=off go vet ./...
+        GOWORK=off go test ./...
+
+    # Blocking on PR / merge-queue: fail only when the change newly leads imported kure
+    # on a shared direct dep. The script fetches its own base ref.
+    - name: Check launcher not newly ahead of imported kure
+      if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+      env:
+        BASE_REF: ${{ github.base_ref || 'main' }}
+      run: bash site/scripts/check-kure-dep-sync.sh --base "origin/${BASE_REF}"
+
+    # Visibility only on push / schedule (base merge-base can equal HEAD → no-op diff).
+    - name: Report launcher-kure shared-dep lead
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      run: bash site/scripts/check-kure-dep-sync.sh --report
 
     - name: Fetch base branch for diff-based lint
       if: github.event_name == 'pull_request'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,6 +242,31 @@ standard (`go-kure/.github` → `docs/standards.md`), CI-enforced here by
 legitimately unavoidable term takes an adjacent `allow-term:<word>` pragma. The remediation
 runbook is `go-kure/.github` → `docs/no-downstream-references.md`.
 
+### Shared dependencies with kure (mandatory)
+
+Launcher imports `github.com/go-kure/kure` and shares several third-party dependencies with
+it (cert-manager, fluxcd controller APIs, cloudnative-pg, external-secrets/apis, gateway-api,
+…) that launcher's own code also imports directly.
+
+**Why it matters.** Go's Minimum Version Selection makes launcher's effective version of a
+shared dep `max(launcher require, kure require)`. Launcher can therefore never fall *below*
+the kure it imports (MVS pulls it up), so the only manageable direction is launcher racing
+*ahead* — compiling kure's own code against a dependency version kure never released against.
+
+**The rule.** Launcher must not *newly* lead the kure release it imports on a shared **direct**
+dependency. Only deps that are direct requires of **both** go.mods are in scope; deps unique
+to either repo, and indirect deps (MVS-governed — they float to the max across launcher's whole
+graph), are unconstrained. Existing drift is grandfathered.
+
+**How it's enforced.** `site/scripts/check-kure-dep-sync.sh` (Go helper in
+`site/scripts/kuredepsync/`) runs in CI's `validate` job: diff-scoped and blocking on PRs /
+merge-queue (fails only when a change introduces or increases the lead), `--report`-only on
+push/schedule. Also wired into `make check` / `make precommit`.
+
+**Exception path.** Never lead unilaterally. To adopt a newer shared dep: land the matching
+kure bump → cut a kure release → bump launcher's `go-kure/kure` require to it and take the
+shared-dep bump together (yields no lead → guard passes).
+
 ### Reverse Mapping: Code to Docs
 
 This table is generated from `site/docs-map.yaml`. Do not edit it by hand — edit the

--- a/Makefile
+++ b/Makefile
@@ -329,14 +329,19 @@ dev: tools ## Set up development environment (mise, deps, git hooks)
 # CI/CD
 # =============================================================================
 
+.PHONY: check-kure-dep-sync
+check-kure-dep-sync: ## Guard: launcher must not newly lead imported kure on shared direct deps
+	cd site/scripts/kuredepsync && GOWORK=off go mod tidy && git diff --exit-code go.mod go.sum && GOWORK=off go vet ./... && GOWORK=off go test ./...
+	bash site/scripts/check-kure-dep-sync.sh --base origin/main
+
 .PHONY: check
-check: lint vet test-short ## Quick code quality check (lint, vet, short tests)
+check: lint vet test-short check-kure-dep-sync ## Quick code quality check (lint, vet, short tests, kure dep sync)
 
 .PHONY: precommit
-precommit: fmt tidy lint test ## Run fast pre-commit checks (fmt, tidy, lint, test)
+precommit: fmt tidy lint test check-kure-dep-sync ## Run fast pre-commit checks (fmt, tidy, lint, test, kure dep sync)
 
 .PHONY: ci
-ci: deps fmt tidy lint vet test test-race test-coverage test-integration build vuln ## Run comprehensive CI pipeline
+ci: deps fmt tidy lint vet test test-race test-coverage test-integration build vuln check-kure-dep-sync ## Run comprehensive CI pipeline
 
 # =============================================================================
 # Cleanup

--- a/mise.toml
+++ b/mise.toml
@@ -36,9 +36,13 @@ run = "make tidy"
 description = "Quick pre-commit check"
 run = "make check"
 
+[tasks.check-kure-dep-sync]
+description = "Guard: launcher must not newly lead imported kure on shared direct deps"
+run = "make check-kure-dep-sync"
+
 [tasks.verify]
-description = "Run all checks (tidy, lint, test)"
-depends = ["tidy", "lint", "test"]
+description = "Run all checks (tidy, lint, test, kure dep sync)"
+depends = ["tidy", "lint", "test", "check-kure-dep-sync"]
 
 [tasks.changelog]
 description = "Generate changelog from git history"

--- a/site/scripts/check-kure-dep-sync.sh
+++ b/site/scripts/check-kure-dep-sync.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-kure-dep-sync.sh — Guards launcher against leading the kure release it
+# imports on a shared DIRECT dependency.
+#
+# Go's Minimum Version Selection makes launcher's effective version of a shared dep
+# max(launcher, kure), so launcher can never fall *below* the kure it imports — only
+# race *ahead*, compiling kure's own code against a dependency version kure never
+# released against. This guard flags only that "ahead" direction, and only for deps
+# that are DIRECT requires of both launcher and the imported kure. Indirect deps are
+# MVS-governed (they float to the max across launcher's whole graph) and are out of
+# scope. See AGENTS.md § "Shared dependencies with kure".
+#
+# Modes:
+#   --base <ref>   Diff-scoped enforcement. Compares HEAD go.mod against <ref>'s and
+#                  fails only when a PR *introduces or increases* launcher's lead over
+#                  the imported kure. Existing drift is grandfathered. Used by PR CI,
+#                  merge-queue, and local make check/precommit.
+#   --report       Whole-tree visibility. Lists current shared-direct lead, never
+#                  fails. Used by push/schedule CI and for local inspection.
+#
+# The script is self-contained: it fetches the base ref itself so a workflow reorder
+# can't move it ahead of an external fetch step and silently break it.
+#
+# Usage: check-kure-dep-sync.sh --base origin/main
+#        check-kure-dep-sync.sh --report
+
+set -euo pipefail
+
+export GOWORK=off  # workspace go.work must not perturb module resolution
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+HELPER_DIR="$REPO_ROOT/site/scripts/kuredepsync"
+KURE_MODULE="github.com/go-kure/kure"
+
+MODE=""
+BASE=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base) MODE="base"; BASE="${2:-}"; [[ -n "$BASE" ]] || { echo "ERROR: --base needs a ref" >&2; exit 2; }; shift 2 ;;
+    --report) MODE="report"; shift ;;
+    -h|--help) sed -n '2,29p' "$0"; exit 0 ;;
+    *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+[[ -n "$MODE" ]] || { echo "usage: $0 --base <ref> | --report" >&2; exit 2; }
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# kure_version_of <go.mod path> — extract the imported kure module version. Matches
+# both block (`\t<mod> <ver>`) and single-line (`require <mod> <ver>`) require forms.
+kure_version_of() {
+  local gomod="$1" ver
+  ver="$(awk -v m="$KURE_MODULE" '{for(i=1;i<=NF;i++) if($i==m){print $(i+1); exit}}' "$gomod")"
+  [[ -n "$ver" ]] || { echo "ERROR: $KURE_MODULE not found in $gomod" >&2; exit 2; }
+  printf '%s' "$ver"
+}
+
+# kure_gomod_for <version> — download that kure release and echo its go.mod path.
+kure_gomod_for() {
+  local ver="$1" path
+  GOWORK=off go mod download "$KURE_MODULE@$ver" \
+    || { echo "ERROR: go mod download $KURE_MODULE@$ver failed" >&2; exit 2; }
+  path="$(GOWORK=off go env GOMODCACHE)/cache/download/$KURE_MODULE/@v/$ver.mod"
+  [[ -f "$path" ]] || { echo "ERROR: kure go.mod not found at $path" >&2; exit 2; }
+  printf '%s' "$path"
+}
+
+LAUNCHER_HEAD="$REPO_ROOT/go.mod"
+KURE_HEAD="$(kure_gomod_for "$(kure_version_of "$LAUNCHER_HEAD")")"
+
+# Build the helper once (it is a separate nested module, so `go run <dir>` from the
+# main module can't resolve it, and building avoids `go run`'s "exit status 1" stderr
+# noise while propagating the real exit code). File args passed to it are absolute.
+HELPER_BIN="$TMPDIR/kuredepsync"
+( cd "$HELPER_DIR" && GOWORK=off go build -o "$HELPER_BIN" . )
+run_helper() { "$HELPER_BIN" "$@"; }
+
+if [[ "$MODE" == "report" ]]; then
+  run_helper --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" --report
+  exit 0
+fi
+
+# --base mode: resolve the base go.mod, fetching the ref ourselves.
+resolve_base() {
+  local ref="$1"
+  # Try as-is; if the object is missing, fetch it.
+  if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
+    local remote="origin" branch="$ref"
+    [[ "$ref" == origin/* ]] && branch="${ref#origin/}"
+    git -C "$REPO_ROOT" fetch --no-tags --depth=1 "$remote" "$branch" >/dev/null 2>&1 || true
+  fi
+  git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null
+}
+
+if ! resolve_base "$BASE"; then
+  echo "WARN: could not resolve base ref '$BASE' (offline?); reporting only, not enforcing." >&2
+  run_helper --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" --report
+  exit 0
+fi
+
+LAUNCHER_BASE="$TMPDIR/launcher-base.mod"
+git -C "$REPO_ROOT" show "$BASE:go.mod" > "$LAUNCHER_BASE"
+KURE_BASE="$(kure_gomod_for "$(kure_version_of "$LAUNCHER_BASE")")"
+
+run_helper \
+  --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" \
+  --launcher-base "$LAUNCHER_BASE" --kure-base "$KURE_BASE"

--- a/site/scripts/check-kure-dep-sync.sh
+++ b/site/scripts/check-kure-dep-sync.sh
@@ -47,12 +47,19 @@ done
 TMPDIR="$(mktemp -d)"
 trap 'rm -rf "$TMPDIR"' EXIT
 
-# kure_version_of <go.mod path> — extract the imported kure module version. Matches
-# both block (`\t<mod> <ver>`) and single-line (`require <mod> <ver>`) require forms.
+# Build the helper once up front (separate nested module, so `go run <dir>` from the
+# main module can't resolve it; building also avoids `go run`'s "exit status 1" stderr
+# noise while propagating the real exit code). File args passed to it are absolute.
+HELPER_BIN="$TMPDIR/kuredepsync"
+( cd "$HELPER_DIR" && GOWORK=off go build -o "$HELPER_BIN" . )
+run_helper() { "$HELPER_BIN" "$@"; }
+
+# kure_version_of <go.mod path> — the imported kure require version, parsed by the
+# helper via modfile (robust against comment/replace noise, no line-scraping).
 kure_version_of() {
-  local gomod="$1" ver
-  ver="$(awk -v m="$KURE_MODULE" '{for(i=1;i<=NF;i++) if($i==m){print $(i+1); exit}}' "$gomod")"
-  [[ -n "$ver" ]] || { echo "ERROR: $KURE_MODULE not found in $gomod" >&2; exit 2; }
+  local ver
+  ver="$("$HELPER_BIN" --print-kure-version "$1")" \
+    || { echo "ERROR: could not read $KURE_MODULE version from $1" >&2; exit 2; }
   printf '%s' "$ver"
 }
 
@@ -67,17 +74,12 @@ kure_gomod_for() {
 }
 
 LAUNCHER_HEAD="$REPO_ROOT/go.mod"
-KURE_HEAD="$(kure_gomod_for "$(kure_version_of "$LAUNCHER_HEAD")")"
-
-# Build the helper once (it is a separate nested module, so `go run <dir>` from the
-# main module can't resolve it, and building avoids `go run`'s "exit status 1" stderr
-# noise while propagating the real exit code). File args passed to it are absolute.
-HELPER_BIN="$TMPDIR/kuredepsync"
-( cd "$HELPER_DIR" && GOWORK=off go build -o "$HELPER_BIN" . )
-run_helper() { "$HELPER_BIN" "$@"; }
+KURE_HEAD_VER="$(kure_version_of "$LAUNCHER_HEAD")"
+KURE_HEAD="$(kure_gomod_for "$KURE_HEAD_VER")"
 
 if [[ "$MODE" == "report" ]]; then
-  run_helper --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" --report
+  run_helper --launcher-head "$LAUNCHER_HEAD" \
+    --kure-head "$KURE_HEAD" --kure-head-version "$KURE_HEAD_VER" --report
   exit 0
 fi
 
@@ -94,8 +96,15 @@ resolve_base() {
 }
 
 if ! resolve_base "$BASE"; then
+  # In CI a required check must never silently pass: an unresolved base means the guard
+  # cannot enforce, so fail hard. Locally (offline precommit), degrade to report-only.
+  if [[ "${CI:-}" == "true" ]]; then
+    echo "ERROR: could not resolve base ref '$BASE' in CI; refusing to skip enforcement." >&2
+    exit 2
+  fi
   echo "WARN: could not resolve base ref '$BASE' (offline?); reporting only, not enforcing." >&2
-  run_helper --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" --report
+  run_helper --launcher-head "$LAUNCHER_HEAD" \
+    --kure-head "$KURE_HEAD" --kure-head-version "$KURE_HEAD_VER" --report
   exit 0
 fi
 
@@ -104,5 +113,5 @@ git -C "$REPO_ROOT" show "$BASE:go.mod" > "$LAUNCHER_BASE"
 KURE_BASE="$(kure_gomod_for "$(kure_version_of "$LAUNCHER_BASE")")"
 
 run_helper \
-  --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" \
+  --launcher-head "$LAUNCHER_HEAD" --kure-head "$KURE_HEAD" --kure-head-version "$KURE_HEAD_VER" \
   --launcher-base "$LAUNCHER_BASE" --kure-base "$KURE_BASE"

--- a/site/scripts/check-kure-dep-sync.sh
+++ b/site/scripts/check-kure-dep-sync.sh
@@ -86,11 +86,13 @@ fi
 # --base mode: resolve the base go.mod, fetching the ref ourselves.
 resolve_base() {
   local ref="$1"
-  # Try as-is; if the object is missing, fetch it.
-  if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
-    local remote="origin" branch="$ref"
-    [[ "$ref" == origin/* ]] && branch="${ref#origin/}"
-    git -C "$REPO_ROOT" fetch --no-tags --depth=1 "$remote" "$branch" >/dev/null 2>&1 || true
+  if [[ "$ref" == origin/* ]]; then
+    # Always refresh a remote-tracking base so a stale local origin/main can't cause
+    # false positives/negatives; best-effort so offline runs fall back to the cached ref.
+    git -C "$REPO_ROOT" fetch --no-tags --depth=1 origin "${ref#origin/}" >/dev/null 2>&1 || true
+  elif ! git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
+    # Non-tracking ref (e.g. a merge-base SHA): only fetch if the object is missing.
+    git -C "$REPO_ROOT" fetch --no-tags --depth=1 origin "$ref" >/dev/null 2>&1 || true
   fi
   git -C "$REPO_ROOT" rev-parse --verify --quiet "$ref^{commit}" >/dev/null
 }

--- a/site/scripts/kuredepsync/go.mod
+++ b/site/scripts/kuredepsync/go.mod
@@ -1,0 +1,5 @@
+module kuredepsync
+
+go 1.26.5
+
+require golang.org/x/mod v0.37.0

--- a/site/scripts/kuredepsync/go.sum
+++ b/site/scripts/kuredepsync/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
+golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=

--- a/site/scripts/kuredepsync/main.go
+++ b/site/scripts/kuredepsync/main.go
@@ -47,11 +47,13 @@ func main() {
 }
 
 type opts struct {
-	launcherHead string
-	kureHead     string
-	launcherBase string
-	kureBase     string
-	report       bool
+	launcherHead    string
+	kureHead        string
+	kureHeadVersion string // imported kure release tag at head, for the message
+	launcherBase    string
+	kureBase        string
+	report          bool
+	printKureVer    string // if set, just print that go.mod's kure require version and exit
 }
 
 // run parses args, applies the guard, and returns a process exit code
@@ -71,16 +73,35 @@ func run(args []string, out io.Writer) (int, error) {
 			o.launcherHead = next()
 		case "--kure-head":
 			o.kureHead = next()
+		case "--kure-head-version":
+			o.kureHeadVersion = next()
 		case "--launcher-base":
 			o.launcherBase = next()
 		case "--kure-base":
 			o.kureBase = next()
 		case "--report":
 			o.report = true
+		case "--print-kure-version":
+			o.printKureVer = next()
 		default:
 			return 2, fmt.Errorf("unknown argument: %s", args[i])
 		}
 	}
+
+	// Version-extraction mode: robustly read the kure require version from a go.mod
+	// (via modfile, not line-scraping) so the wrapper can download it and label output.
+	if o.printKureVer != "" {
+		ver, err := kureVersion(o.printKureVer)
+		if err != nil {
+			return 2, err
+		}
+		if ver == "" {
+			return 2, fmt.Errorf("%s not found in %s", kureModule, o.printKureVer)
+		}
+		fmt.Fprintln(out, ver)
+		return 0, nil
+	}
+
 	if o.launcherHead == "" || o.kureHead == "" {
 		return 2, fmt.Errorf("--launcher-head and --kure-head are required")
 	}
@@ -110,6 +131,9 @@ func run(args []string, out io.Writer) (int, error) {
 	}
 
 	violations := evaluate(launcherHead, kureHead, launcherBase, kureBase)
+	for i := range violations {
+		violations[i].kureTag = o.kureHeadVersion
+	}
 	if len(violations) == 0 {
 		fmt.Fprintln(out, "OK: launcher does not newly lead imported kure on any shared direct dependency.")
 		return 0, nil
@@ -125,14 +149,19 @@ type violation struct {
 	reason       string // launcher-raised | kure-regressed | newly-shared/ahead
 	launcherHead string
 	kureHead     string
+	kureTag      string // imported kure release version, e.g. v0.2.0-beta.6 (may be empty)
 }
 
 func (v violation) message() string {
+	kure := "imported kure"
+	if v.kureTag != "" {
+		kure = "imported kure " + v.kureTag
+	}
 	return fmt.Sprintf(
-		"%s [%s]: launcher pins %s but imported kure pins %s — launcher would lead kure. "+
+		"%s [%s]: launcher pins %s but %s pins %s — launcher would lead kure. "+
 			"Land the matching kure release and bump the %s require first, then take this dep. "+
 			"(guard: check-kure-dep-sync.sh)",
-		v.module, v.reason, v.launcherHead, v.kureHead, kureModule)
+		v.module, v.reason, v.launcherHead, kure, v.kureHead, kureModule)
 }
 
 // evaluate applies the guard rule and returns the violating modules, sorted by name.
@@ -230,4 +259,23 @@ func directRequires(path string) (map[string]string, error) {
 		m[r.Mod.Path] = r.Mod.Version
 	}
 	return m, nil
+}
+
+// kureVersion parses a go.mod and returns the version of its go-kure/kure require
+// (empty string if absent). Robust against comment/replace noise — unlike scraping.
+func kureVersion(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	f, err := modfile.Parse(path, data, nil)
+	if err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	for _, r := range f.Require {
+		if r.Mod.Path == kureModule {
+			return r.Mod.Version, nil
+		}
+	}
+	return "", nil
 }

--- a/site/scripts/kuredepsync/main.go
+++ b/site/scripts/kuredepsync/main.go
@@ -1,0 +1,233 @@
+// Command kuredepsync is the analysis half of the check-kure-dep-sync guard.
+//
+// It compares launcher's DIRECT dependencies against the DIRECT dependencies of
+// the kure release launcher imports, and reports when launcher would lead kure on
+// a shared direct dependency. Go's Minimum Version Selection makes the floor
+// uncontrollable (launcher can never fall below the kure it imports), so only the
+// "launcher ahead" direction is enforced.
+//
+// The wrapper script (check-kure-dep-sync.sh) handles all git/go plumbing and
+// hands this program four go.mod files (head + base, launcher + kure); this
+// program only parses and applies the rule, so it stays pure and unit-testable.
+//
+// Modes:
+//
+//	--report                              whole-tree lead report, never fails
+//	--launcher-base X --kure-base Y        diff-scoped enforcement (exit 1 on violation)
+//
+// The rule (only enforced when base files are supplied):
+//
+//	violation iff headAhead && ( !baseAhead
+//	                             || launcher raised D
+//	                             || kure regressed for D )
+//
+// Each comparison runs only when both operands are present; an absent version
+// means "not a direct shared dep on that side".
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+
+	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/semver"
+)
+
+const kureModule = "github.com/go-kure/kure"
+
+func main() {
+	code, err := run(os.Args[1:], os.Stdout)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "kuredepsync:", err)
+		os.Exit(2)
+	}
+	os.Exit(code)
+}
+
+type opts struct {
+	launcherHead string
+	kureHead     string
+	launcherBase string
+	kureBase     string
+	report       bool
+}
+
+// run parses args, applies the guard, and returns a process exit code
+// (0 = ok/report, 1 = violations found).
+func run(args []string, out io.Writer) (int, error) {
+	var o opts
+	for i := 0; i < len(args); i++ {
+		next := func() string {
+			i++
+			if i >= len(args) {
+				return ""
+			}
+			return args[i]
+		}
+		switch args[i] {
+		case "--launcher-head":
+			o.launcherHead = next()
+		case "--kure-head":
+			o.kureHead = next()
+		case "--launcher-base":
+			o.launcherBase = next()
+		case "--kure-base":
+			o.kureBase = next()
+		case "--report":
+			o.report = true
+		default:
+			return 2, fmt.Errorf("unknown argument: %s", args[i])
+		}
+	}
+	if o.launcherHead == "" || o.kureHead == "" {
+		return 2, fmt.Errorf("--launcher-head and --kure-head are required")
+	}
+
+	launcherHead, err := directRequires(o.launcherHead)
+	if err != nil {
+		return 2, err
+	}
+	kureHead, err := directRequires(o.kureHead)
+	if err != nil {
+		return 2, err
+	}
+
+	// Report mode (explicit, or no base supplied): list current direct lead, never fail.
+	if o.report || o.launcherBase == "" {
+		reportLead(out, launcherHead, kureHead)
+		return 0, nil
+	}
+
+	launcherBase, err := directRequires(o.launcherBase)
+	if err != nil {
+		return 2, err
+	}
+	kureBase, err := directRequires(o.kureBase)
+	if err != nil {
+		return 2, err
+	}
+
+	violations := evaluate(launcherHead, kureHead, launcherBase, kureBase)
+	if len(violations) == 0 {
+		fmt.Fprintln(out, "OK: launcher does not newly lead imported kure on any shared direct dependency.")
+		return 0, nil
+	}
+	for _, v := range violations {
+		fmt.Fprintln(out, v.message())
+	}
+	return 1, nil
+}
+
+type violation struct {
+	module       string
+	reason       string // launcher-raised | kure-regressed | newly-shared/ahead
+	launcherHead string
+	kureHead     string
+}
+
+func (v violation) message() string {
+	return fmt.Sprintf(
+		"%s [%s]: launcher pins %s but imported kure pins %s — launcher would lead kure. "+
+			"Land the matching kure release and bump the %s require first, then take this dep. "+
+			"(guard: check-kure-dep-sync.sh)",
+		v.module, v.reason, v.launcherHead, v.kureHead, kureModule)
+}
+
+// evaluate applies the guard rule and returns the violating modules, sorted by name.
+//
+// A dep D is a "direct shared dep on a side" iff it is a direct require of both
+// launcher and that side's imported kure. Comparisons run only when both operands
+// are present.
+func evaluate(launcherHead, kureHead, launcherBase, kureBase map[string]string) []violation {
+	// Candidate set: union of the per-side shared-direct sets. kure itself is never
+	// a candidate (directRequires already drops it; guarded here for defense too).
+	candidates := map[string]struct{}{}
+	for m := range launcherHead {
+		if _, ok := kureHead[m]; ok && m != kureModule {
+			candidates[m] = struct{}{}
+		}
+	}
+	for m := range launcherBase {
+		if _, ok := kureBase[m]; ok && m != kureModule {
+			candidates[m] = struct{}{}
+		}
+	}
+
+	var out []violation
+	for m := range candidates {
+		lh, lhOK := launcherHead[m]
+		kh, khOK := kureHead[m]
+		lb, lbOK := launcherBase[m]
+		kb, kbOK := kureBase[m]
+
+		headAhead := lhOK && khOK && semver.Compare(lh, kh) > 0
+		if !headAhead {
+			continue
+		}
+		baseAhead := lbOK && kbOK && semver.Compare(lb, kb) > 0
+
+		var reason string
+		switch {
+		case lhOK && lbOK && semver.Compare(lh, lb) > 0:
+			reason = "launcher-raised"
+		case khOK && kbOK && semver.Compare(kh, kb) < 0:
+			reason = "kure-regressed"
+		case !baseAhead:
+			reason = "newly-shared/ahead"
+		default:
+			// headAhead && baseAhead && launcher unchanged && kure not regressed:
+			// pre-existing, grandfathered drift — not a violation.
+			continue
+		}
+		out = append(out, violation{module: m, reason: reason, launcherHead: lh, kureHead: kh})
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].module < out[j].module })
+	return out
+}
+
+// reportLead prints current direct-shared lead without failing.
+func reportLead(out io.Writer, launcherHead, kureHead map[string]string) {
+	var ahead []string
+	for m, lv := range launcherHead {
+		kv, ok := kureHead[m]
+		if !ok {
+			continue
+		}
+		if semver.Compare(lv, kv) > 0 {
+			ahead = append(ahead, fmt.Sprintf("  %s: launcher %s > kure %s", m, lv, kv))
+		}
+	}
+	sort.Strings(ahead)
+	if len(ahead) == 0 {
+		fmt.Fprintln(out, "Shared direct deps (enforced): launcher does not lead imported kure. OK.")
+		return
+	}
+	fmt.Fprintln(out, "Shared direct deps where launcher leads imported kure (enforced scope):")
+	for _, line := range ahead {
+		fmt.Fprintln(out, line)
+	}
+}
+
+// directRequires parses a go.mod and returns its DIRECT (non-indirect) requires as
+// module→version, excluding the kure module itself.
+func directRequires(path string) (map[string]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	f, err := modfile.Parse(path, data, nil)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	m := map[string]string{}
+	for _, r := range f.Require {
+		if r.Indirect || r.Mod.Path == kureModule {
+			continue
+		}
+		m[r.Mod.Path] = r.Mod.Version
+	}
+	return m, nil
+}

--- a/site/scripts/kuredepsync/rule_test.go
+++ b/site/scripts/kuredepsync/rule_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -108,12 +109,41 @@ func TestKureModuleExcluded(t *testing.T) {
 }
 
 func TestMessageIncludesReasonAndFix(t *testing.T) {
-	v := violation{module: "example.com/dep", reason: "launcher-raised", launcherHead: "v1.21.0", kureHead: "v1.20.3"}
+	v := violation{module: "example.com/dep", reason: "launcher-raised", launcherHead: "v1.21.0", kureHead: "v1.20.3", kureTag: "v0.2.0-beta.6"}
 	msg := v.message()
-	for _, want := range []string{"launcher-raised", "v1.21.0", "v1.20.3", "check-kure-dep-sync.sh"} {
+	for _, want := range []string{"launcher-raised", "v1.21.0", "v1.20.3", "v0.2.0-beta.6", "check-kure-dep-sync.sh"} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("message missing %q: %s", want, msg)
 		}
+	}
+	// Empty tag must still produce a sensible message (no dangling "kure ").
+	bare := violation{module: "d", reason: "launcher-raised", launcherHead: "v2", kureHead: "v1"}.message()
+	if strings.Contains(bare, "imported kure  pins") {
+		t.Errorf("empty tag left a double space: %s", bare)
+	}
+}
+
+func TestKureVersion(t *testing.T) {
+	dir := t.TempDir()
+	path := dir + "/go.mod"
+	const src = `module example.com/x
+
+go 1.26.5
+
+require (
+	github.com/go-kure/kure v0.2.0-beta.6
+	example.com/other v1.2.3 // indirect
+)
+`
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := kureVersion(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v0.2.0-beta.6" {
+		t.Fatalf("kureVersion = %q, want v0.2.0-beta.6", got)
 	}
 }
 

--- a/site/scripts/kuredepsync/rule_test.go
+++ b/site/scripts/kuredepsync/rule_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// reasons returns module→reason for the violations, for compact assertions.
+func reasons(vs []violation) map[string]string {
+	m := map[string]string{}
+	for _, v := range vs {
+		m[v.module] = v.reason
+	}
+	return m
+}
+
+func TestEvaluate(t *testing.T) {
+	const D = "example.com/dep"
+
+	tests := []struct {
+		name                       string
+		lHead, kHead, lBase, kBase map[string]string
+		wantReason                 string // "" means no violation
+	}{
+		{
+			name:  "in-sync: launcher equals kure",
+			lHead: m(D, "v1.2.0"), kHead: m(D, "v1.2.0"),
+			lBase: m(D, "v1.2.0"), kBase: m(D, "v1.2.0"),
+			wantReason: "",
+		},
+		{
+			name:  "grandfathered: pre-existing lead, PR touches nothing",
+			lHead: m(D, "v1.6.0"), kHead: m(D, "v1.5.1"),
+			lBase: m(D, "v1.6.0"), kBase: m(D, "v1.5.1"),
+			wantReason: "",
+		},
+		{
+			name:  "launcher-raised: PR bumps shared dep above kure",
+			lHead: m(D, "v1.21.0"), kHead: m(D, "v1.20.3"),
+			lBase: m(D, "v1.20.3"), kBase: m(D, "v1.20.3"),
+			wantReason: "launcher-raised",
+		},
+		{
+			name:  "kure-regressed: kure lowered for D on a grandfathered lead (widened)",
+			lHead: m(D, "v1.6.0"), kHead: m(D, "v1.4.0"),
+			lBase: m(D, "v1.6.0"), kBase: m(D, "v1.5.1"),
+			wantReason: "kure-regressed",
+		},
+		{
+			name:  "newly-shared: PR adds D as direct dep already ahead (absent at base)",
+			lHead: m(D, "v2.0.0"), kHead: m(D, "v1.0.0"),
+			lBase: map[string]string{}, kBase: map[string]string{},
+			wantReason: "newly-shared/ahead",
+		},
+		{
+			name:  "newly-ahead via kure regression: was in sync at base, kure lowered D",
+			lHead: m(D, "v1.5.0"), kHead: m(D, "v1.4.0"),
+			lBase: m(D, "v1.5.0"), kBase: m(D, "v1.5.0"),
+			wantReason: "kure-regressed", // kure going down is the informative cause
+		},
+		{
+			name:  "catch-up: kure regressed for D but launcher no longer leads → harmless",
+			lHead: m(D, "v1.4.0"), kHead: m(D, "v1.5.0"),
+			lBase: m(D, "v1.6.0"), kBase: m(D, "v1.5.1"),
+			wantReason: "", // !headAhead gates it out despite kure_head < kure_base
+		},
+		{
+			name:  "prerelease precedence: v1.0.0 leads v1.0.0-rc.1 (sort -V would miss)",
+			lHead: m(D, "v1.0.0"), kHead: m(D, "v1.0.0-rc.1"),
+			lBase: map[string]string{}, kBase: map[string]string{},
+			wantReason: "newly-shared/ahead",
+		},
+		{
+			name:  "not shared: D direct in launcher only → ignored",
+			lHead: m(D, "v9.9.9"), kHead: map[string]string{},
+			lBase: m(D, "v9.9.9"), kBase: map[string]string{},
+			wantReason: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := reasons(evaluate(tc.lHead, tc.kHead, tc.lBase, tc.kBase))
+			if tc.wantReason == "" {
+				if len(got) != 0 {
+					t.Fatalf("expected no violation, got %v", got)
+				}
+				return
+			}
+			if got[D] != tc.wantReason {
+				t.Fatalf("D reason = %q, want %q (all: %v)", got[D], tc.wantReason, got)
+			}
+		})
+	}
+}
+
+func TestKureModuleExcluded(t *testing.T) {
+	// kure itself is never treated as a shared dep even if it appears ahead.
+	vs := evaluate(
+		map[string]string{kureModule: "v0.3.0"},
+		map[string]string{kureModule: "v0.2.0"},
+		map[string]string{kureModule: "v0.2.0"},
+		map[string]string{kureModule: "v0.2.0"},
+	)
+	if len(vs) != 0 {
+		t.Fatalf("kure module should be excluded, got %v", vs)
+	}
+}
+
+func TestMessageIncludesReasonAndFix(t *testing.T) {
+	v := violation{module: "example.com/dep", reason: "launcher-raised", launcherHead: "v1.21.0", kureHead: "v1.20.3"}
+	msg := v.message()
+	for _, want := range []string{"launcher-raised", "v1.21.0", "v1.20.3", "check-kure-dep-sync.sh"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func m(k, v string) map[string]string { return map[string]string{k: v} }


### PR DESCRIPTION
## Context

Launcher imports `go-kure/kure` and shares several third-party deps with it (cert-manager, fluxcd controller APIs, cloudnative-pg, external-secrets/apis, gateway-api) that launcher's own code imports directly. Dependabot runs per-repo, so launcher can bump a shared dep **ahead** of the kure release it imports — compiling kure's own code against a version kure never released against (e.g. live PRs #218, #217).

Go's Minimum Version Selection makes the *floor* uncontrollable (launcher can never fall below the imported kure — it's pulled up), so only the **ahead** direction needs coordination.

## What this does

A **diff-scoped, direct-deps-only** guard that fails a PR only when it *introduces or increases* launcher's lead over the imported kure on a shared **direct** dependency. Existing drift is **grandfathered**; indirect deps (MVS-governed) are out of scope.

Rule: `violation iff headAhead && (!baseAhead || launcher raised D || kure regressed for D)`, each comparison guarded on operand presence.

## Changes

- `site/scripts/check-kure-dep-sync.sh` — bash wrapper (`--base` enforce / `--report` visibility); self-fetches its base ref; resolves + downloads the imported kure `go.mod`.
- `site/scripts/kuredepsync/` — isolated Go module parsing `go.mod` via `x/mod/modfile`, comparing with `semver.Compare` (not `sort -V`); table tests for every violation class + grandfathered/catch-up/prerelease.
- `ci.yml` — change-filter paths; `validate`-job steps (blocking on PR/merge-queue, `--report` on push/schedule) + helper-module hygiene check.
- `Makefile`/`mise.toml` — `check-kure-dep-sync` in `check`, `precommit`, `ci`, `verify`.
- `.github/dependabot.yml` / `AGENTS.md` — document the ceiling rule and exception path.

## Verification

- `--report` on main lists exactly the 3 grandfathered direct deps (cloudnative-pg, external-secrets/apis, gateway-api).
- Clean branch passes; simulated cert-manager 1.21.0 / gateway-api bumps fail with `[launcher-raised]`.
- Helper `go vet`/`go test` pass; doc-sync/links green.

## Notes

- **Grandfathered deps** (cloudnative-pg, external-secrets/apis, gateway-api) will be reconciled by the upcoming launcher→new-kure-release bump — no separate tracking issue.
- **Dependabot #218/#217** are left as-is; this guard will block them automatically, and the kure bump is expected to supersede them.