### PR TITLE
feat(oam/netpol): EndpointProvider + endpoint-ingress NetworkPolicy synthesis

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -28,9 +28,9 @@ parse → resolve parameters → transform (component + trait handlers) → mani
    `ComponentHandler` and each trait to its `TraitHandler`, merging the
    `ClusterProfile`'s capability choices.
 
-A Phase-4 post-build stage then synthesizes per-component `NetworkPolicy` resources
-in two directions, each a **separate** additive resource (the authored
-`networkpolicy` / `cilium-networkpolicy` traits are unaffected):
+A Phase-4 post-build stage then synthesizes per-component `NetworkPolicy` resources,
+each a **separate** additive resource (the authored `networkpolicy` /
+`cilium-networkpolicy` traits are unaffected):
 
 - **Inbound** (`{comp}-allow-ingress-traffic`) — routing-derived, from routing traits'
   platform-reserved `networkPolicy.trafficSources` capability rendering.
@@ -38,8 +38,20 @@ in two directions, each a **separate** additive resource (the authored
   downstream-supplied, non-authorable synthesis input (graph-derived dependency peers; never
   set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a
   caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op.
+- **Endpoint ingress** (`{comp}-allow-endpoint-ingress`) — the **target side** of a
+  connection, from `TransformContext.IngressPeers` (a platform-supplied, non-authorable
+  graph-derived input). Each `netpol.IngressPeer` names an `Endpoint` (pod selector + ports)
+  and the sources allowed to reach it; launcher emits an Ingress `NetworkPolicy` selecting the
+  **endpoint's own selector** — deliberately **not** the component-label key — so it protects
+  operator-created pods (e.g. a CloudNativePG cluster's `cnpg.io/cluster` instance pods) that
+  carry no component-provenance label. Fail-closed: each source must carry a namespace + a
+  non-empty matchLabels pod selector (namespace-wide sources are dropped), and a policy with no
+  valid rule is not emitted. A component's endpoints are declared by its handler via the
+  optional `EndpointProvider` interface and read through `Transformer.ComponentEndpoints` — the
+  producer half a downstream platform uses to learn the real selector (no hardcoding) and build
+  its dependency graph.
 
-Both families select the component's own pods (the ingress recipients / the egress
+The inbound/egress families select the component's own pods (the ingress recipients / the egress
 source pods) via a **derived `<domain>/component`** label by default — the domain comes
 from `TransformContext.Domain` (empty ⇒ the library default `gokure.dev`; the kurel CLI
 uses `launcher.gokure.dev`). The full key is overridable per transform through

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -57,6 +57,10 @@ share these fields: `image` (validated — no untagged/`latest`), `env` (with
 - **postgresql** — `provider: cnpg`, `version` (default `16`), `storageSize`
   (precedence: authored > policy default `storageSize` > `1Gi`), `replicas`,
   `backup.*`, `monitoring.enabled`, `pooler.enabled`, `managedRoles`, `databases`.
+  Its handler implements the optional `oam.EndpointProvider`: it declares the CNPG cluster's
+  data-plane endpoint (`cnpg.io/cluster: <component-name>` on port `5432`) so a downstream
+  platform can synthesize the target-side ingress allow (`{comp}-allow-endpoint-ingress`)
+  without hardcoding the operator selector.
 - **passthrough** — `object` (full apiVersion/kind/metadata/spec), `clusterScoped`.
   Its config exposes `ComponentName() string` (the `oam.ComponentNamed` interface) so
   consumers can attribute the emitted resource to its owning OAM component.

--- a/pkg/oam/builtin/components/endpoint_test.go
+++ b/pkg/oam/builtin/components/endpoint_test.go
@@ -1,0 +1,26 @@
+package components_test
+
+import (
+	"testing"
+
+	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/builtin/components"
+)
+
+func TestPostgresqlHandler_Endpoints(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+	eps, err := h.Endpoints(&oam.Component{Name: "orders-db", Type: "postgresql"})
+	if err != nil {
+		t.Fatalf("Endpoints: %v", err)
+	}
+	if len(eps) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(eps))
+	}
+	sel := eps[0].PodSelector
+	if sel == nil || sel.MatchLabels["cnpg.io/cluster"] != "orders-db" || len(sel.MatchLabels) != 1 {
+		t.Errorf("selector = %v, want cnpg.io/cluster=orders-db", sel)
+	}
+	if len(eps[0].Ports) != 1 || eps[0].Ports[0].IntVal != 5432 {
+		t.Errorf("ports = %v, want [5432]", eps[0].Ports)
+	}
+}

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -5,10 +5,20 @@ import (
 
 	kurecnpg "github.com/go-kure/kure/pkg/kubernetes/cnpg"
 	"github.com/go-kure/kure/pkg/stack"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/errors"
 	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/netpol"
+)
+
+// cnpgClusterLabel is the label the CloudNativePG operator stamps on every instance pod of a
+// Cluster (value = the Cluster name). postgresqlPort is the default PostgreSQL service port.
+const (
+	cnpgClusterLabel = "cnpg.io/cluster"
+	postgresqlPort   = 5432
 )
 
 // PostgresqlHandler handles OAM postgresql components.
@@ -17,6 +27,17 @@ type PostgresqlHandler struct{}
 // CanHandle returns true for postgresql component type.
 func (h *PostgresqlHandler) CanHandle(componentType string) bool {
 	return componentType == "postgresql"
+}
+
+// Endpoints implements oam.EndpointProvider: a postgresql component's data-plane endpoint is
+// the CNPG cluster's instance pods (labelled cnpg.io/cluster=<cluster name>, which equals the
+// OAM component name) on the PostgreSQL port. A downstream platform uses this to synthesize the
+// target-side ingress allow without hardcoding the operator selector.
+func (h *PostgresqlHandler) Endpoints(component *oam.Component) ([]netpol.Endpoint, error) {
+	return []netpol.Endpoint{{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{cnpgClusterLabel: component.Name}},
+		Ports:       []intstr.IntOrString{intstr.FromInt32(postgresqlPort)},
+	}}, nil
 }
 
 // PropertySchema declares the postgresql component's top-level user-facing

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-kure/kure/pkg/stack"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/go-kure/launcher/pkg/oam"
@@ -384,5 +385,46 @@ func TestTransform_ComponentLabelKey_Override(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// End-to-end: a postgresql component + platform-supplied IngressPeers yields a synthesized
+// {comp}-allow-endpoint-ingress policy whose podSelector is the endpoint's own operator label
+// (cnpg.io/cluster), not the component-label key.
+func TestTransform_IngressPeers_SynthesizesEndpointIngressNetworkPolicy(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("postgresql", &components.PostgresqlHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{Name: "orders-db", Type: "postgresql"}},
+		},
+	}
+	ctx := oam.TransformContext{
+		Namespace: "default",
+		IngressPeers: map[string][]netpol.IngressPeer{
+			"orders-db": {{
+				Endpoint: netpol.Endpoint{
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/cluster": "orders-db"}},
+					Ports:       []intstr.IntOrString{intstr.FromInt32(5432)},
+				},
+				Sources: []netpol.TrafficSource{{
+					Namespace:   "app",
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+				}},
+			}},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, ctx)
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	if !clusterHasApp(cluster, "orders-db-allow-endpoint-ingress") {
+		t.Fatalf("expected orders-db-allow-endpoint-ingress; apps: %v", clusterAppNames(cluster))
+	}
+	sel := synthesizedPodSelector(t, cluster, "orders-db-allow-endpoint-ingress")
+	if sel["cnpg.io/cluster"] != "orders-db" || len(sel) != 1 {
+		t.Errorf("podSelector = %v, want single cnpg.io/cluster=orders-db", sel)
 	}
 }

--- a/pkg/oam/endpoint_dispatch_test.go
+++ b/pkg/oam/endpoint_dispatch_test.go
@@ -1,0 +1,70 @@
+package oam
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/go-kure/launcher/pkg/oam/netpol"
+)
+
+// stubEndpointHandler is a ComponentHandler that also implements EndpointProvider.
+type stubEndpointHandler struct {
+	typeName string
+	eps      []netpol.Endpoint
+	err      error
+}
+
+func (h *stubEndpointHandler) CanHandle(t string) bool { return t == h.typeName }
+func (h *stubEndpointHandler) ToApplicationConfig(_ *Component, _ string) (stack.ApplicationConfig, error) {
+	return &stubAppConfig{}, nil
+}
+func (h *stubEndpointHandler) Endpoints(_ *Component) ([]netpol.Endpoint, error) {
+	return h.eps, h.err
+}
+
+// stubPlainHandler is a ComponentHandler that is NOT an EndpointProvider.
+type stubPlainHandler struct{ typeName string }
+
+func (h *stubPlainHandler) CanHandle(t string) bool { return t == h.typeName }
+func (h *stubPlainHandler) ToApplicationConfig(_ *Component, _ string) (stack.ApplicationConfig, error) {
+	return &stubAppConfig{}, nil
+}
+
+func TestComponentEndpoints_Dispatch(t *testing.T) {
+	tr := NewTransformer(nil, nil)
+	tr.RegisterComponent("db", &stubEndpointHandler{typeName: "db", eps: []netpol.Endpoint{validEndpoint()}})
+	tr.RegisterComponent("plain", &stubPlainHandler{typeName: "plain"})
+
+	// provider → its endpoints
+	eps, err := tr.ComponentEndpoints(&Component{Name: "x", Type: "db"})
+	if err != nil || len(eps) != 1 || eps[0].PodSelector.MatchLabels["cnpg.io/cluster"] != "pg" {
+		t.Errorf("provider dispatch: eps=%v err=%v", eps, err)
+	}
+	// registered non-provider → (nil, nil)
+	if eps, err := tr.ComponentEndpoints(&Component{Name: "x", Type: "plain"}); eps != nil || err != nil {
+		t.Errorf("non-provider: want (nil,nil), got (%v,%v)", eps, err)
+	}
+	// unknown type → (nil, nil)
+	if eps, err := tr.ComponentEndpoints(&Component{Name: "x", Type: "nope"}); eps != nil || err != nil {
+		t.Errorf("unknown: want (nil,nil), got (%v,%v)", eps, err)
+	}
+	// nil component → (nil, nil), no panic
+	if eps, err := tr.ComponentEndpoints(nil); eps != nil || err != nil {
+		t.Errorf("nil comp: want (nil,nil), got (%v,%v)", eps, err)
+	}
+}
+
+func TestComponentEndpoints_MalformedProviderErrors(t *testing.T) {
+	malformed := []netpol.Endpoint{{ // nil selector, empty ports
+		PodSelector: &metav1.LabelSelector{},
+		Ports:       []intstr.IntOrString{},
+	}}
+	tr := NewTransformer(nil, nil)
+	tr.RegisterComponent("db", &stubEndpointHandler{typeName: "db", eps: malformed})
+	if _, err := tr.ComponentEndpoints(&Component{Name: "x", Type: "db"}); err == nil {
+		t.Error("expected error for malformed provider endpoint, got nil")
+	}
+}

--- a/pkg/oam/handler.go
+++ b/pkg/oam/handler.go
@@ -1,6 +1,10 @@
 package oam
 
-import "github.com/go-kure/kure/pkg/stack"
+import (
+	"github.com/go-kure/kure/pkg/stack"
+
+	"github.com/go-kure/launcher/pkg/oam/netpol"
+)
 
 // ComponentHandler handles transformation of a specific OAM component type
 // into a kure ApplicationConfig.
@@ -50,4 +54,14 @@ type SourceDeduplicatable interface {
 // (e.g. a provenance label) without re-deriving the component from sub-app names.
 type ComponentNamed interface {
 	ComponentName() string
+}
+
+// EndpointProvider is an optional ComponentHandler interface: it declares the component's
+// in-cluster data-plane endpoints (selector + ports) that launcher knows deterministically
+// (e.g. an operator-managed database's instance pods). A downstream platform consumer calls
+// Transformer.ComponentEndpoints to learn these — to build its dependency graph and the
+// target-side allows it feeds back via TransformContext.IngressPeers — without hardcoding the
+// operator selector. It is not read by synthesis (synthesis emits from IngressPeers).
+type EndpointProvider interface {
+	Endpoints(component *Component) ([]netpol.Endpoint, error)
 }

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -12,6 +12,14 @@ Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
   selector + ports). Unlike `TrafficSource`, it is a downstream-supplied, non-authorable
   synthesis input carried on `TransformContext.EgressPeers` (never set from OAM YAML or
   capability rendering); it has no trait-side producer.
+- `Endpoint` — a component's declared in-cluster data-plane endpoint: a pod selector
+  (matchLabels only) + ports. Namespace is deliberately absent (the caller knows the target's
+  namespace). Declared by a component handler via the optional `oam.EndpointProvider`.
+- `IngressPeer` — one **target-side** allow (an `Endpoint` + the `Sources` allowed to reach
+  it), carried on `TransformContext.IngressPeers`; platform-supplied and non-authorable.
+  **Fail-closed contract:** unlike `TrafficSource` (where a nil pod selector means "all pods"),
+  each `IngressPeer.Source` MUST carry a namespace and a non-empty matchLabels pod selector —
+  a namespace-wide source is dropped. Both endpoint and source selectors are matchLabels-only.
 
 Internal support type, not a user-facing API. See
 [pkg.go.dev](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/netpol).

--- a/pkg/oam/netpol/types.go
+++ b/pkg/oam/netpol/types.go
@@ -28,3 +28,25 @@ type EgressPeer struct {
 	PodSelector *metav1.LabelSelector // nil = all pods; matchLabels only
 	Ports       []intstr.IntOrString
 }
+
+// Endpoint is a component's declared in-cluster data-plane endpoint (e.g. an operator-managed
+// database's instance pods). Namespace is deliberately absent — the platform caller knows the
+// target's namespace, and the synthesized NetworkPolicy is emitted in the component's namespace.
+// PodSelector is required (matchLabels only); Ports is required and non-empty (TCP).
+type Endpoint struct {
+	PodSelector *metav1.LabelSelector // required; matchLabels only
+	Ports       []intstr.IntOrString  // required, non-empty; TCP
+}
+
+// IngressPeer is a target-side allow: who may reach one of a component's endpoints. It is a
+// platform-supplied, non-authorable synthesis input (never from OAM YAML or capability
+// rendering); launcher only emits. All selectors are platform-supplied.
+//
+// Unlike TrafficSource (where a nil PodSelector means "all pods"), endpoint-ingress synthesis
+// is fail-closed: each Source MUST carry a namespace and a non-empty matchLabels pod selector
+// (matchLabels only) — a namespace-wide source is dropped, since it would let every pod in that
+// namespace reach the endpoint on the endpoint ports.
+type IngressPeer struct {
+	Endpoint Endpoint        // NetworkPolicy podSelector + ports
+	Sources  []TrafficSource // required matchLabels pod selector + namespace per source
+}

--- a/pkg/oam/netpol_endpoint_synthesis_test.go
+++ b/pkg/oam/netpol_endpoint_synthesis_test.go
@@ -1,0 +1,284 @@
+package oam
+
+import (
+	"testing"
+
+	"github.com/go-kure/kure/pkg/stack"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/go-kure/launcher/pkg/oam/netpol"
+)
+
+// src builds a fail-closed traffic source (namespace + matchLabels pod selector).
+func src(ns, k, v string) netpol.TrafficSource {
+	return netpol.TrafficSource{Namespace: ns, PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{k: v}}}
+}
+
+// endpointPolicyOrNil runs Generate and returns nil for zero objects or the single
+// NetworkPolicy for one object (fail on anything else) — invalid-input cases assert nil.
+func endpointPolicyOrNil(t *testing.T, cfg *componentEndpointIngressPolicyConfig) *networkingv1.NetworkPolicy {
+	t.Helper()
+	app := stack.NewApplication(cfg.ComponentName+"-allow-endpoint-ingress", "default", cfg)
+	objs, err := cfg.Generate(app)
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	switch len(objs) {
+	case 0:
+		return nil
+	case 1:
+		np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+		if !ok {
+			t.Fatalf("expected *NetworkPolicy, got %T", *objs[0])
+		}
+		return np
+	default:
+		t.Fatalf("expected 0 or 1 object, got %d", len(objs))
+		return nil
+	}
+}
+
+func validEndpoint() netpol.Endpoint {
+	return netpol.Endpoint{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/cluster": "pg"}},
+		Ports:       []intstr.IntOrString{intstr.FromInt32(5432)},
+	}
+}
+
+func TestValidateEndpoint(t *testing.T) {
+	cases := []struct {
+		name    string
+		ep      netpol.Endpoint
+		wantErr bool
+	}{
+		{"valid", validEndpoint(), false},
+		{"nil selector", netpol.Endpoint{Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, true},
+		{"empty matchLabels", netpol.Endpoint{
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}},
+			Ports:       []intstr.IntOrString{intstr.FromInt32(5432)},
+		}, true},
+		{"matchExpressions present", netpol.Endpoint{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels:      map[string]string{"a": "b"},
+				MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: metav1.LabelSelectorOpExists}},
+			},
+			Ports: []intstr.IntOrString{intstr.FromInt32(5432)},
+		}, true},
+		{"empty ports", netpol.Endpoint{
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}},
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateEndpoint(tc.ep)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestComponentEndpointIngressPolicyConfig_Generate_Shape(t *testing.T) {
+	cfg := &componentEndpointIngressPolicyConfig{
+		ComponentName: "pg",
+		Endpoint:      validEndpoint(),
+		Rules:         []endpointIngressRule{{Sources: []netpol.TrafficSource{src("app", "app", "web")}}},
+	}
+	np := endpointPolicyOrNil(t, cfg)
+	if np == nil {
+		t.Fatal("expected a policy, got nil")
+	}
+	if np.Name != "pg-allow-endpoint-ingress" {
+		t.Errorf("name = %q", np.Name)
+	}
+	if np.Labels != nil || np.Annotations != nil {
+		t.Errorf("expected nil labels/annotations")
+	}
+	if got := np.Spec.PodSelector.MatchLabels["cnpg.io/cluster"]; got != "pg" || len(np.Spec.PodSelector.MatchLabels) != 1 {
+		t.Errorf("podSelector = %v, want single cnpg.io/cluster=pg", np.Spec.PodSelector.MatchLabels)
+	}
+	if len(np.Spec.PolicyTypes) != 1 || np.Spec.PolicyTypes[0] != networkingv1.PolicyTypeIngress {
+		t.Errorf("policyTypes = %v, want [Ingress]", np.Spec.PolicyTypes)
+	}
+	if len(np.Spec.Egress) != 0 {
+		t.Errorf("expected no egress rules")
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].From) != 1 {
+		t.Fatalf("expected 1 ingress rule with 1 peer, got %+v", np.Spec.Ingress)
+	}
+	from := np.Spec.Ingress[0].From[0]
+	if from.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "app" {
+		t.Errorf("namespace selector = %v, want app", from.NamespaceSelector)
+	}
+	if from.PodSelector == nil || from.PodSelector.MatchLabels["app"] != "web" {
+		t.Errorf("pod selector = %v, want app=web", from.PodSelector)
+	}
+	if len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 5432 {
+		t.Errorf("ports = %v, want [5432]", np.Spec.Ingress[0].Ports)
+	}
+}
+
+func TestComponentEndpointIngressPolicyConfig_Generate_FailClosed(t *testing.T) {
+	base := validEndpoint()
+	cases := []struct {
+		name string
+		cfg  *componentEndpointIngressPolicyConfig
+	}{
+		{"nil rules", &componentEndpointIngressPolicyConfig{ComponentName: "pg", Endpoint: base, Rules: nil}},
+		{"rule with empty sources", &componentEndpointIngressPolicyConfig{ComponentName: "pg", Endpoint: base,
+			Rules: []endpointIngressRule{{Sources: nil}}}},
+		{"rule with only namespace-wide source", &componentEndpointIngressPolicyConfig{ComponentName: "pg", Endpoint: base,
+			Rules: []endpointIngressRule{{Sources: []netpol.TrafficSource{{Namespace: "app"}}}}}},
+		{"invalid endpoint", &componentEndpointIngressPolicyConfig{ComponentName: "pg",
+			Endpoint: netpol.Endpoint{Ports: []intstr.IntOrString{intstr.FromInt32(5432)}},
+			Rules:    []endpointIngressRule{{Sources: []netpol.TrafficSource{src("app", "app", "web")}}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if np := endpointPolicyOrNil(t, tc.cfg); np != nil {
+				t.Errorf("expected no policy, got %+v", np.Spec)
+			}
+		})
+	}
+}
+
+func TestGroupIngressPeers_DropsMalformedAndDedups(t *testing.T) {
+	peers := []netpol.IngressPeer{
+		{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+		// duplicate source set for the same endpoint → deduped
+		{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+		// malformed endpoint (nil selector) → dropped
+		{Endpoint: netpol.Endpoint{Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+		// all sources namespace-wide → dropped
+		{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{{Namespace: "x"}}},
+	}
+	groups := groupIngressPeers(peers)
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Rules) != 1 {
+		t.Errorf("expected 1 deduped rule, got %d", len(groups[0].Rules))
+	}
+}
+
+func TestGroupIngressPeers_TwoDistinctEndpoints(t *testing.T) {
+	ep2 := netpol.Endpoint{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/cluster": "pg", "role": "pooler"}},
+		Ports:       []intstr.IntOrString{intstr.FromInt32(6432)},
+	}
+	groups := groupIngressPeers([]netpol.IngressPeer{
+		{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+		{Endpoint: ep2, Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+	})
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 endpoint groups, got %d", len(groups))
+	}
+}
+
+func TestSynthesizeEndpointIngress_AppendsPolicy(t *testing.T) {
+	cluster, componentMap, _ := egressFixture("pg", "default")
+	peers := map[string][]netpol.IngressPeer{
+		"pg": {{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}}},
+	}
+	synthesizeEndpointIngressNetworkPolicies(cluster, componentMap, peers)
+	names := egressAppNames(cluster)
+	found := false
+	for _, n := range names {
+		if n == "pg-allow-endpoint-ingress" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected pg-allow-endpoint-ingress; apps: %v", names)
+	}
+}
+
+func TestSynthesizeEndpointIngress_NoOpAndGuards(t *testing.T) {
+	// no-op when no peers
+	cluster, componentMap, _ := egressFixture("pg", "default")
+	synthesizeEndpointIngressNetworkPolicies(cluster, componentMap, nil)
+	if got := len(egressAppNames(cluster)); got != 1 {
+		t.Errorf("expected no synthesis without peers, got %d apps", got)
+	}
+	// no-op when no component match
+	cluster2, componentMap2, _ := egressFixture("pg", "default")
+	synthesizeEndpointIngressNetworkPolicies(cluster2, componentMap2, map[string][]netpol.IngressPeer{
+		"other": {{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}}},
+	})
+	if got := len(egressAppNames(cluster2)); got != 1 {
+		t.Errorf("expected no synthesis for unmatched component, got %d apps", got)
+	}
+	// multi-endpoint → skip (no app emitted)
+	cluster3, componentMap3, _ := egressFixture("pg", "default")
+	ep2 := netpol.Endpoint{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}, Ports: []intstr.IntOrString{intstr.FromInt32(6432)}}
+	synthesizeEndpointIngressNetworkPolicies(cluster3, componentMap3, map[string][]netpol.IngressPeer{
+		"pg": {
+			{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+			{Endpoint: ep2, Sources: []netpol.TrafficSource{src("app", "app", "web")}},
+		},
+	})
+	for _, n := range egressAppNames(cluster3) {
+		if n == "pg-allow-endpoint-ingress" {
+			t.Errorf("expected multi-endpoint skip, but a policy was emitted")
+		}
+	}
+}
+
+func TestValidSources_DropsInvalidVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		s    netpol.TrafficSource
+		keep bool
+	}{
+		{"valid", src("app", "app", "web"), true},
+		{"empty namespace", netpol.TrafficSource{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}}}, false},
+		{"nil pod selector", netpol.TrafficSource{Namespace: "app"}, false},
+		{"empty matchLabels", netpol.TrafficSource{Namespace: "app", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}}}, false},
+		{"matchExpressions present", netpol.TrafficSource{Namespace: "app", PodSelector: &metav1.LabelSelector{
+			MatchLabels:      map[string]string{"app": "web"},
+			MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "x", Operator: metav1.LabelSelectorOpExists}},
+		}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := validSources([]netpol.TrafficSource{tc.s})
+			if tc.keep && len(got) != 1 {
+				t.Errorf("expected source kept, got %d", len(got))
+			}
+			if !tc.keep && len(got) != 0 {
+				t.Errorf("expected source dropped, got %d", len(got))
+			}
+		})
+	}
+}
+
+// Emitted rule From order is byte-stable regardless of caller source order.
+func TestGenerate_StableSourceOrder(t *testing.T) {
+	a, b := src("app", "app", "web"), src("db", "app", "api")
+	fwd := &componentEndpointIngressPolicyConfig{ComponentName: "pg", Endpoint: validEndpoint(),
+		Rules: []endpointIngressRule{{Sources: []netpol.TrafficSource{a, b}}}}
+	rev := &componentEndpointIngressPolicyConfig{ComponentName: "pg", Endpoint: validEndpoint(),
+		Rules: []endpointIngressRule{{Sources: []netpol.TrafficSource{b, a}}}}
+	nsOrder := func(cfg *componentEndpointIngressPolicyConfig) []string {
+		np := endpointPolicyOrNil(t, cfg)
+		var out []string
+		for _, p := range np.Spec.Ingress[0].From {
+			out = append(out, p.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+		}
+		return out
+	}
+	f, r := nsOrder(fwd), nsOrder(rev)
+	if len(f) != 2 || len(r) != 2 {
+		t.Fatalf("expected 2 sources each, got fwd=%v rev=%v", f, r)
+	}
+	for i := range f {
+		if f[i] != r[i] {
+			t.Errorf("From order not stable: fwd=%v rev=%v", f, r)
+		}
+	}
+}

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/go-kure/launcher/pkg/errors"
 	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
 
@@ -378,4 +379,250 @@ func sortIntOrStringPorts(ports []intstr.IntOrString) {
 		}
 		return a.StrVal < b.StrVal
 	})
+}
+
+// --- Endpoint-ingress synthesis (platform-supplied, non-authorable target-side allows) ---
+
+// validateEndpoint fails closed on a malformed endpoint: the pod selector is required and
+// matchLabels-only, and at least one port is required. Used to reject bad EndpointProvider
+// output (a launcher-internal bug) and to guard directly-built endpoint-ingress configs.
+func validateEndpoint(e netpol.Endpoint) error {
+	if e.PodSelector == nil || len(e.PodSelector.MatchLabels) == 0 {
+		return errors.New("endpoint pod selector must have non-empty matchLabels")
+	}
+	if len(e.PodSelector.MatchExpressions) > 0 {
+		return errors.New("endpoint pod selector must be matchLabels-only (no matchExpressions)")
+	}
+	if len(e.Ports) == 0 {
+		return errors.New("endpoint must declare at least one port")
+	}
+	return nil
+}
+
+// endpointValid reports whether e passes validateEndpoint — a boolean form for fail-closed
+// drop/skip paths (Generate, grouping) that must not surface a nil error.
+func endpointValid(e netpol.Endpoint) bool { return validateEndpoint(e) == nil }
+
+// validSources keeps only fail-closed traffic sources: each must carry a namespace and a
+// non-empty matchLabels pod selector (matchLabels-only). Namespace-wide sources are dropped —
+// unlike the inbound family, endpoint-ingress never allows "all pods in a namespace". The
+// survivors are sorted by canonical key so the emitted rule's From order (and the dedup key)
+// is byte-stable regardless of the caller's source order.
+func validSources(sources []netpol.TrafficSource) []netpol.TrafficSource {
+	out := make([]netpol.TrafficSource, 0, len(sources))
+	for _, s := range sources {
+		if s.Namespace == "" || s.PodSelector == nil || len(s.PodSelector.MatchLabels) == 0 {
+			continue
+		}
+		if len(s.PodSelector.MatchExpressions) > 0 {
+			continue
+		}
+		out = append(out, s)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return trafficSourceKey(out[i]) < trafficSourceKey(out[j]) })
+	return out
+}
+
+// trafficSourceKey returns a canonical key for one (validated) traffic source: namespace plus
+// sorted key=value matchLabels.
+func trafficSourceKey(s netpol.TrafficSource) string {
+	labelParts := make([]string, 0, len(s.PodSelector.MatchLabels))
+	for lk, lv := range s.PodSelector.MatchLabels {
+		labelParts = append(labelParts, lk+"="+lv)
+	}
+	sort.Strings(labelParts)
+	return s.Namespace + "/" + strings.Join(labelParts, ",")
+}
+
+type endpointIngressRule struct {
+	Sources []netpol.TrafficSource // fail-closed: each carries a namespace + matchLabels pod selector
+}
+
+// componentEndpointIngressPolicyConfig is the ApplicationConfig for an auto-generated
+// NetworkPolicy that allows ingress to one of a component's declared endpoints (e.g. an
+// operator-managed database's instance pods) from platform-supplied sources. The resource
+// name is {component}-allow-endpoint-ingress, distinct from the other synthesized families and
+// the explicit networkpolicy trait, so it is purely additive. The podSelector is the endpoint's
+// own selector — deliberately not the component-label key — because it protects operator pods
+// that carry no component-provenance label.
+type componentEndpointIngressPolicyConfig struct {
+	ComponentName string
+	Endpoint      netpol.Endpoint       // this policy's single endpoint (podSelector + ports)
+	Rules         []endpointIngressRule // one per distinct source set, deduplicated
+}
+
+// ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy fields
+// (matching the other synthesized families).
+func (c *componentEndpointIngressPolicyConfig) ApplyPolicy(_ Policy) error { return nil }
+
+func (c *componentEndpointIngressPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	// Fail closed: never emit a deny-all (no rules) or allow-from-all (bad selectors) policy,
+	// even for a directly-built config. Filter sources with the same strict rule as synthesis.
+	if !endpointValid(c.Endpoint) {
+		return nil, nil // invalid endpoint: emit nothing (not an error at the Generate boundary)
+	}
+	var rules []endpointIngressRule
+	for _, r := range c.Rules {
+		if srcs := validSources(r.Sources); len(srcs) > 0 {
+			rules = append(rules, endpointIngressRule{Sources: srcs})
+		}
+	}
+	if len(rules) == 0 {
+		return nil, nil // no valid sources; an Ingress NP with zero rules would deny all ingress
+	}
+
+	np := kubernetes.CreateNetworkPolicy(c.ComponentName+"-allow-endpoint-ingress", app.Namespace)
+	np.Labels = nil
+	np.Annotations = nil
+	kubernetes.SetNetworkPolicyPodSelector(np, *c.Endpoint.PodSelector)
+	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress})
+
+	proto := corev1.ProtocolTCP
+	for _, r := range rules {
+		rule := networkingv1.NetworkPolicyIngressRule{}
+		for _, src := range r.Sources {
+			peer := networkingv1.NetworkPolicyPeer{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": src.Namespace},
+				},
+				PodSelector: src.PodSelector,
+			}
+			kubernetes.AddNetworkPolicyIngressPeer(&rule, peer)
+		}
+		for _, p := range c.Endpoint.Ports {
+			port := p
+			kubernetes.AddNetworkPolicyIngressPort(&rule, networkingv1.NetworkPolicyPort{
+				Port:     &port,
+				Protocol: &proto,
+			})
+		}
+		kubernetes.AddNetworkPolicyIngressRule(np, rule)
+	}
+
+	obj := client.Object(np)
+	return []*client.Object{&obj}, nil
+}
+
+// synthesizeEndpointIngressNetworkPolicies traverses all leaf bundles and, for each primary
+// component application with platform-supplied ingress peers, appends
+// componentEndpointIngressPolicyConfig applications emitting per-endpoint ingress
+// NetworkPolicies. The signal is non-authorable (TransformContext.IngressPeers), so this is a
+// no-op on the kurel path where no peers are supplied.
+//
+// Runs as a cluster post-build stage (Phase 4), after trait application — so the synthesized
+// policies are not subject to Enforceable.ApplyPolicy (intentional).
+func synthesizeEndpointIngressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, ingressPeers map[string][]netpol.IngressPeer) {
+	if cluster == nil || len(ingressPeers) == 0 {
+		return
+	}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		var autoApps []*stack.Application
+		for _, app := range bundle.Applications {
+			// Match the primary component app by identity, not just by name (same guard as
+			// the egress path): a trait sub-app whose name collides with a component name
+			// could otherwise attach the policy beside the wrong app in the wrong bundle.
+			entry, ok := componentMap[app.Name]
+			if !ok || app != entry.app {
+				continue
+			}
+			groups := groupIngressPeers(ingressPeers[app.Name])
+			// Multi-endpoint rule (v1): the NP name has no per-endpoint discriminator, so a
+			// component with >1 distinct endpoint would collide. Only postgresql produces
+			// endpoints today (exactly one), so this is unreachable; skip rather than emit a
+			// colliding or partial policy.
+			// TODO(pooler): suffix per-endpoint NP names when a second endpoint is added.
+			if len(groups) != 1 {
+				continue
+			}
+			autoApps = append(autoApps, stack.NewApplication(
+				app.Name+"-allow-endpoint-ingress",
+				app.Namespace,
+				&componentEndpointIngressPolicyConfig{
+					ComponentName: app.Name,
+					Endpoint:      groups[0].Endpoint,
+					Rules:         groups[0].Rules,
+				},
+			))
+		}
+		bundle.Applications = append(bundle.Applications, autoApps...)
+	})
+}
+
+type endpointIngressGroup struct {
+	Endpoint netpol.Endpoint
+	Rules    []endpointIngressRule
+}
+
+// groupIngressPeers normalizes platform-supplied ingress peers into per-endpoint groups for
+// deterministic, fail-closed output: it drops peers whose endpoint is malformed or whose sources
+// are all namespace-wide, groups the survivors by endpoint (selector + ports), deduplicates
+// identical source sets within a group, and sorts groups + rules by canonical key.
+func groupIngressPeers(peers []netpol.IngressPeer) []endpointIngressGroup {
+	byEndpoint := map[string]*endpointIngressGroup{}
+	var order []string
+	for _, p := range peers {
+		if !endpointValid(p.Endpoint) {
+			continue
+		}
+		srcs := validSources(p.Sources)
+		if len(srcs) == 0 {
+			continue
+		}
+		ports := make([]intstr.IntOrString, len(p.Endpoint.Ports))
+		copy(ports, p.Endpoint.Ports)
+		sortIntOrStringPorts(ports)
+		ep := netpol.Endpoint{PodSelector: p.Endpoint.PodSelector, Ports: ports}
+		ek := endpointKey(ep)
+		g, ok := byEndpoint[ek]
+		if !ok {
+			g = &endpointIngressGroup{Endpoint: ep}
+			byEndpoint[ek] = g
+			order = append(order, ek)
+		}
+		sk := sourcesKey(srcs)
+		dup := false
+		for _, r := range g.Rules {
+			if sourcesKey(r.Sources) == sk {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			g.Rules = append(g.Rules, endpointIngressRule{Sources: srcs})
+		}
+	}
+	out := make([]endpointIngressGroup, 0, len(order))
+	for _, ek := range order {
+		g := byEndpoint[ek]
+		sort.SliceStable(g.Rules, func(i, j int) bool { return sourcesKey(g.Rules[i].Sources) < sourcesKey(g.Rules[j].Sources) })
+		out = append(out, *g)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return endpointKey(out[i].Endpoint) < endpointKey(out[j].Endpoint) })
+	return out
+}
+
+// endpointKey returns a canonical dedup/ordering key for an endpoint (matchLabels + Type-tagged
+// ports, mirroring egressPeerKey).
+func endpointKey(e netpol.Endpoint) string {
+	labelParts := make([]string, 0, len(e.PodSelector.MatchLabels))
+	for lk, lv := range e.PodSelector.MatchLabels {
+		labelParts = append(labelParts, lk+"="+lv)
+	}
+	sort.Strings(labelParts)
+	portKeys := make([]string, 0, len(e.Ports))
+	for _, pt := range e.Ports {
+		portKeys = append(portKeys, fmt.Sprintf("%d:%s", pt.Type, pt.String()))
+	}
+	return fmt.Sprintf("sel:%s;ports:%s", strings.Join(labelParts, ","), strings.Join(portKeys, "|"))
+}
+
+// sourcesKey returns a canonical dedup/ordering key for a source set — per-source keys sorted
+// so order does not affect the key. (validSources already sorts, but sort defensively.)
+func sourcesKey(sources []netpol.TrafficSource) string {
+	srcKeys := make([]string, 0, len(sources))
+	for _, s := range sources {
+		srcKeys = append(srcKeys, trafficSourceKey(s))
+	}
+	sort.Strings(srcKeys)
+	return strings.Join(srcKeys, "|")
 }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -50,6 +50,11 @@ type TransformContext struct {
 	// input; a downstream platform embedding launcher sets its own domain. Validated as a
 	// DNS-1123 subdomain — an invalid value fails the transform.
 	Domain string
+	// IngressPeers carries platform-supplied, graph-derived target-side allows keyed by OAM
+	// component name (the endpoint owner). Each IngressPeer names an endpoint (selector +
+	// ports) and the sources allowed to reach it. Non-authorable, like EgressPeers. nil on the
+	// kurel path, where endpoint-ingress synthesis is a no-op.
+	IngressPeers map[string][]netpol.IngressPeer
 }
 
 // fluxNamespaceSettable is implemented by ApplicationConfig types that emit
@@ -269,6 +274,31 @@ func (t *Transformer) EvaluateProfile(profile *ClusterProfile) (*ClusterProfile,
 	return &result, nil
 }
 
+// ComponentEndpoints returns the endpoints declared by the handler for comp.Type, or
+// (nil, nil) if comp is nil, no handler is registered, or the handler is not an
+// EndpointProvider. It returns an error if a registered provider yields a malformed endpoint
+// (fail-fast: a broken handler surfaces early, not as a silent connectivity outage). Consumed
+// by a downstream platform to learn endpoint selectors when building its dependency graph.
+func (t *Transformer) ComponentEndpoints(comp *Component) ([]netpol.Endpoint, error) {
+	if comp == nil {
+		return nil, nil
+	}
+	ep, ok := t.findComponentHandler(comp.Type).(EndpointProvider)
+	if !ok {
+		return nil, nil
+	}
+	eps, err := ep.Endpoints(comp)
+	if err != nil {
+		return nil, err
+	}
+	for i, e := range eps {
+		if err := validateEndpoint(e); err != nil {
+			return nil, errors.Wrapf(err, "component %q endpoint[%d]", comp.Name, i)
+		}
+	}
+	return eps, nil
+}
+
 func (t *Transformer) findComponentHandler(componentType string) ComponentHandler {
 	return t.componentHandlers[componentType]
 }
@@ -379,6 +409,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	}
 	synthesizeNetworkPolicies(cluster, labelKey)
 	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey)
+	synthesizeEndpointIngressNetworkPolicies(cluster, componentMap, ctx.IngressPeers)
 	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
 
 	return cluster, policyResult, nil


### PR DESCRIPTION
Closes #213. Adds the **target side** of app→infra connection synthesis (crane#333 Phase 2's launcher half). #214 was closed as a duplicate; its hardening detail is folded in here.

## Problem

The inbound (`{comp}-allow-ingress-traffic`) and egress (`{comp}-allow-egress-traffic`) families select a component's *own* pods via the component-provenance label. But an operator-managed target — e.g. a CloudNativePG cluster's instance pods, labelled `cnpg.io/cluster` — carries no such label, so a namespace `default-deny` still blocks consumers. A source-egress allow is only half a connection; the target namespace is ingress-isolated too.

## Design — third synthesized family `{comp}-allow-endpoint-ingress`

Two halves:

- **Producer** — optional `EndpointProvider` component interface + `Transformer.ComponentEndpoints(comp)` dispatch. A handler declares its in-cluster endpoints (selector + ports) launcher knows deterministically; postgresql declares `cnpg.io/cluster:<component>`:5432. `ComponentEndpoints` is nil-safe and returns an **error** on a malformed provider endpoint (a launcher-internal bug should surface early). A downstream platform calls this to learn the operator selector without hardcoding it, and to build its dependency graph. Not read by synthesis.
- **Emitter** — new non-authorable `TransformContext.IngressPeers` channel (platform-supplied, graph-derived, like `EgressPeers`) + `synthesizeEndpointIngressNetworkPolicies`. Emits an Ingress `NetworkPolicy` whose podSelector is the **endpoint's own selector** — deliberately **not** the component-label key.

New `netpol.Endpoint` / `netpol.IngressPeer` types. **Fail-closed contract:** unlike `TrafficSource` (nil selector = all pods), each `IngressPeer.Source` must carry a namespace + non-empty matchLabels pod selector (matchLabels-only); namespace-wide sources are dropped, and a policy with no valid rule is not emitted (an Ingress NP with zero rules would deny all ingress). Output is byte-stable (sources + groups canonically sorted). A component with >1 distinct endpoint is skipped (name-collision guard; `TODO(pooler)` — postgresql yields exactly one endpoint today).

## Out of scope

- Egress nil-selector hardening (a contract change to a shipped type) — separate follow-up.
- webservice/worker endpoints (container-port-semantics decision); pooler / multi-endpoint NP naming; `expose.backendRefs` (deferred from #211); UDP.

## Tests (TDD)

`validateEndpoint`; dispatch (provider / non-provider / unknown / nil / malformed→error); `Generate` shape + fail-closed (nil rules, empty sources, namespace-wide source, invalid endpoint); `validSources` invalid-variant table; stable source ordering; grouping dedup + two-endpoint; synthesize append / no-op / identity guard / multi-endpoint skip; postgresql producer; end-to-end (podSelector exactly `{cnpg.io/cluster: <comp>}`).

## Verification

`mise run verify` (tidy + lint 0 issues + tests), `mise run build`; `check-forbidden-terms.sh --full-tree` **and** `--diff origin/main`; `check-doc-sync.sh`; `check-links.sh`; `check-doc-gate.sh` (READMEs for `pkg/oam`, `pkg/oam/netpol`, `pkg/oam/builtin/components`).

## Coordination

The endpoint selector `cnpg.io/cluster` is domain-independent — no interaction with the parametrized-domain work. After merge, cut the next launcher alpha; a downstream consumer then supplies `IngressPeers` + calls `ComponentEndpoints`, and retires its authored stopgap policies. Refs #213.