### PR TITLE
refactor(oam): tighten builtin rbac and flux patch schemas

### DIFF
--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -12,8 +12,11 @@ Every built-in trait handler also implements `oam.PropertySchemaProvider`
 (`PropertySchema()`), declaring a constrained schema for its user-facing properties so
 the downstream runtime can validate them before invocation. This includes the platform-reserved keys a
 handler reads from merged properties (e.g. `networkPolicy`, `allowedHostnameWildcard`,
-`controllerType`). Deeply nested or K8s-adjacent shapes are kept shallow/open
-(`additionalProperties`) rather than modeled field-by-field; `prune-protection` accepts no
+`controllerType`). Some deeply nested or K8s-adjacent shapes are kept shallow/open
+(`additionalProperties`) rather than modeled field-by-field, but strictness-sensitive traits are
+**closed**: the `rbac` rule object and the `fluxcd-patches` patch item and its `target` selector
+enumerate their fields and set `additionalProperties: false` (unknown keys rejected), matching the
+downstream single-owner adoption of these builtins. `prune-protection` accepts no
 properties and so declares an empty schema. Every property (including nested object fields and
 array item schemas at every depth) carries a `Description`, surfaced in the downstream runtime's generated Handler
 API Reference.

--- a/pkg/oam/builtin/traits/patches.go
+++ b/pkg/oam/builtin/traits/patches.go
@@ -20,8 +20,9 @@ func (h *FluxCDPatchesHandler) CanHandle(traitType string) bool {
 }
 
 // PropertySchema declares the fluxcd-patches trait's user-facing properties. Each
-// patch carries a strategic-merge/JSON6902 body plus a kustomize target selector,
-// kept open beyond the enumerated fields.
+// patch carries a strategic-merge/JSON6902 body plus an optional kustomize target
+// selector. Both the patch item and its target selector are closed objects: only the
+// enumerated fields are accepted and unknown keys are rejected.
 func (h *FluxCDPatchesHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"patches": {
@@ -30,11 +31,24 @@ func (h *FluxCDPatchesHandler) PropertySchema() map[string]oam.PropertySchema {
 			Description: "Strategic-merge or JSON6902 patches applied to the generated Kustomization.",
 			Items: &oam.PropertySchema{
 				Type:                 oam.PropertyTypeObject,
-				AdditionalProperties: true,
+				AdditionalProperties: false,
 				Description:          "A single patch with its body and optional target selector.",
 				Properties: map[string]oam.PropertySchema{
-					"patch":  {Type: oam.PropertyTypeString, Required: true, Description: "Patch body as a strategic-merge YAML or JSON6902 document."},
-					"target": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Kustomize target selector (group/version/kind/name/namespace/labelSelector/annotationSelector) restricting which resources the patch applies to."},
+					"patch": {Type: oam.PropertyTypeString, Required: true, Description: "Patch body as a strategic-merge YAML or JSON6902 document."},
+					"target": {
+						Type:                 oam.PropertyTypeObject,
+						AdditionalProperties: false,
+						Description:          "Kustomize target selector restricting which resources the patch applies to.",
+						Properties: map[string]oam.PropertySchema{
+							"group":              {Type: oam.PropertyTypeString, Description: "API group of the resources to patch."},
+							"version":            {Type: oam.PropertyTypeString, Description: "API version of the resources to patch."},
+							"kind":               {Type: oam.PropertyTypeString, Description: "Kind of the resources to patch."},
+							"name":               {Type: oam.PropertyTypeString, Description: "Name of the resource to patch."},
+							"namespace":          {Type: oam.PropertyTypeString, Description: "Namespace of the resources to patch."},
+							"labelSelector":      {Type: oam.PropertyTypeString, Description: "Label selector restricting the resources to patch."},
+							"annotationSelector": {Type: oam.PropertyTypeString, Description: "Annotation selector restricting the resources to patch."},
+						},
+					},
 				},
 			},
 		},

--- a/pkg/oam/builtin/traits/patches_test.go
+++ b/pkg/oam/builtin/traits/patches_test.go
@@ -24,6 +24,42 @@ func TestFluxCDPatchesHandler_CanHandle(t *testing.T) {
 	}
 }
 
+// TestFluxCDPatchesHandler_Schema_Strict guards the strict shape: the patch item and
+// its target selector are closed objects (unknown keys rejected), and
+// the target enumerates the seven kustomize selector fields as strings so valid
+// selectors still pass. Downstream consumers preflight against this schema.
+func TestFluxCDPatchesHandler_Schema_Strict(t *testing.T) {
+	schema := (&traits.FluxCDPatchesHandler{}).PropertySchema()
+	patches, ok := schema["patches"]
+	if !ok {
+		t.Fatal("schema missing 'patches' property")
+	}
+	if patches.Items == nil {
+		t.Fatal("patches.Items is nil")
+	}
+	if patches.Items.AdditionalProperties {
+		t.Error("patch item must be a closed object (AdditionalProperties=false) so unknown keys are rejected")
+	}
+
+	target, ok := patches.Items.Properties["target"]
+	if !ok {
+		t.Fatal("patch item missing 'target' property")
+	}
+	if target.AdditionalProperties {
+		t.Error("patch target must be a closed object (AdditionalProperties=false) so unknown keys in target are rejected")
+	}
+	for _, field := range []string{"group", "version", "kind", "name", "namespace", "labelSelector", "annotationSelector"} {
+		p, ok := target.Properties[field]
+		if !ok {
+			t.Errorf("target missing enumerated selector field %q", field)
+			continue
+		}
+		if p.Type != oam.PropertyTypeString {
+			t.Errorf("target.%s type = %q, want %q", field, p.Type, oam.PropertyTypeString)
+		}
+	}
+}
+
 func TestFluxCDPatchesHandler_Apply_AppendsToBundlePatches(t *testing.T) {
 	h := &traits.FluxCDPatchesHandler{}
 	trait := &oam.Trait{

--- a/pkg/oam/builtin/traits/rbac.go
+++ b/pkg/oam/builtin/traits/rbac.go
@@ -21,7 +21,8 @@ func (h *RBACHandler) CanHandle(traitType string) bool {
 }
 
 // PropertySchema declares the rbac trait's user-facing properties. Each rule is a
-// K8s PolicyRule-shaped object, kept open beyond the enumerated fields.
+// closed K8s-PolicyRule-shaped object: only the enumerated fields are accepted and
+// unknown keys are rejected. `resources` and `verbs` are required.
 func (h *RBACHandler) PropertySchema() map[string]oam.PropertySchema {
 	return map[string]oam.PropertySchema{
 		"rules": {
@@ -30,12 +31,12 @@ func (h *RBACHandler) PropertySchema() map[string]oam.PropertySchema {
 			Description: "Policy rules granted to the component's ServiceAccount.",
 			Items: &oam.PropertySchema{
 				Type:                 oam.PropertyTypeObject,
-				AdditionalProperties: true,
+				AdditionalProperties: false,
 				Description:          "A single RBAC policy rule.",
 				Properties: map[string]oam.PropertySchema{
 					"apiGroups": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "An API group the rule applies to."}, Description: "API groups the rule applies to."},
-					"resources": {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A resource type the rule applies to."}, Description: "Resource types the rule applies to."},
-					"verbs":     {Type: oam.PropertyTypeArray, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A verb the rule permits."}, Description: "Verbs the rule permits on the listed resources."},
+					"resources": {Type: oam.PropertyTypeArray, Required: true, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A resource type the rule applies to."}, Description: "Resource types the rule applies to."},
+					"verbs":     {Type: oam.PropertyTypeArray, Required: true, Items: &oam.PropertySchema{Type: oam.PropertyTypeString, Description: "A verb the rule permits."}, Description: "Verbs the rule permits on the listed resources."},
 				},
 			},
 		},

--- a/pkg/oam/builtin/traits/rbac_test.go
+++ b/pkg/oam/builtin/traits/rbac_test.go
@@ -26,6 +26,38 @@ func TestRBACHandler_CanHandle(t *testing.T) {
 	}
 }
 
+// TestRBACHandler_Schema_Strict guards the strict shape of the rbac schema: a rule
+// is a closed object (unknown keys rejected) and resources/verbs are required.
+// Downstream consumers preflight against this schema, so a regression here would
+// silently relax their strict validation.
+func TestRBACHandler_Schema_Strict(t *testing.T) {
+	schema := (&traits.RBACHandler{}).PropertySchema()
+	rules, ok := schema["rules"]
+	if !ok {
+		t.Fatal("schema missing 'rules' property")
+	}
+	if rules.Items == nil {
+		t.Fatal("rules.Items is nil")
+	}
+	if rules.Items.AdditionalProperties {
+		t.Error("rules item must be a closed object (AdditionalProperties=false) so unknown keys in a rule are rejected")
+	}
+	for _, field := range []string{"resources", "verbs"} {
+		p, ok := rules.Items.Properties[field]
+		if !ok {
+			t.Fatalf("rules item missing %q property", field)
+		}
+		if !p.Required {
+			t.Errorf("rules item %q must be Required", field)
+		}
+	}
+	if p, ok := rules.Items.Properties["apiGroups"]; !ok {
+		t.Fatal("rules item missing \"apiGroups\" property")
+	} else if p.Required {
+		t.Error("rules item \"apiGroups\" must stay optional (not Required)")
+	}
+}
+
 func TestRBACHandler_Apply_NamespaceOnly(t *testing.T) {
 	h := &traits.RBACHandler{}
 	trait := &oam.Trait{


### PR DESCRIPTION
Closes #228.

Tightens the `rbac` and `fluxcd-patches` builtin trait `PropertySchema()` to strict mode so a downstream consumer that preflights against the registered handler's schema keeps its "reject unknown fields; no silent fallbacks" behavior when adopting these builtins as the single source.

## Changes
- **`rbac`**: rule object set to `additionalProperties: false`; `resources` and `verbs` marked `Required` (`apiGroups` stays optional). Runtime parse already enforced non-empty resources/verbs — this rejects earlier at the schema layer.
- **`fluxcd-patches`**: patch item set to `additionalProperties: false`; `target` selector modeled with the seven kustomize fields (`group`, `version`, `kind`, `name`, `namespace`, `labelSelector`, `annotationSelector`, all string) then closed with `additionalProperties: false`. These are exactly the fields `Apply` already reads into `stack.PatchSelector`, so there is no behavior change.
- Doc comments and the package README updated to reflect the closed shapes (doc-sync).

## Notes
- Schema-strictness only — no change to rendered output.
- New schema-shape regression tests (`TestRBACHandler_Schema_Strict`, `TestFluxCDPatchesHandler_Schema_Strict`) assert the closed shape and required fields, so consumers rely on a launcher regression guard rather than pin-bump inspection.

## Verification
- `go build ./...`, `go test ./...` pass
- `golangci-lint run` — 0 issues
- `check-doc-sync.sh` / `doc-gate` — OK