### PR TITLE
feat(oam/components): EndpointProvider for webservice (app→app synthesis)

### DIFF
--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -43,6 +43,11 @@ share these fields: `image` (validated — no untagged/`latest`), `env` (with
 ## Per-type highlights
 
 - **webservice / worker** — `image`, `replicas` (default 1), `port` (webservice).
+  The `webservice` handler implements the optional `oam.EndpointProvider`: it declares its own
+  pods (`app: <component-name>`) on the declared `port` (its single `port` property drives both
+  the container port and the Service port), letting a downstream platform synthesize generic
+  app→app connections targeting a webservice. `worker` declares no in-cluster port and emits no
+  Service, so it deliberately advertises no endpoint (not an `EndpointProvider`).
 - **statefulset** — `volumeClaimTemplates` (`name`, `size`, `storageClass`,
   `accessModes`, `mountPath`), `serviceName` (headless).
 - **daemonset** — `tolerations` (`key`/`operator`/`value`/`effect`); `port`

--- a/pkg/oam/builtin/components/endpoint_test.go
+++ b/pkg/oam/builtin/components/endpoint_test.go
@@ -7,6 +7,47 @@ import (
 	"github.com/go-kure/launcher/pkg/oam/builtin/components"
 )
 
+func TestWebserviceHandler_Endpoints(t *testing.T) {
+	h := &components.WebserviceHandler{}
+
+	tests := []struct {
+		name     string
+		props    map[string]any
+		wantPort int32
+	}{
+		{name: "default port", props: nil, wantPort: 80},
+		{name: "explicit port", props: map[string]any{"port": 8080}, wantPort: 8080},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			eps, err := h.Endpoints(&oam.Component{Name: "api", Type: "webservice", Properties: tt.props})
+			if err != nil {
+				t.Fatalf("Endpoints: %v", err)
+			}
+			if len(eps) != 1 {
+				t.Fatalf("expected 1 endpoint, got %d", len(eps))
+			}
+			sel := eps[0].PodSelector
+			if sel == nil || sel.MatchLabels["app"] != "api" || len(sel.MatchLabels) != 1 {
+				t.Errorf("selector = %v, want app=api", sel)
+			}
+			if len(eps[0].Ports) != 1 || eps[0].Ports[0].IntVal != tt.wantPort {
+				t.Errorf("ports = %v, want [%d]", eps[0].Ports, tt.wantPort)
+			}
+		})
+	}
+}
+
+// TestWorkerHandler_NotEndpointProvider documents the #225 decision: worker declares no
+// in-cluster port and emits no Service, so it deliberately does not implement EndpointProvider
+// (ComponentEndpoints then returns (nil,nil) for a worker component).
+func TestWorkerHandler_NotEndpointProvider(t *testing.T) {
+	var h any = &components.WorkerHandler{}
+	if _, ok := h.(oam.EndpointProvider); ok {
+		t.Error("WorkerHandler should not implement oam.EndpointProvider (worker has no in-cluster port)")
+	}
+}
+
 func TestPostgresqlHandler_Endpoints(t *testing.T) {
 	h := &components.PostgresqlHandler{}
 	eps, err := h.Endpoints(&oam.Component{Name: "orders-db", Type: "postgresql"})

--- a/pkg/oam/builtin/components/webservice.go
+++ b/pkg/oam/builtin/components/webservice.go
@@ -5,11 +5,13 @@ import (
 	"github.com/go-kure/kure/pkg/stack"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/errors"
 	"github.com/go-kure/launcher/pkg/oam"
+	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
 
 // WebserviceHandler handles OAM webservice components.
@@ -18,6 +20,22 @@ type WebserviceHandler struct{}
 // CanHandle returns true for webservice component type.
 func (h *WebserviceHandler) CanHandle(componentType string) bool {
 	return componentType == "webservice"
+}
+
+// Endpoints implements oam.EndpointProvider: a webservice's in-cluster endpoint is its own pods
+// (labelled app=<component name>) on the declared container/service port. This lets a downstream
+// platform consumer synthesize generic app→app connections whose target is a webservice, the same
+// way it does for a postgresql target. The webservice's single `port` property drives both the
+// container port and the Service port (TargetPort == Port), so there is one endpoint per component.
+func (h *WebserviceHandler) Endpoints(component *oam.Component) ([]netpol.Endpoint, error) {
+	port := int32(80)
+	if p, ok := toInt32(component.Properties["port"]); ok {
+		port = p
+	}
+	return []netpol.Endpoint{{
+		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": component.Name}},
+		Ports:       []intstr.IntOrString{intstr.FromInt32(port)},
+	}}, nil
 }
 
 // PropertySchema declares the webservice component's user-facing properties.


### PR DESCRIPTION
## Summary

Implements `oam.EndpointProvider` on `WebserviceHandler` so a downstream platform consumer can synthesize generic **app→app** connections whose target is a `webservice` — the same way #213 enabled it for `postgresql` targets.

- `WebserviceHandler.Endpoints` returns one `netpol.Endpoint`: the component's own pods (`app: <name>`) on its declared `port`.
- `worker` is a documented **no-op**: it declares no in-cluster port and emits no Service, so it deliberately does not implement `EndpointProvider` (`ComponentEndpoints` returns `(nil,nil)` for a worker component).

## Closing the issue's open questions (#225)

- **Port semantics**: a webservice's single `port` property drives both the container port and the Service port (`TargetPort == Port`), so there is no service-vs-container-port ambiguity to resolve — one endpoint per component. The `[]Endpoint` API already accommodates future multi-port webservices.
- **worker**: no `port` property, no Service ⇒ a worker endpoint would be meaningless; hence the no-op.

## Scope

No change to the synthesis engine or the `IngressPeers`/`EgressPeers` channels — purely additive `EndpointProvider` coverage. Follows #213; complements the postgresql provider.

## Tests

- `WebserviceHandler.Endpoints` (default + explicit port) → correct `app=<name>` selector + port.
- `WorkerHandler` asserted **not** to implement `oam.EndpointProvider`.

## Docs

- `pkg/oam/builtin/components/README.md` updated (webservice EndpointProvider; worker N/A).

Closes #225