### PR TITLE
fix(oam/netpol): fail fast on invalid egress peers

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -37,7 +37,11 @@ each a **separate** additive resource (the authored `networkpolicy` /
 - **Egress** (`{comp}-allow-egress-traffic`) — from `TransformContext.EgressPeers`, a
   downstream-supplied, non-authorable synthesis input (graph-derived dependency peers; never
   set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a
-  caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op.
+  caller supplies no peers (e.g. the kurel CLI), so synthesis is then a no-op. **Fail-fast**
+  (aligned with the endpoint-ingress family): a peer that carries ports but a nil, empty, or
+  expression-bearing pod selector is a producer bug and fails the transform with an error — it
+  would otherwise emit a namespace-wide egress allow. A peer with **no ports** is the documented
+  escape hatch and is silently skipped (the destination stays authored).
 - **Endpoint ingress** (`{comp}-allow-endpoint-ingress`) — the **target side** of a
   connection, from `TransformContext.IngressPeers` (a platform-supplied, non-authorable
   graph-derived input). Each `netpol.IngressPeer` names an `Endpoint` (pod selector + ports)

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -301,7 +301,7 @@ func TestTransform_EgressPeers_SynthesizesEgressNetworkPolicy(t *testing.T) {
 	ctx := oam.TransformContext{
 		Namespace: "default",
 		EgressPeers: map[string][]netpol.EgressPeer{
-			"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+			"web": {{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 		},
 	}
 	cluster, _, err := tr.TransformWithPolicy(app, ctx)
@@ -318,6 +318,33 @@ func TestTransform_EgressPeers_SynthesizesEgressNetworkPolicy(t *testing.T) {
 	// Default egress source-pod selector is gokure.dev/component.
 	if sel := synthesizedPodSelector(t, cluster, "web-allow-egress-traffic"); sel["gokure.dev/component"] != "web" {
 		t.Errorf("default egress podSelector = %v, want gokure.dev/component=web", sel)
+	}
+}
+
+// End-to-end: a malformed non-authorable egress peer (ported but selector-less) fails the whole
+// transform (fail-fast), rather than silently emitting a namespace-wide egress allow.
+func TestTransform_EgressPeers_InvalidSelector_Errors(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "web",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+			}},
+		},
+	}
+	ctx := oam.TransformContext{
+		Namespace: "default",
+		EgressPeers: map[string][]netpol.EgressPeer{
+			"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}}, // ported, selector-less
+		},
+	}
+	if _, _, err := tr.TransformWithPolicy(app, ctx); err == nil {
+		t.Error("expected TransformWithPolicy to fail on a ported selector-less egress peer, got nil")
 	}
 }
 
@@ -367,7 +394,7 @@ func TestTransform_ComponentLabelKey_Override(t *testing.T) {
 				Namespace:         "default",
 				ComponentLabelKey: tc.key,
 				EgressPeers: map[string][]netpol.EgressPeer{
-					"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+					"web": {{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 				},
 			}
 			cluster, _, err := tr.TransformWithPolicy(app, ctx)

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -8,10 +8,14 @@ Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
   platform-reserved `networkPolicy.trafficSources`. It lives outside `pkg/oam` so that
   both the synthesis stage (`pkg/oam`) and the routing trait configs that expose the
   collected sources (`pkg/oam/builtin/traits`) can import it without an import cycle.
-- `EgressPeer` — one allowed **egress** destination (namespace selector + optional pod
-  selector + ports). Unlike `TrafficSource`, it is a downstream-supplied, non-authorable
-  synthesis input carried on `TransformContext.EgressPeers` (never set from OAM YAML or
-  capability rendering); it has no trait-side producer.
+- `EgressPeer` — one allowed **egress** destination (namespace selector + pod selector +
+  ports). Unlike `TrafficSource`, it is a downstream-supplied, non-authorable synthesis input
+  carried on `TransformContext.EgressPeers` (never set from OAM YAML or capability rendering);
+  it has no trait-side producer. **Fail-fast contract** (aligned with the endpoint-ingress
+  family): a peer with ports but a nil, empty-matchLabels, or expression-bearing pod selector is
+  a producer bug and is rejected with a build error — it would otherwise emit a namespace-wide
+  egress allow (`to.PodSelector` nil = all pods). A peer with **no ports** is the documented
+  escape hatch and is silently skipped (destination stays authored).
 - `Endpoint` — a component's declared in-cluster data-plane endpoint: a pod selector
   (matchLabels only) + ports. Namespace is deliberately absent (the caller knows the target's
   namespace). Declared by a component handler via the optional `oam.EndpointProvider`.

--- a/pkg/oam/netpol/types.go
+++ b/pkg/oam/netpol/types.go
@@ -21,11 +21,17 @@ type TrafficSource struct {
 // per-component egress NetworkPolicy. It is a downstream-supplied, non-authorable
 // synthesis input surfaced from the downstream runtime's dependency graph — OAM authors cannot
 // set it. Namespace is required; PodSelector narrows to specific pods within
-// that namespace (matchLabels only; nil = all pods); Ports are the destination
-// ports (TCP). A peer with no Ports is skipped by synthesis.
+// that namespace (matchLabels only); Ports are the destination ports (TCP).
+//
+// Fail-fast (aligned with the endpoint-ingress family): a peer that carries Ports but a nil,
+// empty-matchLabels, or expression-bearing PodSelector is a producer bug and is rejected with a
+// build error — it would otherwise emit a namespace-wide egress allow (to.PodSelector nil/empty =
+// all pods). A peer with no Ports is the documented escape hatch: it is silently skipped by
+// synthesis (the destination stays authored), so a ported-but-selector-less peer never slips
+// through as "all pods".
 type EgressPeer struct {
 	Namespace   string
-	PodSelector *metav1.LabelSelector // nil = all pods; matchLabels only
+	PodSelector *metav1.LabelSelector // required matchLabels when Ports set (else the peer is skipped)
 	Ports       []intstr.IntOrString
 }
 

--- a/pkg/oam/netpol_egress_synthesis_test.go
+++ b/pkg/oam/netpol_egress_synthesis_test.go
@@ -97,8 +97,9 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 				Ports:       []intstr.IntOrString{intstr.FromInt32(5432)},
 			},
 			{
-				Namespace: "cache",
-				Ports:     []intstr.IntOrString{intstr.FromInt32(6379)},
+				Namespace:   "cache",
+				PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "redis"}},
+				Ports:       []intstr.IntOrString{intstr.FromInt32(6379)},
 			},
 		},
 	}
@@ -128,7 +129,7 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 		t.Fatalf("expected 2 egress rules (one per peer), got %d", len(np.Spec.Egress))
 	}
 
-	// First peer: cache with no pod selector, port 6379/TCP.
+	// First peer: cache with pod selector app=redis, port 6379/TCP.
 	r0 := np.Spec.Egress[0]
 	if len(r0.To) != 1 {
 		t.Fatalf("rule 0: expected 1 peer, got %d", len(r0.To))
@@ -136,8 +137,8 @@ func TestComponentEgressPolicyConfig_Generate_Shape(t *testing.T) {
 	if got := r0.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; got != "cache" {
 		t.Errorf("rule 0 namespace selector = %q, want cache", got)
 	}
-	if r0.To[0].PodSelector != nil {
-		t.Errorf("rule 0: expected nil pod selector, got %v", r0.To[0].PodSelector)
+	if r0.To[0].PodSelector == nil || r0.To[0].PodSelector.MatchLabels["app"] != "redis" {
+		t.Errorf("rule 0 pod selector = %v, want app=redis", r0.To[0].PodSelector)
 	}
 	if len(r0.Ports) != 1 || r0.Ports[0].Port.IntVal != 6379 || *r0.Ports[0].Protocol != corev1.ProtocolTCP {
 		t.Errorf("rule 0 ports = %v, want [6379/TCP]", r0.Ports)
@@ -175,7 +176,7 @@ func TestComponentEgressPolicyConfig_PodSelectorKey(t *testing.T) {
 				ComponentName:  "web",
 				PodSelectorKey: tc.key,
 				Peers: []netpol.EgressPeer{
-					{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}},
+					{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}},
 				},
 			}
 			np := egressPolicyFromGenerate(t, cfg)
@@ -197,7 +198,7 @@ func TestComponentEgressPolicyConfig_Generate_SkipsEmptyPortPeer(t *testing.T) {
 		ComponentName: "web",
 		Peers: []netpol.EgressPeer{
 			{Namespace: "db", Ports: nil}, // no derivable ports → must be dropped
-			{Namespace: "cache", Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
+			{Namespace: "cache", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "redis"}}, Ports: []intstr.IntOrString{intstr.FromInt32(6379)}},
 		},
 	}
 	np := egressPolicyFromGenerate(t, cfg)
@@ -206,6 +207,67 @@ func TestComponentEgressPolicyConfig_Generate_SkipsEmptyPortPeer(t *testing.T) {
 	}
 	if got := np.Spec.Egress[0].To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; got != "cache" {
 		t.Errorf("surviving rule namespace = %q, want cache", got)
+	}
+}
+
+// --- fail-fast on invalid egress peers (#224) ---
+
+// TestSynthesizeEgress_ErrorsOnInvalidSelector is the loud layer: a ported peer with a nil,
+// empty-matchLabels, or expression-bearing selector fails the build rather than emitting a
+// namespace-wide egress allow. The len(Ports)==0 escape hatch stays a silent skip.
+func TestSynthesizeEgress_ErrorsOnInvalidSelector(t *testing.T) {
+	cases := []struct {
+		name    string
+		peer    netpol.EgressPeer
+		wantErr bool
+	}{
+		{"nil selector with ports", netpol.EgressPeer{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, true},
+		{"empty matchLabels with ports", netpol.EgressPeer{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, true},
+		{"matchExpressions with ports", netpol.EgressPeer{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{{Key: "app", Operator: metav1.LabelSelectorOpExists}}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, true},
+		{"nil selector no ports (escape hatch)", netpol.EgressPeer{Namespace: "db"}, false},
+		{"valid selector with ports", netpol.EgressPeer{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cluster, componentMap, _ := egressFixture("web", "default")
+			peers := map[string][]netpol.EgressPeer{"web": {tc.peer}}
+			err := synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
+			if tc.wantErr && err == nil {
+				t.Errorf("expected error for %s, got nil", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("unexpected error for %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
+// TestSynthesizeEgress_ErrorsOnUnmatchedComponent verifies the loud layer validates the whole
+// non-authorable input up front — a malformed peer keyed by a component absent from the bundle
+// still fails the build (a producer bug should not depend on which components render).
+func TestSynthesizeEgress_ErrorsOnUnmatchedComponent(t *testing.T) {
+	cluster, componentMap, _ := egressFixture("web", "default")
+	peers := map[string][]netpol.EgressPeer{
+		"other": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}}, // ported, selector-less
+	}
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel); err == nil {
+		t.Error("expected error for malformed peer on unmatched component, got nil")
+	}
+}
+
+// TestComponentEgressPolicyConfig_Generate_RejectsInvalidSelector is the residual layer: even a
+// directly-built config (bypassing the synthesis boundary) must not emit a ported peer with an
+// invalid selector.
+func TestComponentEgressPolicyConfig_Generate_RejectsInvalidSelector(t *testing.T) {
+	cfg := &componentEgressPolicyConfig{
+		ComponentName: "web",
+		Peers: []netpol.EgressPeer{
+			{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}, // ported, selector-less
+		},
+	}
+	app := stack.NewApplication("web-allow-egress-traffic", "default", cfg)
+	if _, err := cfg.Generate(app); err == nil {
+		t.Error("expected Generate to reject a ported selector-less peer, got nil")
 	}
 }
 
@@ -236,10 +298,12 @@ func egressAppNames(cluster *stack.Cluster) []string {
 func TestSynthesizeEgress_AppendsPolicy(t *testing.T) {
 	cluster, componentMap, primary := egressFixture("web", "default")
 	peers := map[string][]netpol.EgressPeer{
-		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+		"web": {{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
 
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeEgressNetworkPolicies: %v", err)
+	}
 
 	leaf := cluster.Node.Bundle
 	if len(leaf.Applications) != 2 {
@@ -259,7 +323,9 @@ func TestSynthesizeEgress_AppendsPolicy(t *testing.T) {
 
 func TestSynthesizeEgress_NoOpWhenNoPeers(t *testing.T) {
 	cluster, componentMap, _ := egressFixture("web", "default")
-	synthesizeEgressNetworkPolicies(cluster, componentMap, nil, ComponentLabel)
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, nil, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeEgressNetworkPolicies: %v", err)
+	}
 	if n := len(cluster.Node.Bundle.Applications); n != 1 {
 		t.Errorf("expected no synthesis for nil peers, got %d apps", n)
 	}
@@ -269,9 +335,11 @@ func TestSynthesizeEgress_NoOpWhenNoComponentMatch(t *testing.T) {
 	cluster, componentMap, _ := egressFixture("web", "default")
 	// Peers keyed by a component that is not present in the bundle/componentMap.
 	peers := map[string][]netpol.EgressPeer{
-		"other": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+		"other": {{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeEgressNetworkPolicies: %v", err)
+	}
 	if n := len(cluster.Node.Bundle.Applications); n != 1 {
 		t.Errorf("expected no synthesis for unmatched component, got %d apps", n)
 	}
@@ -290,10 +358,12 @@ func TestSynthesizeEgress_IdentityGuard(t *testing.T) {
 		"web": {component: Component{Name: "web"}, app: primary},
 	}
 	peers := map[string][]netpol.EgressPeer{
-		"web": {{Namespace: "db", Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
+		"web": {{Namespace: "db", PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "postgres"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}},
 	}
 
-	synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel)
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, peers, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeEgressNetworkPolicies: %v", err)
+	}
 
 	var policies []*stack.Application
 	for _, a := range bundle.Applications {

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -254,6 +254,12 @@ func (c *componentEgressPolicyConfig) Generate(app *stack.Application) ([]*clien
 	// Normalize here too (not just on the synthesis path) so a config built
 	// directly can never emit an all-ports rule from an empty-port peer.
 	for _, peer := range buildEgressPeers(c.Peers) {
+		// Residual defense behind the synthesizeEgressNetworkPolicies boundary check: reject a
+		// ported peer with an invalid selector here too, so a directly-built config can never
+		// emit a namespace-wide egress allow if the loud layer is ever bypassed.
+		if err := validateMatchLabelsSelector(peer.PodSelector); err != nil {
+			return nil, errors.Wrapf(err, "component %q egress peer", c.ComponentName)
+		}
 		// One egress rule per peer: a NetworkPolicyEgressRule is (any To) AND (any
 		// Ports), so grouping peers with differing ports would cross-product them
 		// (one peer reachable on another's ports).
@@ -291,9 +297,33 @@ func (c *componentEgressPolicyConfig) Generate(app *stack.Application) ([]*clien
 //
 // Runs as a cluster post-build stage (Phase 4), after trait application — so the
 // synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
-func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, egressPeers map[string][]netpol.EgressPeer, labelKey string) {
+//
+// Loud layer (fail-fast): it returns an error for any peer that carries ports but a nil, empty,
+// or expression-bearing pod selector — which would otherwise emit a namespace-wide egress allow
+// (to.PodSelector nil/empty = all pods in the namespace). EgressPeers is non-authorable
+// (platform-supplied), so a malformed peer is a producer bug; erroring surfaces it at build time
+// rather than silently widening egress — or, under default-deny, silently emitting a too-narrow
+// rule. The len(Ports)==0 skip stays a documented escape hatch, not an invariant violation.
+func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, egressPeers map[string][]netpol.EgressPeer, labelKey string) error {
 	if cluster == nil || len(egressPeers) == 0 {
-		return
+		return nil
+	}
+	// Validate the whole non-authorable input up front (sorted keys → deterministic first error),
+	// independent of which components happen to appear in a bundle.
+	comps := make([]string, 0, len(egressPeers))
+	for name := range egressPeers {
+		comps = append(comps, name)
+	}
+	sort.Strings(comps)
+	for _, name := range comps {
+		for i, p := range egressPeers[name] {
+			if len(p.Ports) == 0 {
+				continue // documented escape hatch: underivable ports → peer stays authored
+			}
+			if err := validateMatchLabelsSelector(p.PodSelector); err != nil {
+				return errors.Wrapf(err, "component %q egress peer[%d]", name, i)
+			}
+		}
 	}
 	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
 		var autoApps []*stack.Application
@@ -318,6 +348,7 @@ func synthesizeEgressNetworkPolicies(cluster *stack.Cluster, componentMap map[st
 		}
 		bundle.Applications = append(bundle.Applications, autoApps...)
 	})
+	return nil
 }
 
 // buildEgressPeers normalizes downstream-supplied egress peers for deterministic output:
@@ -383,15 +414,26 @@ func sortIntOrStringPorts(ports []intstr.IntOrString) {
 
 // --- Endpoint-ingress synthesis (platform-supplied, non-authorable target-side allows) ---
 
+// validateMatchLabelsSelector is the single shared selector validator for the synthesis paths:
+// a pod selector must be non-nil, carry non-empty matchLabels, and use matchLabels only (no
+// matchExpressions). Both the egress fail-fast path and endpoint validation route through it so
+// the "matchLabels-only, non-empty" rule cannot drift between the two synthesis families.
+func validateMatchLabelsSelector(sel *metav1.LabelSelector) error {
+	if sel == nil || len(sel.MatchLabels) == 0 {
+		return errors.New("pod selector must have non-empty matchLabels")
+	}
+	if len(sel.MatchExpressions) > 0 {
+		return errors.New("pod selector must be matchLabels-only (no matchExpressions)")
+	}
+	return nil
+}
+
 // validateEndpoint fails closed on a malformed endpoint: the pod selector is required and
 // matchLabels-only, and at least one port is required. Used to reject bad EndpointProvider
 // output (a launcher-internal bug) and to guard directly-built endpoint-ingress configs.
 func validateEndpoint(e netpol.Endpoint) error {
-	if e.PodSelector == nil || len(e.PodSelector.MatchLabels) == 0 {
-		return errors.New("endpoint pod selector must have non-empty matchLabels")
-	}
-	if len(e.PodSelector.MatchExpressions) > 0 {
-		return errors.New("endpoint pod selector must be matchLabels-only (no matchExpressions)")
+	if err := validateMatchLabelsSelector(e.PodSelector); err != nil {
+		return errors.Wrap(err, "endpoint")
 	}
 	if len(e.Ports) == 0 {
 		return errors.New("endpoint must declare at least one port")

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -408,7 +408,11 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 		labelKey = ComponentLabelKeyForDomain(ctx.Domain)
 	}
 	synthesizeNetworkPolicies(cluster, labelKey)
-	synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey)
+	// Egress synthesis fails fast on a malformed non-authorable peer (ported but selector-less):
+	// a producer bug should fail the build, not silently emit a namespace-wide egress allow.
+	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey); err != nil {
+		return nil, nil, err
+	}
 	synthesizeEndpointIngressNetworkPolicies(cluster, componentMap, ctx.IngressPeers)
 	postProcessFluxNamespace(cluster, ctx.FluxNamespace)
 


### PR DESCRIPTION
## Summary

Hardens the egress synthesis path to **fail fast** on an egress peer that carries ports but a nil, empty-`MatchLabels`, or expression-bearing `PodSelector` — which today silently emits a **namespace-wide** egress allow (`to.PodSelector` nil/empty = all pods in the selected namespace). This aligns egress with the fail-closed posture the endpoint-ingress path adopted in #213, but **error-first** rather than drop-first: `EgressPeers` is a non-authorable, platform-supplied input, so a malformed peer is a producer bug that should fail the build rather than silently widen egress (or, under default-deny, silently deny the intended traffic).

## Two layers (mirroring #213)

1. **Loud layer** — `synthesizeEgressNetworkPolicies` now returns `error` and validates the whole `EgressPeers` input up front (sorted keys → deterministic first error), independent of which components render. `TransformWithPolicy` propagates it via the existing fail-fast phase pattern.
2. **Residual layer** — `componentEgressPolicyConfig.Generate` rejects such peers too, in case the loud layer is ever bypassed by a directly-built config.

## Shared validator

Extracts `validateMatchLabelsSelector` (non-empty `matchLabels`, no `matchExpressions`) as the **single** selector validator reused by the egress path and `validateEndpoint`, so the "matchLabels-only, non-empty" rule cannot drift between the two synthesis families.

## Unchanged

The `len(Ports)==0` skip stays exactly as-is — a **documented escape hatch** (the destination stays authored), not an invariant violation. A ported-but-selector-less peer can no longer slip through as "all pods".

## Behavioral change (deliberate)

This changes a shipped, documented contract (`nil = all pods` for egress) into a build error. No known consumer relies on the old behavior. Docs updated in the same PR: `pkg/oam/README.md`, `pkg/oam/netpol/README.md`, and the `EgressPeer` type doc.

## Tests

- Loud layer: nil / empty-matchLabels / matchExpressions selectors with ports → error; ports-empty escape hatch → skipped (no error); valid selector → policy emitted.
- Whole-input validation: malformed peer on a component absent from the bundle still errors.
- Residual layer: `Generate` rejects a ported selector-less peer.
- End-to-end: `TransformWithPolicy` fails on a malformed egress peer; existing egress shape/ordering tests updated to valid selectors and still pass.

Closes #224