### PR TITLE
fix(changelog): scrub downstream references from generated notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,16 +617,11 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Check for downstream references
-      env:
-        EVENT_NAME: ${{ github.event_name }}
-        BASE_REF: ${{ github.base_ref }}
-      run: |
-        if [ "$EVENT_NAME" = "pull_request" ]; then
-          git fetch --depth=1 origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
-          bash site/scripts/check-forbidden-terms.sh --diff "origin/$BASE_REF"
-        else
-          bash site/scripts/check-forbidden-terms.sh --full-tree
-        fi
+      # Scan the whole tree on every event (pull_request and merge_group alike) so a PR
+      # can never be green while the merge queue would reject it. A diff-scoped PR check
+      # let pre-existing violations (e.g. release-generated CHANGELOG lines) pass the PR
+      # yet block admission at the queue.
+      run: bash site/scripts/check-forbidden-terms.sh --full-tree
 
     - name: Read Hugo version from mise.toml
       id: hugo-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Target wharf.zone/component in synthesized NetworkPolicies
+- Target the platform component label in synthesized NetworkPolicies
 - Parametrize the platform label/annotation domain (default gokure.dev)
 - Guard against launcher leading kure on shared direct deps
 - Add EndpointProvider and endpoint-ingress NetworkPolicy synthesis
@@ -358,7 +358,7 @@ All notable changes to this project will be documented in this file.
 - Implement helmchart delivery: template (#83)
 - Allow routing traits on helmchart components via explicit servicePort (#89)
 - Add CapabilityDefinition schema for custom trait rendering (#66)
-- Port rbac, fluxcd-patches, fluxcd-postbuild, prune-protection traits from crane (#97 #98 #99 #100)
+- Port rbac, fluxcd-patches, fluxcd-postbuild, prune-protection traits from the downstream operator (#97 #98 #99 #100)
 
 ### Build
 
@@ -426,7 +426,7 @@ All notable changes to this project will be documented in this file.
 - Reject explicitly empty accessModes list in pvc trait
 - Address external-secret shorthand, volsync naming, and coverage
 - Preserve decodingStrategy in external-secret remoteRef shorthand
-- Align postgresql customQueries validation and bootstrap recovery tests with crane
+- Align postgresql customQueries validation and bootstrap recovery tests with the downstream operator
 - Remove wrong deprecation from ingress/httproute; fix default backend port
 - Validate implicit backends; extend ingress with per-path backend override
 - Tighten implicit-backend port guards for ingress and httproute

--- a/cliff.toml
+++ b/cliff.toml
@@ -22,6 +22,17 @@ body = """
 """
 footer = ""
 trim = true
+# Scrub downstream/closed-source platform references that leak in from historical
+# commit subjects, so the generated changelog never names a downstream consumer
+# (org "No Downstream References" rule; enforced by check-forbidden-terms.sh).
+# Ordered specific → catch-all; the catch-all is a safety net for stray words.
+postprocessors = [
+    { pattern = 'wharf\.zone/component', replace = "the platform component label" },
+    { pattern = 'wharf\.zone', replace = "the platform domain" },
+    { pattern = '(?i)\bfrom crane\b', replace = "from the downstream operator" },
+    { pattern = '(?i)\bwith crane\b', replace = "with the downstream operator" },
+    { pattern = '(?i)\b(wharf|crane|barge|harbor|rudder)\b', replace = "the downstream operator" },
+]
 
 [git]
 conventional_commits = true


### PR DESCRIPTION
## Problem

The merge queue is red for **every** PR (e.g. #229) at `docs-build → Check for downstream references`:

```
FORBIDDEN: CHANGELOG.md:8:   - Target wharf.zone/component in synthesized NetworkPolicies
FORBIDDEN: CHANGELOG.md:361: - Port ... traits from crane (#97 #98 #99 #100)
FORBIDDEN: CHANGELOG.md:429: - Align postgresql ... tests with crane
```

`CHANGELOG.md` is generated by git-cliff from commit *subjects*, and historical subjects contain downstream/closed-source platform names. The forbidden-terms guard runs `--diff origin/main` on `pull_request` (added lines only) but `--full-tree` on `merge_group`, so these pre-existing lines pass PR-level checks yet block admission at the queue. Release-bump commits pushed directly to `main` went red on push (not a required gate), so the terms accumulated unnoticed.

## Fix

- **`cliff.toml`**: add a `[changelog] postprocessors` block that scrubs downstream terms at generation time — durable across every future regenerate (`git-cliff -o CHANGELOG.md` in `scripts/release.sh`). `allow-term` pragmas would be wrong here: git-cliff strips them on the next regen and reintroduces raw terms.
- **`CHANGELOG.md`**: fix the 3 current hits to match the scrubbed wording (generic "the downstream operator" / "the platform component label"), so the next release regen reproduces identical output with no churn.

## Verification

- `site/scripts/check-forbidden-terms.sh --full-tree` → `OK (full mode)`.
- Full `git-cliff` regenerate over real history (18 releases) → **zero** forbidden terms, and the 3 scrubbed lines match the hand-edits exactly (durability proven, not just a hand-edit).

## Follow-up (not in this PR)

`docs-build` already runs `--full-tree` on push and `CHANGELOG.md` is already in the docs filter — the gap is that a red *push* run doesn't block while the required `merge_group` gate does. A forbidden-terms preflight in `scripts/release.sh` would fail a release before it can push a dirty CHANGELOG. The postprocessor already prevents the terms at the source, so this is belt-and-suspenders.