### PR TITLE
feat(oam/netpol): postgresql pooler EndpointProvider + per-endpoint NP naming

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -49,7 +49,10 @@ each a **separate** additive resource (the authored `networkpolicy` /
   valid rule is not emitted. A component's endpoints are declared by its handler via the
   optional `EndpointProvider` interface and read through `Transformer.ComponentEndpoints` — the
   producer half a downstream platform uses to learn the real selector (no hardcoding) and build
-  its dependency graph.
+  its dependency graph. One policy is emitted **per distinct endpoint**: a single-endpoint
+  component keeps the bare `{comp}-allow-endpoint-ingress` name, while a multi-endpoint component
+  (e.g. a CloudNativePG cluster plus its pooler) suffixes each policy with a short content hash of
+  the endpoint, so the names are distinct and stay stable across unrelated endpoint additions.
 
 The inbound/egress families select the component's own pods (the ingress recipients / the egress
 source pods) via a **derived `<domain>/component`** label by default — the domain comes

--- a/pkg/oam/builtin/components/README.md
+++ b/pkg/oam/builtin/components/README.md
@@ -60,7 +60,10 @@ share these fields: `image` (validated — no untagged/`latest`), `env` (with
   Its handler implements the optional `oam.EndpointProvider`: it declares the CNPG cluster's
   data-plane endpoint (`cnpg.io/cluster: <component-name>` on port `5432`) so a downstream
   platform can synthesize the target-side ingress allow (`{comp}-allow-endpoint-ingress`)
-  without hardcoding the operator selector.
+  without hardcoding the operator selector. When `pooler.enabled` is set it declares a **second**
+  endpoint for the pooler (PgBouncer) pods (`cnpg.io/poolerName: <component-name>-pooler` on port
+  `5432`), so a consumer that dials the pooler — whose pods carry a different label set and are not
+  matched by the direct-cluster selector — also gets its connection synthesized.
 - **passthrough** — `object` (full apiVersion/kind/metadata/spec), `clusterScoped`.
   Its config exposes `ComponentName() string` (the `oam.ComponentNamed` interface) so
   consumers can attribute the emitted resource to its owning OAM component.

--- a/pkg/oam/builtin/components/endpoint_test.go
+++ b/pkg/oam/builtin/components/endpoint_test.go
@@ -24,3 +24,38 @@ func TestPostgresqlHandler_Endpoints(t *testing.T) {
 		t.Errorf("ports = %v, want [5432]", eps[0].Ports)
 	}
 }
+
+func TestPostgresqlHandler_Endpoints_Pooler(t *testing.T) {
+	h := &components.PostgresqlHandler{}
+
+	// Pooler disabled (or absent) → only the direct-cluster endpoint.
+	eps, err := h.Endpoints(&oam.Component{Name: "orders-db", Type: "postgresql",
+		Properties: map[string]any{"pooler": map[string]any{"enabled": false}}})
+	if err != nil {
+		t.Fatalf("Endpoints: %v", err)
+	}
+	if len(eps) != 1 {
+		t.Fatalf("pooler disabled: expected 1 endpoint, got %d", len(eps))
+	}
+
+	// Pooler enabled → a second endpoint on the pooler pods.
+	eps, err = h.Endpoints(&oam.Component{Name: "orders-db", Type: "postgresql",
+		Properties: map[string]any{"pooler": map[string]any{"enabled": true}}})
+	if err != nil {
+		t.Fatalf("Endpoints: %v", err)
+	}
+	if len(eps) != 2 {
+		t.Fatalf("pooler enabled: expected 2 endpoints, got %d", len(eps))
+	}
+	// First is the direct cluster endpoint; second is the pooler.
+	if eps[0].PodSelector.MatchLabels["cnpg.io/cluster"] != "orders-db" {
+		t.Errorf("endpoint[0] selector = %v, want cnpg.io/cluster=orders-db", eps[0].PodSelector)
+	}
+	pooler := eps[1].PodSelector
+	if pooler == nil || pooler.MatchLabels["cnpg.io/poolerName"] != "orders-db-pooler" || len(pooler.MatchLabels) != 1 {
+		t.Errorf("endpoint[1] selector = %v, want cnpg.io/poolerName=orders-db-pooler", pooler)
+	}
+	if len(eps[1].Ports) != 1 || eps[1].Ports[0].IntVal != 5432 {
+		t.Errorf("pooler ports = %v, want [5432]", eps[1].Ports)
+	}
+}

--- a/pkg/oam/builtin/components/postgresql.go
+++ b/pkg/oam/builtin/components/postgresql.go
@@ -15,10 +15,12 @@ import (
 )
 
 // cnpgClusterLabel is the label the CloudNativePG operator stamps on every instance pod of a
-// Cluster (value = the Cluster name). postgresqlPort is the default PostgreSQL service port.
+// Cluster (value = the Cluster name). cnpgPoolerNameLabel is the label it stamps on every pooler
+// (PgBouncer) pod (value = the Pooler name). postgresqlPort is the PostgreSQL/PgBouncer port.
 const (
-	cnpgClusterLabel = "cnpg.io/cluster"
-	postgresqlPort   = 5432
+	cnpgClusterLabel    = "cnpg.io/cluster"
+	cnpgPoolerNameLabel = "cnpg.io/poolerName"
+	postgresqlPort      = 5432
 )
 
 // PostgresqlHandler handles OAM postgresql components.
@@ -29,15 +31,39 @@ func (h *PostgresqlHandler) CanHandle(componentType string) bool {
 	return componentType == "postgresql"
 }
 
-// Endpoints implements oam.EndpointProvider: a postgresql component's data-plane endpoint is
+// Endpoints implements oam.EndpointProvider: a postgresql component's data-plane endpoints are
 // the CNPG cluster's instance pods (labelled cnpg.io/cluster=<cluster name>, which equals the
-// OAM component name) on the PostgreSQL port. A downstream platform uses this to synthesize the
-// target-side ingress allow without hardcoding the operator selector.
+// OAM component name) on the PostgreSQL port and, when the component declares a pooler, the
+// pooler (PgBouncer) pods (labelled cnpg.io/poolerName=<cluster name>-pooler) on the same port.
+// A downstream platform uses these to synthesize the target-side ingress allow(s) without
+// hardcoding the operator selectors; a consumer that dials the pooler needs the second endpoint
+// because pooler pods carry a different label set and are not matched by the direct-cluster
+// selector.
 func (h *PostgresqlHandler) Endpoints(component *oam.Component) ([]netpol.Endpoint, error) {
-	return []netpol.Endpoint{{
+	eps := []netpol.Endpoint{{
 		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{cnpgClusterLabel: component.Name}},
 		Ports:       []intstr.IntOrString{intstr.FromInt32(postgresqlPort)},
-	}}, nil
+	}}
+	// The pooler resource name mirrors createPooler: <component name>-pooler.
+	if poolerEnabled(component) {
+		eps = append(eps, netpol.Endpoint{
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{cnpgPoolerNameLabel: component.Name + "-pooler"}},
+			Ports:       []intstr.IntOrString{intstr.FromInt32(postgresqlPort)},
+		})
+	}
+	return eps, nil
+}
+
+// poolerEnabled reports whether the component declares an enabled pooler. It reads the raw
+// property (mirroring ToApplicationConfig's pooler parse) so Endpoints stays a lightweight,
+// side-effect-free view that does not require a full config build.
+func poolerEnabled(component *oam.Component) bool {
+	pooler, ok := component.Properties["pooler"].(map[string]any)
+	if !ok {
+		return false
+	}
+	enabled, _ := pooler["enabled"].(bool)
+	return enabled
 }
 
 // PropertySchema declares the postgresql component's top-level user-facing

--- a/pkg/oam/netpol_endpoint_synthesis_test.go
+++ b/pkg/oam/netpol_endpoint_synthesis_test.go
@@ -1,6 +1,7 @@
 package oam
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/go-kure/kure/pkg/stack"
@@ -166,6 +167,28 @@ func TestGroupIngressPeers_DropsMalformedAndDedups(t *testing.T) {
 	}
 }
 
+func TestEndpointIngressPolicyName(t *testing.T) {
+	ep := validEndpoint()
+	// Single-endpoint component keeps the bare, back-compatible name.
+	if got := endpointIngressPolicyName("pg", ep, false); got != "pg-allow-endpoint-ingress" {
+		t.Errorf("single-endpoint name = %q, want pg-allow-endpoint-ingress", got)
+	}
+	// Multi-endpoint: suffixed, deterministic, and content-stable (same endpoint → same name).
+	m1 := endpointIngressPolicyName("pg", ep, true)
+	m2 := endpointIngressPolicyName("pg", ep, true)
+	if m1 != m2 {
+		t.Errorf("multi-endpoint name not deterministic: %q vs %q", m1, m2)
+	}
+	if !strings.HasPrefix(m1, "pg-allow-endpoint-ingress-") || len(m1) != len("pg-allow-endpoint-ingress-")+8 {
+		t.Errorf("multi-endpoint name = %q, want bare+'-'+8 hex chars", m1)
+	}
+	// A different endpoint yields a different suffix.
+	pooler := netpol.Endpoint{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/poolerName": "pg-pooler"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}
+	if other := endpointIngressPolicyName("pg", pooler, true); other == m1 {
+		t.Errorf("distinct endpoints produced the same name %q", other)
+	}
+}
+
 func TestGroupIngressPeers_TwoDistinctEndpoints(t *testing.T) {
 	ep2 := netpol.Endpoint{
 		PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/cluster": "pg", "role": "pooler"}},
@@ -213,19 +236,68 @@ func TestSynthesizeEndpointIngress_NoOpAndGuards(t *testing.T) {
 	if got := len(egressAppNames(cluster2)); got != 1 {
 		t.Errorf("expected no synthesis for unmatched component, got %d apps", got)
 	}
-	// multi-endpoint → skip (no app emitted)
-	cluster3, componentMap3, _ := egressFixture("pg", "default")
-	ep2 := netpol.Endpoint{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "b"}}, Ports: []intstr.IntOrString{intstr.FromInt32(6432)}}
-	synthesizeEndpointIngressNetworkPolicies(cluster3, componentMap3, map[string][]netpol.IngressPeer{
+}
+
+// TestSynthesizeEndpointIngress_MultiEndpoint verifies a component with two distinct endpoints
+// (e.g. a postgresql cluster + its pooler) emits one policy per endpoint, each with a distinct,
+// content-derived suffixed name — and that neither uses the bare single-endpoint name.
+func TestSynthesizeEndpointIngress_MultiEndpoint(t *testing.T) {
+	cluster, componentMap, _ := egressFixture("pg", "default")
+	ep2 := netpol.Endpoint{PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"cnpg.io/poolerName": "pg-pooler"}}, Ports: []intstr.IntOrString{intstr.FromInt32(5432)}}
+	synthesizeEndpointIngressNetworkPolicies(cluster, componentMap, map[string][]netpol.IngressPeer{
 		"pg": {
 			{Endpoint: validEndpoint(), Sources: []netpol.TrafficSource{src("app", "app", "web")}},
 			{Endpoint: ep2, Sources: []netpol.TrafficSource{src("app", "app", "web")}},
 		},
 	})
-	for _, n := range egressAppNames(cluster3) {
-		if n == "pg-allow-endpoint-ingress" {
-			t.Errorf("expected multi-endpoint skip, but a policy was emitted")
+	// Collect the two synthesized policies and render each NP, keyed by its distinguishing
+	// selector label, so we can assert both the naming and the rendered target.
+	var epApps []*stack.Application
+	for _, app := range cluster.Node.Bundle.Applications {
+		if strings.HasPrefix(app.Name, "pg-allow-endpoint-ingress") {
+			epApps = append(epApps, app)
 		}
+		if app.Name == "pg-allow-endpoint-ingress" {
+			t.Errorf("multi-endpoint component must not use the bare policy name")
+		}
+	}
+	if len(epApps) != 2 {
+		t.Fatalf("expected 2 endpoint-ingress policies, got %d", len(epApps))
+	}
+	if epApps[0].Name == epApps[1].Name {
+		t.Errorf("expected two distinct policy names, both are %q", epApps[0].Name)
+	}
+
+	// One NP must select the direct cluster pods, the other the pooler pods; both on port 5432.
+	sawCluster, sawPooler := false, false
+	for _, app := range epApps {
+		objs, err := app.Config.Generate(app)
+		if err != nil {
+			t.Fatalf("Generate %q: %v", app.Name, err)
+		}
+		np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+		if !ok {
+			t.Fatalf("expected *NetworkPolicy from %q, got %T", app.Name, *objs[0])
+		}
+		ml := np.Spec.PodSelector.MatchLabels
+		port := np.Spec.Ingress[0].Ports[0].Port.IntVal
+		switch {
+		case ml["cnpg.io/cluster"] == "pg":
+			sawCluster = true
+			if len(ml) != 1 || port != 5432 {
+				t.Errorf("cluster NP %q: selector=%v port=%d, want cnpg.io/cluster=pg port=5432", app.Name, ml, port)
+			}
+		case ml["cnpg.io/poolerName"] == "pg-pooler":
+			sawPooler = true
+			if len(ml) != 1 || port != 5432 {
+				t.Errorf("pooler NP %q: selector=%v port=%d, want cnpg.io/poolerName=pg-pooler port=5432", app.Name, ml, port)
+			}
+		default:
+			t.Errorf("unexpected NP %q selector: %v", app.Name, ml)
+		}
+	}
+	if !sawCluster || !sawPooler {
+		t.Errorf("expected both cluster and pooler NPs (cluster=%v pooler=%v)", sawCluster, sawPooler)
 	}
 }
 

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -1,6 +1,8 @@
 package oam
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strings"
@@ -526,23 +528,24 @@ func synthesizeEndpointIngressNetworkPolicies(cluster *stack.Cluster, componentM
 				continue
 			}
 			groups := groupIngressPeers(ingressPeers[app.Name])
-			// Multi-endpoint rule (v1): the NP name has no per-endpoint discriminator, so a
-			// component with >1 distinct endpoint would collide. Only postgresql produces
-			// endpoints today (exactly one), so this is unreachable; skip rather than emit a
-			// colliding or partial policy.
-			// TODO(pooler): suffix per-endpoint NP names when a second endpoint is added.
-			if len(groups) != 1 {
-				continue
+			// One NP per distinct endpoint. A single-endpoint component keeps the bare name
+			// (back-compat); a multi-endpoint component (e.g. a postgresql cluster + its pooler)
+			// gets a per-endpoint suffix so the names don't collide. The suffix is a content
+			// hash of the endpoint, not a positional index, so each endpoint's NP name is stable
+			// across unrelated endpoint additions (an index would renumber, causing spurious
+			// downstream prune+create).
+			multi := len(groups) > 1
+			for _, g := range groups {
+				autoApps = append(autoApps, stack.NewApplication(
+					endpointIngressPolicyName(app.Name, g.Endpoint, multi),
+					app.Namespace,
+					&componentEndpointIngressPolicyConfig{
+						ComponentName: app.Name,
+						Endpoint:      g.Endpoint,
+						Rules:         g.Rules,
+					},
+				))
 			}
-			autoApps = append(autoApps, stack.NewApplication(
-				app.Name+"-allow-endpoint-ingress",
-				app.Namespace,
-				&componentEndpointIngressPolicyConfig{
-					ComponentName: app.Name,
-					Endpoint:      groups[0].Endpoint,
-					Rules:         groups[0].Rules,
-				},
-			))
 		}
 		bundle.Applications = append(bundle.Applications, autoApps...)
 	})
@@ -614,6 +617,21 @@ func endpointKey(e netpol.Endpoint) string {
 		portKeys = append(portKeys, fmt.Sprintf("%d:%s", pt.Type, pt.String()))
 	}
 	return fmt.Sprintf("sel:%s;ports:%s", strings.Join(labelParts, ","), strings.Join(portKeys, "|"))
+}
+
+// endpointIngressPolicyName returns the NetworkPolicy name for a component's endpoint-ingress
+// policy. A single-endpoint component keeps the bare "{comp}-allow-endpoint-ingress" name
+// (back-compat with #213). When a component exposes more than one distinct endpoint (multi=true,
+// e.g. a postgresql cluster plus its pooler), every policy is suffixed with a short content hash
+// of the endpoint so the names are distinct and — because the hash is derived from the endpoint's
+// own selector+ports, not its position — stable across unrelated endpoint additions.
+func endpointIngressPolicyName(comp string, e netpol.Endpoint, multi bool) string {
+	base := comp + "-allow-endpoint-ingress"
+	if !multi {
+		return base
+	}
+	sum := sha256.Sum256([]byte(endpointKey(e)))
+	return base + "-" + hex.EncodeToString(sum[:])[:8]
 }
 
 // sourcesKey returns a canonical dedup/ordering key for a source set — per-source keys sorted


### PR DESCRIPTION
## Summary

Two coupled changes so a downstream consumer can synthesize the **pooler** (PgBouncer) connection for a CloudNativePG cluster:

1. **Provider** — `PostgresqlHandler.Endpoints` now returns a **second** `netpol.Endpoint` for the pooler pods (`cnpg.io/poolerName: <name>-pooler` on port `5432`) when the component declares an enabled pooler, alongside the direct-cluster endpoint. Pooler pods carry a different label set and are **not** matched by the direct-cluster selector, so under a target-namespace default-deny a pooler-routed connection stays blocked without this.
2. **Synthesis naming** — the endpoint-ingress path now emits **one NP per distinct endpoint** instead of skipping components with >1 endpoint.

## Why the synthesis fix is required (not optional)

The previous `if len(groups) != 1 { continue }` guard (with its `TODO(pooler)`) skips the **entire** component when it sees more than one endpoint group. Returning the pooler as a second endpoint without this fix would silently stop rendering the direct-cluster policy that ships today — a regression of #213. Provider-only is not a safe smaller step.

## Naming scheme

- Single-endpoint component → bare `{comp}-allow-endpoint-ingress` (unchanged, back-compat).
- Multi-endpoint component → each policy suffixed with an 8-char `sha256(endpointKey)` truncation. The suffix is **content-derived, not a positional index**, so each endpoint's NP name is stable across unrelated endpoint additions (an index would renumber and cause spurious downstream prune+create under Flux).

## Behavioral note (downstream)

Enabling the pooler moves a postgresql component from 1→2 endpoint groups, so the existing direct-cluster NP **renames** from the bare name to a suffixed one (both endpoints get suffixes once >1 group exists). Downstream that is a **one-reconcile prune+create**.

## Tests

- Provider: pooler disabled → 1 endpoint (unchanged); enabled → 2 endpoints (cluster + `cnpg.io/poolerName`), both valid.
- `endpointIngressPolicyName`: single → bare; multi → deterministic, content-stable, distinct suffix per endpoint.
- Synthesis: a 2-endpoint component emits 2 distinct, non-colliding, suffixed policies (neither bare); single-endpoint output unchanged.

## Docs

- `pkg/oam/builtin/components/README.md` (pooler endpoint), `pkg/oam/README.md` (per-endpoint naming).

Closes #226