### PR TITLE
feat(oam/netpol): derive ingress-synthesis target from expose backendRefs

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -33,7 +33,11 @@ each a **separate** additive resource (the authored `networkpolicy` /
 `cilium-networkpolicy` traits are unaffected):
 
 - **Inbound** (`{comp}-allow-ingress-traffic`) — routing-derived, from routing traits'
-  platform-reserved `networkPolicy.trafficSources` capability rendering.
+  platform-reserved `networkPolicy.trafficSources` capability rendering. When a routing trait's
+  `backendRef` names a **separate** in-bundle backend Service (not the exposing component's own),
+  the allow is **retargeted onto that backend component's pods** + the backendRef port — resolved
+  by matching the backend Service name to a sibling OAM component in the same bundle. A backendRef
+  that resolves to no in-bundle component is left authored (documented fallback).
 - **Egress** (`{comp}-allow-egress-traffic`) — from `TransformContext.EgressPeers`, a
   downstream-supplied, non-authorable synthesis input (graph-derived dependency peers; never
   set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -111,6 +111,16 @@ Routing traits (`ingress`/`httproute`/`expose`) can surface platform-reserved
 `networkPolicy.trafficSources`, which the OAM layer collects to synthesize a
 matching `NetworkPolicy` (see [`pkg/oam/netpol`](https://pkg.go.dev/github.com/go-kure/launcher/pkg/oam/netpol)).
 
+When a routing trait's `backendRefs` (httproute) or path `backend` (ingress) names a **separate**
+in-bundle backend Service rather than the exposing component's own, the synthesized
+`{comp}-allow-ingress-traffic` allow is **retargeted onto the backend component's pods** + the
+backendRef port — so router→backend traffic is allowed under a namespace default-deny. The backend
+Service name is resolved to a sibling OAM component in the same bundle (a component's Service name
+is its `BackendServiceName()` when it declares one, else its component name); a backendRef that
+resolves to no in-bundle component is **left authored**. Resolution assumes the sibling's Service
+port equals its container port, which holds for all builtin components (e.g. webservice sets
+`TargetPort == Port`).
+
 ## Extending
 
 Custom traits implement `oam.TraitHandler` (`CanHandle` + `Apply`), optionally

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -353,6 +353,7 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 	}
 	config.sources = sources
 	config.ports = collectHTTPRoutePorts(config, defaultServiceName)
+	config.backendTargets = collectHTTPRouteBackendTargets(config, defaultServiceName)
 
 	return config, nil
 }
@@ -910,10 +911,17 @@ type HTTPRouteConfig struct {
 	// networkPolicy.trafficSources rendering; they drive auto-NetworkPolicy synthesis.
 	sources []netpol.TrafficSource
 	ports   []intstr.IntOrString
+	// backendTargets are external backendRef targets (refs naming a separate Service); they
+	// drive ingress-synthesis retargeting onto the backend's pods (#227).
+	backendTargets []netpol.BackendTarget
 }
 
 // TrafficSources implements the cluster-level trafficSourceCollector contract.
 func (c *HTTPRouteConfig) TrafficSources() []netpol.TrafficSource { return c.sources }
+
+// BackendTargets implements the cluster-level backendRefTargetCollector contract: external
+// backendRef targets whose ingress allow should land on the backend's pods, not this component's.
+func (c *HTTPRouteConfig) BackendTargets() []netpol.BackendTarget { return c.backendTargets }
 
 // ComponentName returns the OAM component this sub-app belongs to — always the OAM
 // component name, not the K8s Service name — for resource provenance attribution.

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -340,6 +340,7 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 	}
 	config.sources = sources
 	config.ports = collectIngressPorts(config)
+	config.backendTargets = collectIngressBackendTargets(config)
 
 	return config, nil
 }
@@ -359,10 +360,17 @@ type IngressConfig struct {
 	// networkPolicy.trafficSources rendering; they drive auto-NetworkPolicy synthesis.
 	sources []netpol.TrafficSource
 	ports   []intstr.IntOrString
+	// backendTargets are external backendRef targets (paths naming a separate Service); they
+	// drive ingress-synthesis retargeting onto the backend's pods (#227).
+	backendTargets []netpol.BackendTarget
 }
 
 // TrafficSources implements the cluster-level trafficSourceCollector contract.
 func (c *IngressConfig) TrafficSources() []netpol.TrafficSource { return c.sources }
+
+// BackendTargets implements the cluster-level backendRefTargetCollector contract: external
+// backendRef targets whose ingress allow should land on the backend's pods, not this component's.
+func (c *IngressConfig) BackendTargets() []netpol.BackendTarget { return c.backendTargets }
 
 // ComponentName returns the OAM component this sub-app belongs to — always the OAM
 // component name, not the K8s Service name — for resource provenance attribution.

--- a/pkg/oam/builtin/traits/networkpolicy_auto.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto.go
@@ -158,6 +158,77 @@ func collectHTTPRoutePorts(config *HTTPRouteConfig, selfServiceName string) []in
 	return sortedIntOrStringPorts(seen)
 }
 
+// collectIngressBackendTargets returns the external backend targets of an ingress trait: paths
+// naming a Service other than the component's own, grouped by service name with their ports. These
+// drive ingress-synthesis retargeting (#227) — landing the allow on the backend's pods rather than
+// the exposing component's own.
+func collectIngressBackendTargets(config *IngressConfig) []netpol.BackendTarget {
+	byName := map[string]map[string]intstr.IntOrString{}
+	var order []string
+	for _, rule := range config.Rules {
+		for _, path := range rule.Paths {
+			if path.ServiceName == "" || path.ServiceName == config.ServiceName {
+				continue // self backend; covered by BackendPorts
+			}
+			ports := ensureBackendTarget(byName, &order, path.ServiceName)
+			if path.Port > 0 {
+				ports[fmt.Sprintf("n:%d", path.Port)] = intstr.FromInt32(path.Port)
+			} else if path.PortName != "" {
+				ports["s:"+path.PortName] = intstr.FromString(path.PortName)
+			}
+		}
+	}
+	return buildBackendTargets(order, byName)
+}
+
+// collectHTTPRouteBackendTargets returns the external backend targets of an httproute trait:
+// backendRefs naming a Service other than the component's own, grouped by service name with their
+// ports. See collectIngressBackendTargets.
+func collectHTTPRouteBackendTargets(config *HTTPRouteConfig, selfServiceName string) []netpol.BackendTarget {
+	byName := map[string]map[string]intstr.IntOrString{}
+	var order []string
+	for _, rule := range config.Rules {
+		for _, ref := range rule.BackendRefs {
+			if ref.Name == "" || ref.Name == selfServiceName {
+				continue // self backend; covered by BackendPorts
+			}
+			ports := ensureBackendTarget(byName, &order, ref.Name)
+			if ref.Port > 0 {
+				ports[fmt.Sprintf("n:%d", ref.Port)] = intstr.FromInt32(ref.Port)
+			}
+		}
+	}
+	return buildBackendTargets(order, byName)
+}
+
+// ensureBackendTarget returns the port-dedup map for a service name, registering it (and its
+// insertion order) on first use.
+func ensureBackendTarget(byName map[string]map[string]intstr.IntOrString, order *[]string, name string) map[string]intstr.IntOrString {
+	ports, ok := byName[name]
+	if !ok {
+		ports = map[string]intstr.IntOrString{}
+		byName[name] = ports
+		*order = append(*order, name)
+	}
+	return ports
+}
+
+// buildBackendTargets converts the per-service port maps into a deterministically ordered slice:
+// service names sorted lexically, ports via sortedIntOrStringPorts. Targets with no ports are
+// dropped (nothing to synthesize).
+func buildBackendTargets(order []string, byName map[string]map[string]intstr.IntOrString) []netpol.BackendTarget {
+	sort.Strings(order)
+	var out []netpol.BackendTarget
+	for _, name := range order {
+		ports := sortedIntOrStringPorts(byName[name])
+		if len(ports) == 0 {
+			continue
+		}
+		out = append(out, netpol.BackendTarget{ServiceName: name, Ports: ports})
+	}
+	return out
+}
+
 // sortedIntOrStringPorts converts the dedup map to a deterministically ordered
 // slice: numeric ports ascending, then named ports lexically.
 func sortedIntOrStringPorts(seen map[string]intstr.IntOrString) []intstr.IntOrString {

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -280,6 +280,312 @@ func synthesizedPodSelector(t *testing.T, c *stack.Cluster, name string) map[str
 	return np.Spec.PodSelector.MatchLabels
 }
 
+// synthesizedNetworkPolicy finds a named synthesized app and returns its emitted NetworkPolicy.
+func synthesizedNetworkPolicy(t *testing.T, c *stack.Cluster, name string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	var found *stack.Application
+	var visit func(b *stack.Bundle)
+	visit = func(b *stack.Bundle) {
+		if b == nil || found != nil {
+			return
+		}
+		for _, a := range b.Applications {
+			if a.Name == name {
+				found = a
+				return
+			}
+		}
+		for _, ch := range b.Children {
+			visit(ch)
+		}
+	}
+	var visitNode func(n *stack.Node)
+	visitNode = func(n *stack.Node) {
+		if n == nil || found != nil {
+			return
+		}
+		visit(n.Bundle)
+		for _, ch := range n.Children {
+			visitNode(ch)
+		}
+	}
+	if c != nil {
+		visitNode(c.Node)
+	}
+	if found == nil {
+		t.Fatalf("synthesized app %q not found; cluster apps: %v", name, clusterAppNames(c))
+	}
+	objs, err := found.Config.Generate(found)
+	if err != nil {
+		t.Fatalf("Generate %q: %v", name, err)
+	}
+	np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+	if !ok {
+		t.Fatalf("expected *NetworkPolicy from %q, got %T", name, *objs[0])
+	}
+	return np
+}
+
+// #227: an httproute whose backendRef routes to a SEPARATE in-bundle backend component lands the
+// synthesized ingress allow on the backend's pods + backendRef port, not the router's own. The
+// router itself (which has no self backend port) gets no empty self policy.
+func TestTransform_BackendRef_RetargetsToBackendComponent(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							"rules": []any{map[string]any{
+								"backendRefs": []any{map[string]any{"name": "backend", "port": 9000}},
+							}},
+							"networkPolicy": map[string]any{
+								"trafficSources": []any{map[string]any{"namespace": "gateway-system"}},
+							},
+						},
+					}},
+				},
+				{
+					Name:       "backend",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "api:1.0", "port": 9000},
+				},
+			},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+
+	// The allow lands on the backend component.
+	if !clusterHasApp(cluster, "backend-allow-ingress-traffic") {
+		t.Fatalf("expected synthesized \"backend-allow-ingress-traffic\"; apps: %v", clusterAppNames(cluster))
+	}
+	// The router-only exposer gets no empty self policy.
+	if clusterHasApp(cluster, "router-allow-ingress-traffic") {
+		t.Errorf("did not expect a self policy for the router-only exposer; apps: %v", clusterAppNames(cluster))
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "backend-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "backend" {
+		t.Errorf("target selector = %v, want gokure.dev/component=backend", np.Spec.PodSelector.MatchLabels)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 9000 {
+		t.Errorf("expected a single ingress rule on port 9000, got %+v", np.Spec.Ingress)
+	}
+	if len(np.Spec.Ingress[0].From) != 1 ||
+		np.Spec.Ingress[0].From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "gateway-system" {
+		t.Errorf("expected the router's traffic source (gateway-system), got %+v", np.Spec.Ingress[0].From)
+	}
+}
+
+// #227: a backendRef naming a Service with no owning component in the bundle is left authored —
+// no synthesized policy for it, and no panic.
+func TestTransform_BackendRef_Unresolvable_LeavesAuthored(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "httproute",
+					Properties: map[string]any{
+						"parentRefs": []any{map[string]any{"name": "gw"}},
+						"rules": []any{map[string]any{
+							"backendRefs": []any{map[string]any{"name": "external-svc", "port": 9000}},
+						}},
+						"networkPolicy": map[string]any{
+							"trafficSources": []any{map[string]any{"namespace": "gateway-system"}},
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	for _, n := range clusterAppNames(cluster) {
+		if n == "external-svc-allow-ingress-traffic" || n == "router-allow-ingress-traffic" {
+			t.Errorf("expected no synthesized ingress policy for an unresolvable backendRef, got %q", n)
+		}
+	}
+}
+
+// #227: the ingress trait's external-backend path (collectIngressBackendTargets) also retargets,
+// including the named-port (PortName) branch that only the ingress collector exercises.
+func TestTransform_IngressBackendPath_RetargetsToBackend(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "ingress",
+						Properties: map[string]any{
+							"rules": []any{map[string]any{
+								"host": "example.com",
+								"paths": []any{map[string]any{
+									"path":     "/",
+									"backend":  "backend",
+									"portName": "http",
+								}},
+							}},
+							"networkPolicy": map[string]any{
+								"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}},
+							},
+						},
+					}},
+				},
+				{
+					Name:       "backend",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "api:1.0", "port": 9000},
+				},
+			},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	if !clusterHasApp(cluster, "backend-allow-ingress-traffic") {
+		t.Fatalf("expected \"backend-allow-ingress-traffic\"; apps: %v", clusterAppNames(cluster))
+	}
+	if clusterHasApp(cluster, "router-allow-ingress-traffic") {
+		t.Errorf("did not expect a self policy for the router-only exposer; apps: %v", clusterAppNames(cluster))
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "backend-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "backend" {
+		t.Errorf("target selector = %v, want gokure.dev/component=backend", np.Spec.PodSelector.MatchLabels)
+	}
+	// Named-port branch: the retargeted rule carries the port by name, not number.
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 ||
+		np.Spec.Ingress[0].Ports[0].Port.StrVal != "http" {
+		t.Errorf("expected a single named ingress port \"http\", got %+v", np.Spec.Ingress)
+	}
+}
+
+// #227: a backendRef naming a component whose Service name differs from its component name (e.g. a
+// statefulset's headless service) resolves via BackendServiceName() (the serviceBackendNamer
+// branch) — a break there would silently fall back to "authored".
+func TestTransform_BackendRef_ResolvesViaServiceName(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterComponent("statefulset", &components.StatefulsetHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							"rules": []any{map[string]any{
+								// Names the statefulset's headless Service, not its component name.
+								"backendRefs": []any{map[string]any{"name": "db-headless", "port": 5432}},
+							}},
+							"networkPolicy": map[string]any{
+								"trafficSources": []any{map[string]any{"namespace": "gateway-system"}},
+							},
+						},
+					}},
+				},
+				{
+					Name:       "db",
+					Type:       "statefulset",
+					Properties: map[string]any{"image": "postgres:16", "port": 5432, "serviceName": "db-headless"},
+				},
+			},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	// The Service name "db-headless" resolves to component "db".
+	if !clusterHasApp(cluster, "db-allow-ingress-traffic") {
+		t.Fatalf("expected \"db-allow-ingress-traffic\" (resolved via BackendServiceName); apps: %v", clusterAppNames(cluster))
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "db-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "db" {
+		t.Errorf("target selector = %v, want gokure.dev/component=db", np.Spec.PodSelector.MatchLabels)
+	}
+}
+
+// #227: a self-referencing backendRef (the component's own service) is unchanged — the allow
+// stays on the exposing component.
+func TestTransform_BackendRef_SelfTarget_Unchanged(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "web",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "httproute",
+					Properties: map[string]any{
+						"parentRefs": []any{map[string]any{"name": "gw"}},
+						"rules": []any{map[string]any{
+							"backendRefs": []any{map[string]any{"name": "web", "port": 8080}},
+						}},
+						"networkPolicy": map[string]any{
+							"trafficSources": []any{map[string]any{"namespace": "gateway-system"}},
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	if !clusterHasApp(cluster, "web-allow-ingress-traffic") {
+		t.Errorf("expected self policy \"web-allow-ingress-traffic\"; apps: %v", clusterAppNames(cluster))
+	}
+}
+
 // End-to-end: a webservice with downstream-supplied (non-authorable) egress peers on the
 // transform context yields a synthesized {component}-allow-egress-traffic policy, and
 // no inbound policy is synthesized absent trafficSources (additive, distinct paths).

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -16,6 +16,10 @@ Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
   a producer bug and is rejected with a build error — it would otherwise emit a namespace-wide
   egress allow (`to.PodSelector` nil = all pods). A peer with **no ports** is the documented
   escape hatch and is silently skipped (destination stays authored).
+- `BackendTarget` — one routing `backendRef` that targets a **separate** in-cluster backend
+  Service (not the exposing component's own): a Service name + ports. Ingress synthesis retargets
+  the `{comp}-allow-ingress-traffic` allow onto the backend's pods (resolved from the Service name
+  to a sibling component); an unresolvable target is left authored.
 - `Endpoint` — a component's declared in-cluster data-plane endpoint: a pod selector
   (matchLabels only) + ports. Namespace is deliberately absent (the caller knows the target's
   namespace). Declared by a component handler via the optional `oam.EndpointProvider`.

--- a/pkg/oam/netpol/types.go
+++ b/pkg/oam/netpol/types.go
@@ -35,6 +35,16 @@ type EgressPeer struct {
 	Ports       []intstr.IntOrString
 }
 
+// BackendTarget is one expose/routing backendRef that routes to a **separate** in-cluster
+// backend Service — not the exposing component's own. Ingress synthesis uses it to retarget the
+// synthesized allow onto the pods that actually receive the traffic (resolved from the backend
+// Service name to a sibling component). ServiceName is the referenced Kubernetes Service; Ports
+// are the referenced backend ports.
+type BackendTarget struct {
+	ServiceName string
+	Ports       []intstr.IntOrString
+}
+
 // Endpoint is a component's declared in-cluster data-plane endpoint (e.g. an operator-managed
 // database's instance pods). Namespace is deliberately absent — the platform caller knows the
 // target's namespace, and the synthesized NetworkPolicy is emitted in the component's namespace.

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -33,6 +33,13 @@ type trafficRule struct {
 	Ports   []intstr.IntOrString
 }
 
+// serviceBackendNamer is optionally implemented by a component config whose Kubernetes Service
+// name differs from its component name (e.g. a statefulset's headless service). Used to resolve
+// an expose backendRef (a Service name) back to the sibling component that owns it (#227).
+type serviceBackendNamer interface {
+	BackendServiceName() string
+}
+
 // componentAllowPolicyConfig is the ApplicationConfig for an auto-generated
 // NetworkPolicy that allows ingress from routing controller traffic sources to
 // the component's pods. The resource name is {component}-allow-ingress-traffic,
@@ -107,27 +114,67 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 //
 // Runs as a cluster post-build stage (Phase 4), after trait application — so the
 // synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
-func synthesizeNetworkPolicies(cluster *stack.Cluster, labelKey string) {
+func synthesizeNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, labelKey string) {
 	if cluster == nil {
 		return
 	}
 	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
-		synthesizeForBundle(bundle, labelKey)
+		synthesizeForBundle(bundle, componentMap, labelKey)
 	})
 }
 
-func synthesizeForBundle(bundle *stack.Bundle, labelKey string) {
+// backendRefTargetCollector is optionally implemented by routing trait configs (IngressConfig,
+// HTTPRouteConfig) that can route to a separate backend Service via expose backendRefs. It
+// surfaces those external targets so ingress synthesis can land the allow on the backend's own
+// pods instead of the exposing component's (#227).
+type backendRefTargetCollector interface {
+	BackendTargets() []netpol.BackendTarget
+}
+
+func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]componentEntry, labelKey string) {
 	if bundle == nil {
 		return
 	}
 
-	// Group collectors by component name, preserving insertion order for determinism.
+	// Group collectors by component name, preserving insertion order for determinism. injected
+	// carries retargeted rules for a backend component that a routing trait points at via an
+	// external backendRef (#227) — kept separate from the component's own collectors because its
+	// ports come from the backendRef, not the collector's own BackendPorts.
 	type groupEntry struct {
 		collectors []trafficSourceCollector
+		injected   []trafficRule
 		namespace  string
 	}
 	byComponent := map[string]*groupEntry{}
 	var componentOrder []string
+	ensureGroup := func(name string) *groupEntry {
+		g, exists := byComponent[name]
+		if !exists {
+			g = &groupEntry{}
+			byComponent[name] = g
+			componentOrder = append(componentOrder, name)
+		}
+		return g
+	}
+
+	// Map each in-bundle component's Service name to its component name, for backendRef
+	// resolution. A component's Service name is its BackendServiceName() when it declares one
+	// (e.g. statefulset's headless service), else its component name (webservice's convention).
+	inBundle := map[*stack.Application]bool{}
+	for _, a := range bundle.Applications {
+		inBundle[a] = true
+	}
+	serviceToComponent := map[string]string{}
+	for name, entry := range componentMap {
+		if !inBundle[entry.app] {
+			continue
+		}
+		svc := name
+		if sn, ok := entry.app.Config.(serviceBackendNamer); ok && sn.BackendServiceName() != "" {
+			svc = sn.BackendServiceName()
+		}
+		serviceToComponent[svc] = name
+	}
 
 	for _, appPtr := range bundle.Applications {
 		col, ok := appPtr.Config.(trafficSourceCollector)
@@ -135,17 +182,40 @@ func synthesizeForBundle(bundle *stack.Bundle, labelKey string) {
 			continue
 		}
 		name := col.TargetComponentName()
-		if _, exists := byComponent[name]; !exists {
-			byComponent[name] = &groupEntry{}
-			componentOrder = append(componentOrder, name)
+		g := ensureGroup(name)
+		g.collectors = append(g.collectors, col)
+		g.namespace = appPtr.Namespace
+
+		// #227: an external backendRef routes to a separate backend. Retarget its allow onto the
+		// backend component's pods (resolved from the backend Service name to a sibling
+		// component). Unresolvable refs (no owning component in the bundle) stay authored.
+		bt, ok := appPtr.Config.(backendRefTargetCollector)
+		if !ok {
+			continue
 		}
-		byComponent[name].collectors = append(byComponent[name].collectors, col)
-		byComponent[name].namespace = appPtr.Namespace
+		sources := col.TrafficSources()
+		if len(sources) == 0 {
+			continue // no traffic sources → nothing to allow
+		}
+		for _, target := range bt.BackendTargets() {
+			backendComp, resolved := serviceToComponent[target.ServiceName]
+			if !resolved || backendComp == name {
+				continue // unresolvable (authored fallback) or self (already handled above)
+			}
+			bg := ensureGroup(backendComp)
+			// The backend group's namespace must come from the backend's own app, not the
+			// router-bearing collector's; source it from componentMap.
+			if entry, ok := componentMap[backendComp]; ok {
+				bg.namespace = entry.app.Namespace
+			}
+			bg.injected = append(bg.injected, trafficRule{Sources: sources, Ports: target.Ports})
+		}
 	}
 
 	for _, compName := range componentOrder {
 		entry := byComponent[compName]
 		rules := buildTrafficRules(entry.collectors)
+		rules = appendDedupTrafficRules(rules, entry.injected)
 		if len(rules) == 0 {
 			continue
 		}
@@ -156,6 +226,28 @@ func synthesizeForBundle(bundle *stack.Bundle, labelKey string) {
 		)
 		bundle.Applications = append(bundle.Applications, autoApp)
 	}
+}
+
+// appendDedupTrafficRules appends extra rules to base, skipping any whose (sources, ports) key
+// already appears — so a backendRef-retargeted rule can't duplicate a rule the backend already
+// has from its own routing traits.
+func appendDedupTrafficRules(base, extra []trafficRule) []trafficRule {
+	seen := map[string]struct{}{}
+	for _, r := range base {
+		seen[trafficRuleKey(r.Sources, r.Ports)] = struct{}{}
+	}
+	for _, r := range extra {
+		if len(r.Ports) == 0 || len(r.Sources) == 0 {
+			continue
+		}
+		key := trafficRuleKey(r.Sources, r.Ports)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		base = append(base, r)
+	}
+	return base
 }
 
 // buildTrafficRules returns one trafficRule per collector with non-empty ports

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -108,7 +108,7 @@ func TestSynthesizeForBundle_AddsNetworkPolicyApp(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle, ComponentLabel)
+	synthesizeForBundle(bundle, nil, ComponentLabel)
 
 	if len(bundle.Applications) != 2 {
 		t.Fatalf("expected 2 applications after synthesis, got %d", len(bundle.Applications))
@@ -128,7 +128,7 @@ func TestSynthesizeForBundle_NoSynthesisWithoutSources(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle, ComponentLabel)
+	synthesizeForBundle(bundle, nil, ComponentLabel)
 
 	if len(bundle.Applications) != 1 {
 		t.Errorf("expected no synthesis (no sources), got %d apps", len(bundle.Applications))
@@ -150,7 +150,7 @@ func TestSynthesizeForBundle_TwoCollectorsSameComponent(t *testing.T) {
 	app2 := stack.NewApplication("web-httproute", "default", col2)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app1, app2}}
 
-	synthesizeForBundle(bundle, ComponentLabel)
+	synthesizeForBundle(bundle, nil, ComponentLabel)
 
 	// One synthesized policy per component (not per collector).
 	count := 0

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -407,7 +407,7 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	if labelKey == "" {
 		labelKey = ComponentLabelKeyForDomain(ctx.Domain)
 	}
-	synthesizeNetworkPolicies(cluster, labelKey)
+	synthesizeNetworkPolicies(cluster, componentMap, labelKey)
 	// Egress synthesis fails fast on a malformed non-authorable peer (ported but selector-less):
 	// a producer bug should fail the build, not silently emit a namespace-wide egress allow.
 	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey); err != nil {


### PR DESCRIPTION
## Summary

When a routing trait's `backendRef` (httproute) / path `backend` (ingress) names a **separate** in-bundle backend Service rather than the exposing component's own, the synthesized `{comp}-allow-ingress-traffic` allow is now **retargeted onto the backend component's pods** + the backendRef port.

Previously the synthesized ingress policy only covered the **exposing** component's pods, so under a namespace default-deny the router→backend traffic to the *separate* backend stayed blocked — forcing a downstream platform consumer to author a stopgap CiliumNetworkPolicy selecting the real backend pod labels. This retires that stopgap for expose-to-separate-backend cases.

## Resolution — sibling-component match

The backend Service name is resolved to a sibling OAM component in the same bundle: a component's Service name is its `BackendServiceName()` when it declares one (e.g. a statefulset's headless service), else its component name (webservice's convention). The retargeted rule is attributed to the backend component's group and reuses the existing `{backend}-allow-ingress-traffic` name + component-label selector.

- **Namespace** is sourced from the **backend's own app** (via `componentMap`), not the router-bearing collector's.
- **Dedup**: the retargeted rule is deduped against any rule the backend already has from its own routing traits.
- **Port assumption**: resolution assumes the sibling's Service port equals its container port, which holds for all builtin components (e.g. webservice sets `TargetPort == Port`). Documented in the traits README.

## Fallback

A backendRef that resolves to **no** in-bundle component (external / cross-bundle / a Service with no owning component) is **left authored** — no synthesis, no panic.

## Scope

Same-bundle sibling-component resolution only; no cross-bundle or Service-object (`spec.selector`) resolution.

## API

New shared type `netpol.BackendTarget`; routing configs expose their external backendRef targets via the optional `backendRefTargetCollector` interface consumed by the inbound synthesis pass.

## Tests

- Retarget: httproute backendRef → sibling webservice backend lands `backend-allow-ingress-traffic` on the backend selector + port 9000 with the router's traffic sources; the router-only exposer gets **no empty self policy**.
- Self-backendRef → unchanged (`web-allow-ingress-traffic` on the exposing component).
- Unresolvable backendRef → no synthesized policy; no panic.

## Docs

- `pkg/oam/builtin/traits/README.md`, `pkg/oam/README.md`, `pkg/oam/netpol/README.md`.

Closes #227