### PR TITLE
refactor(ci): adopt shared check-forbidden-terms action for scan parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -616,12 +616,21 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
 
+    # Shared org action; always scans --full-tree so a PR and the merge queue see
+    # identical results (go-kure/.github → docs/standards.md, scan-parity MUST rule).
     - name: Check for downstream references
-      # Scan the whole tree on every event (pull_request and merge_group alike) so a PR
-      # can never be green while the merge queue would reject it. A diff-scoped PR check
-      # let pre-existing violations (e.g. release-generated CHANGELOG lines) pass the PR
-      # yet block admission at the queue.
-      run: bash site/scripts/check-forbidden-terms.sh --full-tree
+      uses: go-kure/.github/.github/actions/check-forbidden-terms@main
+
+    # The release script (scripts/release.sh) still calls the vendored copy of the
+    # guard; keep it byte-identical to the canonical so the release preflight can't rot.
+    - name: Verify vendored guard matches canonical
+      uses: actions/checkout@v7
+      with:
+        repository: go-kure/.github
+        ref: main
+        path: .tmp/go-kure-dot-github
+    - name: Diff vendored guard vs canonical
+      run: diff -u .tmp/go-kure-dot-github/scripts/check-forbidden-terms.sh site/scripts/check-forbidden-terms.sh
 
     - name: Read Hugo version from mise.toml
       id: hugo-version

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,8 +237,10 @@ Launcher is an open-source go-kure project and must not name downstream, closed-
 platform consumers in tracked source, docs, comments, tests, or identifiers. Reword any
 such reference to a generic role (e.g. "a downstream consumer" / "the downstream runtime");
 never introduce a new one. This is the go-kure organization "No Downstream References"
-standard (`go-kure/.github` → `docs/standards.md`), CI-enforced here by
-`site/scripts/check-forbidden-terms.sh` (diff-scoped on PRs, full-tree otherwise). A
+standard (`go-kure/.github` → `docs/standards.md`), CI-enforced here via the shared
+`go-kure/.github` `check-forbidden-terms` action, which scans `--full-tree` on **every** event
+(pull request and merge queue alike) so the two never diverge; `scripts/release.sh` runs a
+byte-identical vendored copy (`site/scripts/check-forbidden-terms.sh`) as a release preflight. A
 legitimately unavoidable term takes an adjacent `allow-term:<word>` pragma. The remediation
 runbook is `go-kure/.github` → `docs/no-downstream-references.md`.
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -95,7 +95,7 @@ temporary branch — the merged result — before the PR is allowed to land.
 | `security` | `Security` | 10 min | changes | govulncheck (symbol scan, allowlist-gated), outdated deps check, sensitive file scan |
 | `coverage-check` | `Coverage Check` | 5 min | test | 80% threshold, Codecov upload, PR sticky comment |
 | `build-binaries` | `Build kurel` | 10 min | changes, test | Build `kurel` linux/amd64 binary; uploaded as artifact |
-| `docs-build` | `docs-build` | 15 min | changes | Hugo site build for docs; go + Hugo caches |
+| `docs-build` | `docs-build` | 15 min | changes | Hugo site build for docs; go + Hugo caches; runs the shared No-Downstream-References guard (`check-forbidden-terms` action, `--full-tree`) + a vendored-copy drift check |
 | `build` | `build` | 1 min | validate, test, build-binaries, docs-build, coverage-check | Aggregation gate |
 | `cross-platform` | `Cross-Platform Build` | 15 min | build-binaries | Matrix: linux × amd64/arm64 (main + release/* only) |
 | `analyze-changes` | `Analyze Changes` | 5 min | — | Changed files summary, breaking change warning for pkg/ (PR only) |
@@ -117,6 +117,10 @@ Runs on main and `release/*` branches only (not PRs):
 
 ### Features
 
+- **No-Downstream-References guard** — `docs-build` runs the shared `go-kure/.github`
+  `check-forbidden-terms` action, which scans `--full-tree` on **every** event so a PR and the merge
+  queue produce identical results (scan parity). A drift-check step keeps the vendored copy that
+  `scripts/release.sh` uses (`site/scripts/check-forbidden-terms.sh`) byte-identical to canonical
 - **Path filtering** — `dorny/paths-filter` skips jobs when unrelated files change
 - **Diff-based lint** — on PRs, lint only checks new/changed lines (`--new-from-rev`)
 - **CGO enabled** — test job installs `build-essential` for cgo-dependent packages

--- a/site/scripts/check-forbidden-terms.sh
+++ b/site/scripts/check-forbidden-terms.sh
@@ -9,10 +9,11 @@
 # See docs/standards.md, "No Downstream References (MUST)".
 #
 # Modes:
-#   --full-tree        Scan every tracked in-scope file. Completeness proof; used
-#                      by cleanup work and by push/schedule/merge_group CI.
-#   --diff BASE        Scan only lines added versus BASE (e.g. origin/main).
-#                      Regression guard for pull_request CI.
+#   --full-tree        Scan every tracked in-scope file. The blessed CI gate: run on
+#                      EVERY event (pull_request/push/schedule/merge_group) so PR and
+#                      merge-queue results are identical.
+#   --diff BASE        Scan only lines added versus BASE (e.g. origin/main). Local/dev
+#                      convenience only — MUST NOT gate CI (it diverges PR vs. queue).
 #
 # Scope (both modes): docs/  site/content/  pkg/**  cmd/**  scripts/**  **/*.md
 #   and .github/workflows/**. The guard script itself is excluded from its own scan.


### PR DESCRIPTION
Part of #31 (consumer-side adoption). Depends on go-kure/.github#32 (merged).

Replaces launcher's inline `docs-build` forbidden-references step with the shared `go-kure/.github` `check-forbidden-terms` composite action, so the CI scan scope is defined in one place and can't drift per-repo. The action always scans `--full-tree` on every event → a PR and the merge queue produce identical results.

## Changes
- **`.github/workflows/ci.yml`** — `docs-build`'s check now `uses: go-kure/.github/.github/actions/check-forbidden-terms@main`. It stays a step inside `docs-build`, so the required-check name is unchanged (no branch-protection change).
- **Re-sync** `site/scripts/check-forbidden-terms.sh` to the canonical copy (its header changed in go-kure/.github#32). `scripts/release.sh` still uses this vendored copy as a release preflight (#235).
- **Drift-check** step diffs the vendored copy against canonical (`go-kure/.github@main`, separate checkout path) so the release helper can't rot.
- **Doc sync**: `docs/github-workflows.md` describes the shared action; `AGENTS.md` fixes the stale "diff-scoped on PRs" note (launcher has scanned full-tree on every event since #232).

## Verification
- `check-forbidden-terms.sh --full-tree` → `OK`; vendored copy byte-identical to canonical.
- `check-doc-sync.sh` + `doc-gate` → OK; `ci.yml` valid YAML.