### PR TITLE
fix(oam/netpol): distinct resource names for multi-endpoint endpoint-ingress policies

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -60,7 +60,9 @@ each a **separate** additive resource (the authored `networkpolicy` /
   its dependency graph. One policy is emitted **per distinct endpoint**: a single-endpoint
   component keeps the bare `{comp}-allow-endpoint-ingress` name, while a multi-endpoint component
   (e.g. a CloudNativePG cluster plus its pooler) suffixes each policy with a short content hash of
-  the endpoint, so the names are distinct and stay stable across unrelated endpoint additions.
+  the endpoint, so the names are distinct and stay stable across unrelated endpoint additions. The
+  suffix names the emitted **NetworkPolicy resource** itself (not just the internal layout entry),
+  so a multi-endpoint component's resource ids are unique and `kustomize build` accepts them.
 
 The inbound/egress families select the component's own pods (the ingress recipients / the egress
 source pods) via a **derived `<domain>/component`** label by default — the domain comes

--- a/pkg/oam/netpol_endpoint_synthesis_test.go
+++ b/pkg/oam/netpol_endpoint_synthesis_test.go
@@ -1,6 +1,7 @@
 package oam
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
@@ -269,16 +270,35 @@ func TestSynthesizeEndpointIngress_MultiEndpoint(t *testing.T) {
 	}
 
 	// One NP must select the direct cluster pods, the other the pooler pods; both on port 5432.
+	// #238: the rendered NetworkPolicy *resource* names must also be distinct and sha-suffixed —
+	// the earlier test asserted only the distinct Application (layout) names, so the resource-name
+	// collision that broke `kustomize build` slipped through. Collect np.Name here to assert both.
+	prefix := "pg-allow-endpoint-ingress-"
+	hexSuffix := regexp.MustCompile(`^[0-9a-f]{8}$`)
+	var resourceNames []string
 	sawCluster, sawPooler := false, false
 	for _, app := range epApps {
 		objs, err := app.Config.Generate(app)
 		if err != nil {
 			t.Fatalf("Generate %q: %v", app.Name, err)
 		}
+		if len(objs) != 1 {
+			t.Fatalf("Generate %q: expected 1 object, got %d", app.Name, len(objs))
+		}
 		np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
 		if !ok {
 			t.Fatalf("expected *NetworkPolicy from %q, got %T", app.Name, *objs[0])
 		}
+		// The resource name must equal the (suffixed) layout name and carry a hex suffix, not the
+		// bare single-endpoint name that would collide across endpoints.
+		if np.Name != app.Name {
+			t.Errorf("resource name %q != layout name %q", np.Name, app.Name)
+		}
+		suffix := strings.TrimPrefix(np.Name, prefix)
+		if suffix == np.Name || !hexSuffix.MatchString(suffix) {
+			t.Errorf("resource name %q lacks %q + 8-hex suffix", np.Name, prefix)
+		}
+		resourceNames = append(resourceNames, np.Name)
 		ml := np.Spec.PodSelector.MatchLabels
 		port := np.Spec.Ingress[0].Ports[0].Port.IntVal
 		switch {
@@ -298,6 +318,9 @@ func TestSynthesizeEndpointIngress_MultiEndpoint(t *testing.T) {
 	}
 	if !sawCluster || !sawPooler {
 		t.Errorf("expected both cluster and pooler NPs (cluster=%v pooler=%v)", sawCluster, sawPooler)
+	}
+	if len(resourceNames) == 2 && resourceNames[0] == resourceNames[1] {
+		t.Errorf("expected two distinct NetworkPolicy resource names, both are %q", resourceNames[0])
 	}
 }
 

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -585,6 +585,20 @@ type componentEndpointIngressPolicyConfig struct {
 	ComponentName string
 	Endpoint      netpol.Endpoint       // this policy's single endpoint (podSelector + ports)
 	Rules         []endpointIngressRule // one per distinct source set, deduplicated
+	// PolicyName is the resource name for the emitted NetworkPolicy. Empty => the bare
+	// {ComponentName}-allow-endpoint-ingress default (directly-built/test configs); the synthesis
+	// path always sets the per-endpoint suffixed name so multi-endpoint resource names don't collide.
+	PolicyName string
+}
+
+// policyName returns the configured resource name, defaulting to the bare
+// {ComponentName}-allow-endpoint-ingress so a directly-built config still emits a valid single-
+// endpoint name. Mirrors the podSelectorKey() default-fallback pattern of the other families.
+func (c *componentEndpointIngressPolicyConfig) policyName() string {
+	if c.PolicyName == "" {
+		return c.ComponentName + "-allow-endpoint-ingress"
+	}
+	return c.PolicyName
 }
 
 // ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy fields
@@ -607,7 +621,7 @@ func (c *componentEndpointIngressPolicyConfig) Generate(app *stack.Application) 
 		return nil, nil // no valid sources; an Ingress NP with zero rules would deny all ingress
 	}
 
-	np := kubernetes.CreateNetworkPolicy(c.ComponentName+"-allow-endpoint-ingress", app.Namespace)
+	np := kubernetes.CreateNetworkPolicy(c.policyName(), app.Namespace)
 	np.Labels = nil
 	np.Annotations = nil
 	kubernetes.SetNetworkPolicyPodSelector(np, *c.Endpoint.PodSelector)
@@ -670,13 +684,18 @@ func synthesizeEndpointIngressNetworkPolicies(cluster *stack.Cluster, componentM
 			// downstream prune+create).
 			multi := len(groups) > 1
 			for _, g := range groups {
+				// Compute the per-endpoint name once and bind it to both the layout Application and
+				// the emitted resource, so a multi-endpoint component's NetworkPolicy resource names
+				// are distinct (not just its layout names).
+				name := endpointIngressPolicyName(app.Name, g.Endpoint, multi)
 				autoApps = append(autoApps, stack.NewApplication(
-					endpointIngressPolicyName(app.Name, g.Endpoint, multi),
+					name,
 					app.Namespace,
 					&componentEndpointIngressPolicyConfig{
 						ComponentName: app.Name,
 						Endpoint:      g.Endpoint,
 						Rules:         g.Rules,
+						PolicyName:    name,
 					},
 				))
 			}


### PR DESCRIPTION
## Summary

Fixes #238. The per-endpoint NetworkPolicy naming added in #226 was applied to the synthesized `stack.Application` *layout* name but **not** to the NetworkPolicy *resource object* name. A multi-endpoint component (e.g. a CloudNativePG cluster + its PgBouncer pooler) emitted **two NetworkPolicy objects with identical `name` + `namespace`**, differing only in `podSelector` — invalid: `kustomize build` fails on the duplicate resource id and `kubectl apply` silently keeps only one allow.

## Root cause

`componentEndpointIngressPolicyConfig.Generate` named the resource with the bare `ComponentName+"-allow-endpoint-ingress"` for every endpoint; the config carried `ComponentName`+`Endpoint` but not the computed suffixed policy name, so `Generate` couldn't reproduce the suffix.

## Fix

- Add a `PolicyName` field to `componentEndpointIngressPolicyConfig` with a `policyName()` fallback to the bare name (preserves directly-built/test configs), and use it in `Generate`.
- `synthesizeEndpointIngressNetworkPolicies` computes the per-endpoint name once and binds both the layout Application name and the emitted resource name to it.
- README doc-sync: clarify the suffix names the emitted NetworkPolicy resource, not just the layout entry.

## Test

Extended `TestSynthesizeEndpointIngress_MultiEndpoint` to assert the rendered `np.Name` equals the suffixed layout name, carries a hex suffix, and is distinct across endpoints. Confirmed it fails against the pre-fix code (bare name, collision) and passes after.

## Verification

- `go test ./pkg/oam/ -run 'TestSynthesizeEndpointIngress|TestEndpointIngress' -v` — pass
- `make precommit` (fmt, tidy, lint, test, kure-dep-sync) — pass
- `mise run build`, `check-doc-sync.sh`, `check-forbidden-terms.sh --diff origin/main` — pass

## Downstream

Unblocks crane#338 pooler-endpoint regression coverage. No production consumer today; impact was latent.