### PR TITLE
feat(oam/netpol): synthesize ingress allows for external routing backends via explicit selector

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -37,7 +37,16 @@ each a **separate** additive resource (the authored `networkpolicy` /
   `backendRef` names a **separate** in-bundle backend Service (not the exposing component's own),
   the allow is **retargeted onto that backend component's pods** + the backendRef port — resolved
   by matching the backend Service name to a sibling OAM component in the same bundle. A backendRef
-  that resolves to no in-bundle component is left authored (documented fallback).
+  that resolves to no in-bundle component (a **bare external Service**) is left authored **unless**
+  it carries an explicit authored `backendSelector` (matchLabels only, on the routing trait's
+  `paths[].backend` / `backendRefs[]` — the selector is not inferable from a Service name): that
+  emits a separate `{service}-allow-ingress-traffic` policy in the router's namespace selecting the
+  backend's pods on the backendRef ports. **Same-namespace only** (the backend is referenced by bare
+  name; cross-namespace `ReferenceGrant` is out of scope). External backends are deduplicated
+  **cluster-wide** (routers in different leaf bundles naming the same Service emit one merged
+  policy). Two routers giving one external Service different selectors, or an external policy name
+  colliding with a component's emitted inbound policy, **fails the transform** rather than emitting
+  conflicting or duplicate allows.
 - **Egress** (`{comp}-allow-egress-traffic`) — from `TransformContext.EgressPeers`, a
   downstream-supplied, non-authorable synthesis input (graph-derived dependency peers; never
   set from OAM YAML or capability rendering). K8s `NetworkPolicy` only. Empty when a

--- a/pkg/oam/builtin/traits/README.md
+++ b/pkg/oam/builtin/traits/README.md
@@ -121,6 +121,28 @@ resolves to no in-bundle component is **left authored**. Resolution assumes the 
 port equals its container port, which holds for all builtin components (e.g. webservice sets
 `TargetPort == Port`).
 
+A backend that names a **bare external Service** (no owning OAM component in the bundle) cannot be
+resolved to a selector by name. To synthesize an allow for it, add an explicit authorable
+`backendSelector` (matchLabels only) beside the backend reference —
+`rules[].paths[].backendSelector` (ingress/expose) or `rules[].backendRefs[].backendSelector`
+(httproute):
+
+```yaml
+paths:
+  - path: /
+    backend: external-svc      # a Service with no OAM component
+    port: 8081
+    backendSelector:
+      matchLabels:
+        app.kubernetes.io/name: external
+```
+
+This emits a `{service}-allow-ingress-traffic` policy in the router's namespace selecting the
+backend's pods on the backend ports. Without a `backendSelector`, an external backend stays authored
+(no selector is ever inferred from the Service name). A `backendSelector` on a self/implicit backend
+is rejected (it could never take effect), and a `backendSelector` on a ref that resolves to a
+sibling component is ignored (component-label retargeting wins). Same-namespace only.
+
 ## Extending
 
 Custom traits implement `oam.TraitHandler` (`CanHandle` + `Apply`), optionally

--- a/pkg/oam/builtin/traits/httproute.go
+++ b/pkg/oam/builtin/traits/httproute.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/go-kure/kure/pkg/kubernetes"
 	"github.com/go-kure/kure/pkg/stack"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -295,6 +296,25 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 				if nameExplicit && !portExplicit {
 					br.Port = 0
 				}
+
+				// backendSelector is honored only for an explicit external backend (see ingress).
+				if rawSel, ok := backendMap["backendSelector"]; ok {
+					selMap, ok := rawSel.(map[string]any)
+					if !ok {
+						return nil, errors.Errorf("rules[%d].backendRefs[%d].backendSelector: expected object, got %T", i, j, rawSel)
+					}
+					if !nameExplicit {
+						return nil, errors.Errorf("rules[%d].backendRefs[%d]: backendSelector is only valid with an explicit external backend 'name'", i, j)
+					}
+					sel, err := parseMatchLabelsSelector(selMap, fmt.Sprintf("rules[%d].backendRefs[%d].backendSelector", i, j))
+					if err != nil {
+						return nil, err
+					}
+					if len(sel.MatchLabels) == 0 {
+						return nil, errors.Errorf("rules[%d].backendRefs[%d].backendSelector.matchLabels: must be non-empty", i, j)
+					}
+					br.BackendSelector = sel
+				}
 				if !nameExplicit {
 					if !traitPortProvided {
 						if err := checkImplicitBackend(app, fmt.Sprintf("rules[%d].backendRefs[%d]", i, j)); err != nil {
@@ -353,7 +373,11 @@ func (h *HTTPRouteHandler) parseProperties(props map[string]any, app *stack.Appl
 	}
 	config.sources = sources
 	config.ports = collectHTTPRoutePorts(config, defaultServiceName)
-	config.backendTargets = collectHTTPRouteBackendTargets(config, defaultServiceName)
+	backendTargets, err := collectHTTPRouteBackendTargets(config, defaultServiceName)
+	if err != nil {
+		return nil, err
+	}
+	config.backendTargets = backendTargets
 
 	return config, nil
 }
@@ -1083,6 +1107,10 @@ type HeaderMatch struct {
 type BackendRef struct {
 	Name string
 	Port int32
+	// BackendSelector is the authored pod selector (matchLabels only) for an external backend
+	// Service — only valid when Name references a service other than the component's own. It drives
+	// ingress-synthesis onto the backend's pods when the Service has no owning component.
+	BackendSelector *metav1.LabelSelector
 }
 
 // Generate creates a Gateway API HTTPRoute resource.

--- a/pkg/oam/builtin/traits/ingress.go
+++ b/pkg/oam/builtin/traits/ingress.go
@@ -6,6 +6,7 @@ import (
 	"github.com/go-kure/kure/pkg/kubernetes"
 	"github.com/go-kure/kure/pkg/stack"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -94,11 +95,12 @@ func (h *IngressHandler) PropertySchema() map[string]oam.PropertySchema {
 							Type:        oam.PropertyTypeObject,
 							Description: "A single path mapping to a service backend.",
 							Properties: map[string]oam.PropertySchema{
-								"path":     {Type: oam.PropertyTypeString, Default: "/", Description: "URL path to match."},
-								"pathType": {Type: oam.PropertyTypeString, Default: "Prefix", Enum: []any{"Prefix", "Exact", "ImplementationSpecific"}, Description: "How the path is matched (Prefix, Exact, or ImplementationSpecific)."},
-								"backend":  {Type: oam.PropertyTypeString, Description: "Service name to route to (defaults to the component's service)."},
-								"port":     {Type: oam.PropertyTypeInteger, Description: "Service port number to route to."},
-								"portName": {Type: oam.PropertyTypeString, Description: "Named service port to route to (alternative to port)."},
+								"path":            {Type: oam.PropertyTypeString, Default: "/", Description: "URL path to match."},
+								"pathType":        {Type: oam.PropertyTypeString, Default: "Prefix", Enum: []any{"Prefix", "Exact", "ImplementationSpecific"}, Description: "How the path is matched (Prefix, Exact, or ImplementationSpecific)."},
+								"backend":         {Type: oam.PropertyTypeString, Description: "Service name to route to (defaults to the component's service)."},
+								"port":            {Type: oam.PropertyTypeInteger, Description: "Service port number to route to."},
+								"portName":        {Type: oam.PropertyTypeString, Description: "Named service port to route to (alternative to port)."},
+								"backendSelector": {Type: oam.PropertyTypeObject, AdditionalProperties: true, Description: "Explicit pod selector (matchLabels only) for an external backend Service; enables ingress NetworkPolicy synthesis onto the backend's pods."},
 							},
 						},
 					},
@@ -254,6 +256,27 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 				}
 			}
 
+			// backendSelector is honored only for an explicit external backend: a self/implicit
+			// backend is retargeted onto the component's own pods, so a selector there can never
+			// take effect — reject it loudly rather than silently ignore.
+			if rawSel, ok := pathMap["backendSelector"]; ok {
+				selMap, ok := rawSel.(map[string]any)
+				if !ok {
+					return nil, errors.Errorf("rules[%d].paths[%d].backendSelector: expected object, got %T", i, j, rawSel)
+				}
+				if !backendExplicit {
+					return nil, errors.Errorf("rules[%d].paths[%d]: backendSelector is only valid with an explicit external 'backend'", i, j)
+				}
+				sel, err := parseMatchLabelsSelector(selMap, fmt.Sprintf("rules[%d].paths[%d].backendSelector", i, j))
+				if err != nil {
+					return nil, err
+				}
+				if len(sel.MatchLabels) == 0 {
+					return nil, errors.Errorf("rules[%d].paths[%d].backendSelector.matchLabels: must be non-empty", i, j)
+				}
+				p.BackendSelector = sel
+			}
+
 			portExplicit := false
 			if port, ok := toIngressPort(pathMap["port"]); ok {
 				p.Port = port
@@ -340,7 +363,11 @@ func (h *IngressHandler) parseProperties(props map[string]any, app *stack.Applic
 	}
 	config.sources = sources
 	config.ports = collectIngressPorts(config)
-	config.backendTargets = collectIngressBackendTargets(config)
+	backendTargets, err := collectIngressBackendTargets(config)
+	if err != nil {
+		return nil, err
+	}
+	config.backendTargets = backendTargets
 
 	return config, nil
 }
@@ -397,6 +424,10 @@ type IngressPath struct {
 	ServiceName string // empty means use IngressConfig.ServiceName (= component service)
 	Port        int32
 	PortName    string
+	// BackendSelector is the authored pod selector (matchLabels only) for an external backend
+	// Service — only valid when ServiceName names a service other than the component's own. It
+	// drives ingress-synthesis onto the backend's pods when the Service has no owning component.
+	BackendSelector *metav1.LabelSelector
 }
 
 // IngressTLS represents a TLS entry.

--- a/pkg/oam/builtin/traits/networkpolicy_auto.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto.go
@@ -3,6 +3,7 @@ package traits
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -159,74 +160,141 @@ func collectHTTPRoutePorts(config *HTTPRouteConfig, selfServiceName string) []in
 }
 
 // collectIngressBackendTargets returns the external backend targets of an ingress trait: paths
-// naming a Service other than the component's own, grouped by service name with their ports. These
-// drive ingress-synthesis retargeting (#227) — landing the allow on the backend's pods rather than
-// the exposing component's own.
-func collectIngressBackendTargets(config *IngressConfig) []netpol.BackendTarget {
-	byName := map[string]map[string]intstr.IntOrString{}
-	var order []string
+// naming a Service other than the component's own, grouped by (service name, backendSelector) with
+// their ports. These drive ingress-synthesis retargeting (#227 for in-bundle components, #239 for
+// external Services carrying an explicit selector). Returns an error when one Service name is given
+// two different non-nil selectors — a Service has a single selector, so that is an authoring
+// conflict.
+func collectIngressBackendTargets(config *IngressConfig) ([]netpol.BackendTarget, error) {
+	var g backendTargetGroups
 	for _, rule := range config.Rules {
 		for _, path := range rule.Paths {
 			if path.ServiceName == "" || path.ServiceName == config.ServiceName {
 				continue // self backend; covered by BackendPorts
 			}
-			ports := ensureBackendTarget(byName, &order, path.ServiceName)
+			var port intstr.IntOrString
+			hasPort := false
 			if path.Port > 0 {
-				ports[fmt.Sprintf("n:%d", path.Port)] = intstr.FromInt32(path.Port)
+				port, hasPort = intstr.FromInt32(path.Port), true
 			} else if path.PortName != "" {
-				ports["s:"+path.PortName] = intstr.FromString(path.PortName)
+				port, hasPort = intstr.FromString(path.PortName), true
+			}
+			if err := g.add(path.ServiceName, path.BackendSelector, port, hasPort); err != nil {
+				return nil, err
 			}
 		}
 	}
-	return buildBackendTargets(order, byName)
+	return g.build(), nil
 }
 
 // collectHTTPRouteBackendTargets returns the external backend targets of an httproute trait:
-// backendRefs naming a Service other than the component's own, grouped by service name with their
-// ports. See collectIngressBackendTargets.
-func collectHTTPRouteBackendTargets(config *HTTPRouteConfig, selfServiceName string) []netpol.BackendTarget {
-	byName := map[string]map[string]intstr.IntOrString{}
-	var order []string
+// backendRefs naming a Service other than the component's own, grouped by (service name,
+// backendSelector) with their ports. See collectIngressBackendTargets.
+func collectHTTPRouteBackendTargets(config *HTTPRouteConfig, selfServiceName string) ([]netpol.BackendTarget, error) {
+	var g backendTargetGroups
 	for _, rule := range config.Rules {
 		for _, ref := range rule.BackendRefs {
 			if ref.Name == "" || ref.Name == selfServiceName {
 				continue // self backend; covered by BackendPorts
 			}
-			ports := ensureBackendTarget(byName, &order, ref.Name)
+			var port intstr.IntOrString
+			hasPort := false
 			if ref.Port > 0 {
-				ports[fmt.Sprintf("n:%d", ref.Port)] = intstr.FromInt32(ref.Port)
+				port, hasPort = intstr.FromInt32(ref.Port), true
+			}
+			if err := g.add(ref.Name, ref.BackendSelector, port, hasPort); err != nil {
+				return nil, err
 			}
 		}
 	}
-	return buildBackendTargets(order, byName)
+	return g.build(), nil
 }
 
-// ensureBackendTarget returns the port-dedup map for a service name, registering it (and its
-// insertion order) on first use.
-func ensureBackendTarget(byName map[string]map[string]intstr.IntOrString, order *[]string, name string) map[string]intstr.IntOrString {
-	ports, ok := byName[name]
-	if !ok {
-		ports = map[string]intstr.IntOrString{}
-		byName[name] = ports
-		*order = append(*order, name)
+// backendTargetGroups accumulates external backend refs into (service name, selector) groups with
+// deduped ports. A selectorless occurrence forms its own nil-selector group so its ports never
+// widen a group that carries a selector. A single Service name may carry at most one distinct
+// non-nil selector (a Kubernetes Service has one selector) — a second, different one is a conflict.
+type backendTargetGroups struct {
+	ports  map[string]map[string]intstr.IntOrString // composite key -> port dedup map
+	sel    map[string]*metav1.LabelSelector         // composite key -> group selector
+	svcSel map[string]*metav1.LabelSelector         // service name -> its single non-nil selector
+	order  []string                                 // composite keys, insertion order
+}
+
+func (g *backendTargetGroups) add(service string, sel *metav1.LabelSelector, port intstr.IntOrString, hasPort bool) error {
+	if g.ports == nil {
+		g.ports = map[string]map[string]intstr.IntOrString{}
+		g.sel = map[string]*metav1.LabelSelector{}
+		g.svcSel = map[string]*metav1.LabelSelector{}
 	}
-	return ports
+	if sel != nil && len(sel.MatchLabels) > 0 {
+		if prev, ok := g.svcSel[service]; ok && !matchLabelsEqual(prev, sel) {
+			return errors.Errorf("backend service %q given conflicting backendSelector values", service)
+		}
+		g.svcSel[service] = sel
+	}
+	key := service + "\x00" + backendSelectorKey(sel)
+	pm, ok := g.ports[key]
+	if !ok {
+		pm = map[string]intstr.IntOrString{}
+		g.ports[key] = pm
+		g.sel[key] = sel
+		g.order = append(g.order, key)
+	}
+	if hasPort {
+		if port.Type == intstr.Int {
+			pm[fmt.Sprintf("n:%d", port.IntVal)] = port
+		} else {
+			pm["s:"+port.StrVal] = port
+		}
+	}
+	return nil
 }
 
-// buildBackendTargets converts the per-service port maps into a deterministically ordered slice:
-// service names sorted lexically, ports via sortedIntOrStringPorts. Targets with no ports are
-// dropped (nothing to synthesize).
-func buildBackendTargets(order []string, byName map[string]map[string]intstr.IntOrString) []netpol.BackendTarget {
-	sort.Strings(order)
+// build converts the groups into a deterministically ordered slice: composite keys sorted (service
+// name then selector key), ports via sortedIntOrStringPorts. Groups with no ports are dropped.
+func (g *backendTargetGroups) build() []netpol.BackendTarget {
+	sort.Strings(g.order)
 	var out []netpol.BackendTarget
-	for _, name := range order {
-		ports := sortedIntOrStringPorts(byName[name])
+	for _, key := range g.order {
+		ports := sortedIntOrStringPorts(g.ports[key])
 		if len(ports) == 0 {
 			continue
 		}
-		out = append(out, netpol.BackendTarget{ServiceName: name, Ports: ports})
+		service := key[:strings.IndexByte(key, '\x00')]
+		out = append(out, netpol.BackendTarget{ServiceName: service, Ports: ports, PodSelector: g.sel[key]})
 	}
 	return out
+}
+
+// backendSelectorKey is a canonical key for a matchLabels-only selector; "" for nil/empty.
+func backendSelectorKey(sel *metav1.LabelSelector) string {
+	if sel == nil || len(sel.MatchLabels) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(sel.MatchLabels))
+	for k, v := range sel.MatchLabels {
+		parts = append(parts, k+"="+v)
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}
+
+// matchLabelsEqual reports whether two matchLabels-only selectors are equal (both nil counts as
+// equal). Used to detect conflicting backendSelector values for one Service name.
+func matchLabelsEqual(a, b *metav1.LabelSelector) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if len(a.MatchLabels) != len(b.MatchLabels) {
+		return false
+	}
+	for k, v := range a.MatchLabels {
+		if b.MatchLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // sortedIntOrStringPorts converts the dedup map to a deterministically ordered

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -761,3 +761,455 @@ func TestTransform_IngressPeers_SynthesizesEndpointIngressNetworkPolicy(t *testi
 		t.Errorf("podSelector = %v, want single cnpg.io/cluster=orders-db", sel)
 	}
 }
+
+// --- #239: external (non-component) routing backends with an explicit backendSelector ---
+
+// ingressExternalBackendApp builds a single-webservice app whose ingress trait routes to one
+// external backend path. selector nil omits backendSelector.
+func ingressExternalBackendApp(backend string, port int, selector map[string]any) *oam.Application {
+	pathMap := map[string]any{"path": "/", "backend": backend, "port": port}
+	if selector != nil {
+		pathMap["backendSelector"] = map[string]any{"matchLabels": selector}
+	}
+	return &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules":         []any{map[string]any{"host": "example.com", "paths": []any{pathMap}}},
+						"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}}},
+					},
+				}},
+			}},
+		},
+	}
+}
+
+// An ingress path routing to an external bare Service with an explicit backendSelector synthesizes
+// an ingress allow onto the selector's pods (not the router), on the backend port, with the
+// namespace-wide routing traffic source preserved.
+func TestTransform_ExternalBackend_Ingress_WithSelector_SynthesizesNP(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := ingressExternalBackendApp("external-svc", 8081, map[string]any{"app.kubernetes.io/name": "external"})
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "external-svc-allow-ingress-traffic")
+	if np.Namespace != "default" {
+		t.Errorf("namespace = %q, want default", np.Namespace)
+	}
+	if got := np.Spec.PodSelector.MatchLabels; got["app.kubernetes.io/name"] != "external" || len(got) != 1 {
+		t.Errorf("podSelector = %v, want single app.kubernetes.io/name=external", got)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 8081 {
+		t.Errorf("expected single ingress port 8081, got %+v", np.Spec.Ingress)
+	}
+	from := np.Spec.Ingress[0].From
+	if len(from) != 1 || from[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "ingress-nginx" || from[0].PodSelector != nil {
+		t.Errorf("expected namespace-wide From ingress-nginx, got %+v", from)
+	}
+	if clusterHasApp(cluster, "router-allow-ingress-traffic") {
+		t.Errorf("did not expect a self policy for the pure-exposer router; apps: %v", clusterAppNames(cluster))
+	}
+}
+
+// The HTTPRoute shape: a backendRef to an external bare Service + backendSelector synthesizes the
+// same kind of policy.
+func TestTransform_ExternalBackend_HTTPRoute_WithSelector_SynthesizesNP(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "httproute",
+					Properties: map[string]any{
+						"parentRefs": []any{map[string]any{"name": "gw"}},
+						"rules": []any{map[string]any{
+							"backendRefs": []any{map[string]any{
+								"name":            "external-svc",
+								"port":            8081,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}},
+							}},
+						}},
+						"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "gateway-system"}}},
+					},
+				}},
+			}},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "external-svc-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels; got["app.kubernetes.io/name"] != "external" || len(got) != 1 {
+		t.Errorf("podSelector = %v, want single app.kubernetes.io/name=external", got)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 8081 {
+		t.Errorf("expected single ingress port 8081, got %+v", np.Spec.Ingress)
+	}
+}
+
+// Without a backendSelector, an unresolvable external backend stays authored — no synthesized
+// policy (the pre-#239 behavior).
+func TestTransform_ExternalBackend_WithoutSelector_LeavesAuthored(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := ingressExternalBackendApp("external-svc", 8081, nil)
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	if clusterHasApp(cluster, "external-svc-allow-ingress-traffic") {
+		t.Errorf("expected no synthesized policy without a selector; apps: %v", clusterAppNames(cluster))
+	}
+}
+
+// Mixed presence for one external Service: a selector-bearing occurrence is synthesized on its own
+// port; a selectorless occurrence stays authored and must not widen the synthesized policy's ports.
+func TestTransform_ExternalBackend_MixedSelectorPresence_DoesNotWiden(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules": []any{map[string]any{"host": "example.com", "paths": []any{
+							map[string]any{"path": "/a", "backend": "external-svc", "port": 8081,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}}},
+							map[string]any{"path": "/b", "backend": "external-svc", "port": 9091},
+						}}},
+						"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}}},
+					},
+				}},
+			}},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "external-svc-allow-ingress-traffic")
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 8081 {
+		t.Errorf("expected only the selected port 8081 (9091 stays authored), got %+v", np.Spec.Ingress)
+	}
+}
+
+// Two paths giving the SAME external Service two different selectors is an authoring conflict — a
+// Service has one selector — rejected at parse.
+func TestTransform_ExternalBackend_ConflictingSelectorsInTrait_Rejected(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules": []any{map[string]any{"host": "example.com", "paths": []any{
+							map[string]any{"path": "/a", "backend": "external-svc", "port": 8081,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}}},
+							map[string]any{"path": "/b", "backend": "external-svc", "port": 8082,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "other"}}},
+						}}},
+						"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}}},
+					},
+				}},
+			}},
+		},
+	}
+	if _, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"}); err == nil {
+		t.Fatal("expected an error for conflicting backendSelector values on one Service")
+	}
+}
+
+// Two routers naming the same external Service in the same namespace with different selectors is a
+// conflict resolved only at synthesis — it must fail the transform, not emit two colliding allows.
+func TestTransform_ExternalBackend_ConflictingSelectorsAcrossRouters_FailsTransform(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	mkRouter := func(name, label string) oam.Component {
+		return oam.Component{
+			Name:       name,
+			Type:       "webservice",
+			Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+			Traits: []oam.Trait{{
+				Type: "ingress",
+				Properties: map[string]any{
+					"rules": []any{map[string]any{"host": name + ".example.com", "paths": []any{
+						map[string]any{"path": "/", "backend": "external-svc", "port": 8081,
+							"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": label}}},
+					}}},
+					"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}}},
+				},
+			}},
+		}
+	}
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec:     oam.ApplicationSpec{Components: []oam.Component{mkRouter("router-a", "external"), mkRouter("router-b", "other")}},
+	}
+	if _, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"}); err == nil {
+		t.Fatal("expected an error for an external Service given two different selectors across routers")
+	}
+}
+
+// An external policy name that collides with an ACTUALLY-EMITTED component inbound policy fails the
+// transform. Component db (statefulset, Service db-headless) emits db-allow-ingress-traffic; a
+// router routing to a bare external Service named db would collide.
+func TestTransform_ExternalBackend_NameCollisionWithEmittedComponent_FailsTransform(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterComponent("statefulset", &components.StatefulsetHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "db",
+					Type:       "statefulset",
+					Properties: map[string]any{"image": "postgres:16", "port": 5432, "serviceName": "db-headless"},
+					// db's own routing trait → emits db-allow-ingress-traffic.
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs":    []any{map[string]any{"name": "gw"}},
+							"rules":         []any{map[string]any{"backendRefs": []any{map[string]any{"name": "db-headless", "port": 5432}}}},
+							"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "gateway-system"}}},
+						},
+					}},
+				},
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							// Bare external Service "db" (not db-headless) → unresolved → db-allow-ingress-traffic.
+							"rules": []any{map[string]any{"backendRefs": []any{map[string]any{
+								"name": "db", "port": 8080,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}},
+							}}}},
+							"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "gateway-system"}}},
+						},
+					}},
+				},
+			},
+		},
+	}
+	if _, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"}); err == nil {
+		t.Fatal("expected an error for an external backend policy name colliding with an emitted component policy")
+	}
+}
+
+// The collision check keys on emitted policy names, not on component existence: a same-named
+// component that emits NO inbound policy is not a conflict, so the external policy is still emitted.
+func TestTransform_ExternalBackend_NameNoCollisionWhenComponentHasNoPolicy(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterComponent("statefulset", &components.StatefulsetHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				// db has a differing Service name and no routing trait → emits no db-allow-ingress-traffic.
+				{
+					Name:       "db",
+					Type:       "statefulset",
+					Properties: map[string]any{"image": "postgres:16", "port": 5432, "serviceName": "db-headless"},
+				},
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							"rules": []any{map[string]any{"backendRefs": []any{map[string]any{
+								"name": "db", "port": 8080,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}},
+							}}}},
+							"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "gateway-system"}}},
+						},
+					}},
+				},
+			},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "db-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels; got["app.kubernetes.io/name"] != "external" || len(got) != 1 {
+		t.Errorf("podSelector = %v, want the external backend selector app.kubernetes.io/name=external", got)
+	}
+}
+
+// A backendSelector on a ref that resolves to a sibling in-bundle component is ignored — #227
+// component-label targeting takes precedence and no error is raised.
+func TestTransform_ExternalBackend_SelectorOnSiblingComponent_Ignored(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							"rules": []any{map[string]any{"backendRefs": []any{map[string]any{
+								"name": "backend", "port": 9000,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}},
+							}}}},
+							"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "gateway-system"}}},
+						},
+					}},
+				},
+				{Name: "backend", Type: "webservice", Properties: map[string]any{"image": "api:1.0", "port": 9000}},
+			},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "backend-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "backend" {
+		t.Errorf("selector = %v, want #227 component-label gokure.dev/component=backend (authored selector ignored)", np.Spec.PodSelector.MatchLabels)
+	}
+	if clusterHasApp(cluster, "external-svc-allow-ingress-traffic") || clusterHasApp(cluster, "backend-allow-backend-ingress") {
+		t.Errorf("did not expect an external-backend policy for a resolvable ref; apps: %v", clusterAppNames(cluster))
+	}
+}
+
+// A backendSelector on a self/implicit backend can never take effect (the allow is retargeted onto
+// the component's own pods) → rejected at parse.
+func TestTransform_ExternalBackend_SelectorOnSelfBackend_Rejected(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules": []any{map[string]any{"host": "example.com", "paths": []any{
+							map[string]any{"path": "/", "port": 8080,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "external"}}},
+						}}},
+					},
+				}},
+			}},
+		},
+	}
+	if _, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"}); err == nil {
+		t.Fatal("expected an error for backendSelector on a self/implicit backend")
+	}
+}
+
+// An empty matchLabels backendSelector is rejected — it would otherwise select every pod.
+func TestTransform_ExternalBackend_EmptyMatchLabels_Rejected(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := ingressExternalBackendApp("external-svc", 8081, map[string]any{})
+	if _, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"}); err == nil {
+		t.Fatal("expected an error for an empty matchLabels backendSelector")
+	}
+}
+
+// Two distinct external Services each with a selector yield two distinct, deterministically named
+// policies.
+func TestTransform_ExternalBackend_MultipleServices_DistinctNames(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterBuiltinTrait("ingress", &traits.IngressHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{{
+				Name:       "router",
+				Type:       "webservice",
+				Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+				Traits: []oam.Trait{{
+					Type: "ingress",
+					Properties: map[string]any{
+						"rules": []any{map[string]any{"host": "example.com", "paths": []any{
+							map[string]any{"path": "/a", "backend": "external-a", "port": 8081,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "a"}}},
+							map[string]any{"path": "/b", "backend": "external-b", "port": 8082,
+								"backendSelector": map[string]any{"matchLabels": map[string]any{"app.kubernetes.io/name": "b"}}},
+						}}},
+						"networkPolicy": map[string]any{"trafficSources": []any{map[string]any{"namespace": "ingress-nginx"}}},
+					},
+				}},
+			}},
+		},
+	}
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	for _, name := range []string{"external-a-allow-ingress-traffic", "external-b-allow-ingress-traffic"} {
+		if !clusterHasApp(cluster, name) {
+			t.Errorf("expected synthesized %q; apps: %v", name, clusterAppNames(cluster))
+		}
+	}
+}

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -17,9 +17,13 @@ Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
   egress allow (`to.PodSelector` nil = all pods). A peer with **no ports** is the documented
   escape hatch and is silently skipped (destination stays authored).
 - `BackendTarget` — one routing `backendRef` that targets a **separate** in-cluster backend
-  Service (not the exposing component's own): a Service name + ports. Ingress synthesis retargets
-  the `{comp}-allow-ingress-traffic` allow onto the backend's pods (resolved from the Service name
-  to a sibling component); an unresolvable target is left authored.
+  Service (not the exposing component's own): a Service name + ports + an optional `PodSelector`.
+  When the Service name resolves to a sibling in-bundle component, ingress synthesis retargets the
+  `{comp}-allow-ingress-traffic` allow onto that component's pods (#227) and the `PodSelector` is
+  ignored. When it does **not** resolve (a bare external Service), the selector is not inferable
+  from the name: an explicit matchLabels `PodSelector` (the authored `backendSelector`) synthesizes
+  a `{service}-allow-ingress-traffic` allow onto those pods, while a nil selector leaves the backend
+  authored.
 - `Endpoint` — a component's declared in-cluster data-plane endpoint: a pod selector
   (matchLabels only) + ports. Namespace is deliberately absent (the caller knows the target's
   namespace). Declared by a component handler via the optional `oam.EndpointProvider`.

--- a/pkg/oam/netpol/types.go
+++ b/pkg/oam/netpol/types.go
@@ -37,12 +37,18 @@ type EgressPeer struct {
 
 // BackendTarget is one expose/routing backendRef that routes to a **separate** in-cluster
 // backend Service — not the exposing component's own. Ingress synthesis uses it to retarget the
-// synthesized allow onto the pods that actually receive the traffic (resolved from the backend
-// Service name to a sibling component). ServiceName is the referenced Kubernetes Service; Ports
-// are the referenced backend ports.
+// synthesized allow onto the pods that actually receive the traffic. ServiceName is the referenced
+// Kubernetes Service; Ports are the referenced backend ports.
+//
+// PodSelector is the authored backend pod selector (matchLabels only), used only when the backend
+// Service does NOT resolve to a sibling in-bundle component: the selector is not inferable from the
+// Service name, so an external bare Service carrying an explicit selector is synthesized onto those
+// pods, while a nil selector leaves the backend authored. When the Service resolves to a sibling
+// component (#227), the component-label targeting takes precedence and PodSelector is ignored.
 type BackendTarget struct {
 	ServiceName string
 	Ports       []intstr.IntOrString
+	PodSelector *metav1.LabelSelector // authored backendSelector (matchLabels only); nil = leave authored
 }
 
 // Endpoint is a component's declared in-cluster data-plane endpoint (e.g. an operator-managed

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -77,8 +77,19 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 	})
 	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress})
 
+	appendIngressTrafficRules(np, c.Rules)
+
+	obj := client.Object(np)
+	return []*client.Object{&obj}, nil
+}
+
+// appendIngressTrafficRules emits one NetworkPolicy ingress rule per trafficRule: a namespace peer
+// (optionally narrowed by the source's matchLabels pod selector, else namespace-wide) for each
+// source, and the rule's ports (TCP). Shared by the inbound component family and the external
+// backend family so their From/Ports emission cannot drift.
+func appendIngressTrafficRules(np *networkingv1.NetworkPolicy, rules []trafficRule) {
 	proto := corev1.ProtocolTCP
-	for _, tr := range c.Rules {
+	for _, tr := range rules {
 		rule := networkingv1.NetworkPolicyIngressRule{}
 		for _, src := range tr.Sources {
 			peer := networkingv1.NetworkPolicyPeer{
@@ -102,6 +113,37 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 		}
 		kubernetes.AddNetworkPolicyIngressRule(np, rule)
 	}
+}
+
+// backendIngressAllowPolicyConfig is the ApplicationConfig for an auto-generated NetworkPolicy that
+// allows ingress to an EXTERNAL routing backend — a bare Service with no owning OAM component (#239).
+// Unlike componentAllowPolicyConfig it selects an explicit, authored pod selector (the backend's
+// pods) rather than a component-label key, and takes an explicit resource name. Like the inbound
+// family (and unlike endpoint-ingress), it permits namespace-wide sources, since routing
+// trafficSources are typically namespace-scoped.
+type backendIngressAllowPolicyConfig struct {
+	PolicyName  string
+	PodSelector *metav1.LabelSelector // authored backend selector (matchLabels-only)
+	Rules       []trafficRule
+}
+
+// ApplyPolicy is a no-op: a synthesized NetworkPolicy has no enforceable policy fields.
+func (c *backendIngressAllowPolicyConfig) ApplyPolicy(_ Policy) error { return nil }
+
+func (c *backendIngressAllowPolicyConfig) Generate(app *stack.Application) ([]*client.Object, error) {
+	// Residual fail-closed: never emit a policy that selects every pod in the namespace, even for a
+	// directly-built config (the synthesis path already validates the selector before constructing).
+	// A directly-built invalid config emits nothing, not an error.
+	if !matchLabelsSelectorValid(c.PodSelector) {
+		return nil, nil
+	}
+	np := kubernetes.CreateNetworkPolicy(c.PolicyName, app.Namespace)
+	np.Labels = nil
+	np.Annotations = nil
+	kubernetes.SetNetworkPolicyPodSelector(np, *c.PodSelector)
+	kubernetes.SetNetworkPolicyPolicyTypes(np, []networkingv1.PolicyType{networkingv1.PolicyTypeIngress})
+
+	appendIngressTrafficRules(np, c.Rules)
 
 	obj := client.Object(np)
 	return []*client.Object{&obj}, nil
@@ -114,13 +156,114 @@ func (c *componentAllowPolicyConfig) Generate(app *stack.Application) ([]*client
 //
 // Runs as a cluster post-build stage (Phase 4), after trait application — so the
 // synthesized policies are not subject to Enforceable.ApplyPolicy (intentional).
-func synthesizeNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, labelKey string) {
+func synthesizeNetworkPolicies(cluster *stack.Cluster, componentMap map[string]componentEntry, labelKey string) error {
 	if cluster == nil {
-		return
+		return nil
 	}
+	// External-backend accumulation and name-collision detection are CLUSTER-wide, not per-bundle:
+	// two routers in different leaf bundles can name the same external Service in the same namespace,
+	// which would otherwise emit duplicate NetworkPolicy resource ids (or miss a cross-bundle
+	// selector conflict). Component policies stay per-bundle (a component lives in exactly one
+	// bundle, so its name is already cluster-unique).
+	reg := newNPSynthesisRegistry()
+	// walkLeafBundles cannot abort traversal, so capture the first error and guard the callback.
+	var firstErr error
 	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
-		synthesizeForBundle(bundle, componentMap, labelKey)
+		if firstErr != nil {
+			return
+		}
+		if err := synthesizeForBundle(bundle, componentMap, labelKey, reg); err != nil {
+			firstErr = err
+		}
 	})
+	if firstErr != nil {
+		return firstErr
+	}
+	if err := reg.emitExternalBackends(); err != nil {
+		return err
+	}
+	// Every append is deferred to here, so an error at any point above leaves the cluster
+	// completely unmutated (no partially-decorated bundle observable by a direct caller).
+	reg.flush()
+	return nil
+}
+
+// externalBackendEntry accumulates one external routing backend (a bare Service with no owning
+// component) cluster-wide, keyed namespace-qualified. rules merge across every router that names it;
+// bundle is the leaf bundle its synthesized policy attaches to (the first router's, by walk order).
+type externalBackendEntry struct {
+	selector  *metav1.LabelSelector
+	namespace string
+	service   string
+	bundle    *stack.Bundle
+	rules     []trafficRule
+}
+
+// pendingSynthApp is a synthesized application queued for append to its bundle. All appends are
+// deferred until every bundle has been validated, so a later error leaves no partial mutation.
+type pendingSynthApp struct {
+	bundle *stack.Bundle
+	app    *stack.Application
+}
+
+// npSynthesisRegistry holds cluster-wide synthesis state: every emitted policy's namespace/name (to
+// detect external-vs-component collisions), the external-backend accumulator, and the deferred
+// append queue.
+type npSynthesisRegistry struct {
+	emitted          map[string]struct{}              // namespace/name of every synthesized policy
+	externalBackends map[string]*externalBackendEntry // key: namespace\x00service
+	externalOrder    []string
+	pending          []pendingSynthApp
+}
+
+func newNPSynthesisRegistry() *npSynthesisRegistry {
+	return &npSynthesisRegistry{
+		emitted:          map[string]struct{}{},
+		externalBackends: map[string]*externalBackendEntry{},
+	}
+}
+
+// queue records a synthesized app for deferred append to its bundle.
+func (r *npSynthesisRegistry) queue(bundle *stack.Bundle, app *stack.Application) {
+	r.pending = append(r.pending, pendingSynthApp{bundle: bundle, app: app})
+}
+
+// flush appends every queued app to its bundle. Called once, after all validation succeeds — the
+// only step that mutates a bundle.
+func (r *npSynthesisRegistry) flush() {
+	for _, p := range r.pending {
+		p.bundle.Applications = append(p.bundle.Applications, p.app)
+	}
+}
+
+// emitExternalBackends queues one {service}-allow-ingress-traffic policy per accumulated external
+// backend, after every bundle has contributed. It fails the transform when an external policy name
+// collides with a policy already emitted this pass (a component whose Service name differs, leaving
+// a bare external Service that shares the component's name). Runs after the walk so the collision
+// check sees every component policy cluster-wide; the queued apps are appended only by flush().
+func (r *npSynthesisRegistry) emitExternalBackends() error {
+	sort.Strings(r.externalOrder)
+	for _, key := range r.externalOrder {
+		eb := r.externalBackends[key]
+		rules := appendDedupTrafficRules(nil, eb.rules)
+		if len(rules) == 0 {
+			continue
+		}
+		policyName := eb.service + "-allow-ingress-traffic"
+		nsName := eb.namespace + "/" + policyName
+		if _, dup := r.emitted[nsName]; dup {
+			return errors.Errorf(
+				"external backend Service %q in namespace %q collides with a synthesized policy named %q",
+				eb.service, eb.namespace, policyName)
+		}
+		r.emitted[nsName] = struct{}{}
+		r.queue(eb.bundle, stack.NewApplication(
+			policyName,
+			eb.namespace,
+			&backendIngressAllowPolicyConfig{PolicyName: policyName, PodSelector: eb.selector, Rules: rules},
+		))
+	}
+	return nil
 }
 
 // backendRefTargetCollector is optionally implemented by routing trait configs (IngressConfig,
@@ -131,9 +274,9 @@ type backendRefTargetCollector interface {
 	BackendTargets() []netpol.BackendTarget
 }
 
-func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]componentEntry, labelKey string) {
+func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]componentEntry, labelKey string, reg *npSynthesisRegistry) error {
 	if bundle == nil {
-		return
+		return nil
 	}
 
 	// Group collectors by component name, preserving insertion order for determinism. injected
@@ -199,19 +342,53 @@ func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]component
 		}
 		for _, target := range bt.BackendTargets() {
 			backendComp, resolved := serviceToComponent[target.ServiceName]
-			if !resolved || backendComp == name {
-				continue // unresolvable (authored fallback) or self (already handled above)
+			if resolved {
+				if backendComp == name {
+					continue // self (already handled above)
+				}
+				// #227: retarget onto the in-bundle backend component's pods. An authored
+				// backendSelector on a resolvable ref is ignored — component-label targeting wins.
+				bg := ensureGroup(backendComp)
+				// The backend group's namespace must come from the backend's own app, not the
+				// router-bearing collector's; source it from componentMap.
+				if entry, ok := componentMap[backendComp]; ok {
+					bg.namespace = entry.app.Namespace
+				}
+				bg.injected = append(bg.injected, trafficRule{Sources: sources, Ports: target.Ports})
+				continue
 			}
-			bg := ensureGroup(backendComp)
-			// The backend group's namespace must come from the backend's own app, not the
-			// router-bearing collector's; source it from componentMap.
-			if entry, ok := componentMap[backendComp]; ok {
-				bg.namespace = entry.app.Namespace
+			// #239: external bare Service. Synthesize only with an explicit, valid authored
+			// selector; otherwise leave authored (current behavior — no name-based inference).
+			// Accumulate cluster-wide (in reg) so a Service named across bundles is deduped/merged
+			// and a cross-bundle selector conflict is still caught.
+			if target.PodSelector == nil || !matchLabelsSelectorValid(target.PodSelector) {
+				continue
 			}
-			bg.injected = append(bg.injected, trafficRule{Sources: sources, Ports: target.Ports})
+			ebKey := appPtr.Namespace + "\x00" + target.ServiceName
+			eb, ok := reg.externalBackends[ebKey]
+			if !ok {
+				eb = &externalBackendEntry{
+					selector:  target.PodSelector,
+					namespace: appPtr.Namespace,
+					service:   target.ServiceName,
+					bundle:    bundle,
+				}
+				reg.externalBackends[ebKey] = eb
+				reg.externalOrder = append(reg.externalOrder, ebKey)
+			} else if !matchLabelsSelectorEqual(eb.selector, target.PodSelector) {
+				return errors.Errorf(
+					"external backend Service %q in namespace %q given conflicting backendSelector values",
+					target.ServiceName, appPtr.Namespace)
+			}
+			eb.rules = append(eb.rules, trafficRule{Sources: sources, Ports: target.Ports})
 		}
 	}
 
+	// Queue the per-component inbound policies for this bundle, recording their names in the
+	// cluster-wide registry so external-backend collisions can be detected against the full set.
+	// Nothing is appended here — every synthesized app (component + external) is flushed only after
+	// the whole cluster is walked and validated (synthesizeNetworkPolicies), so any error leaves the
+	// cluster unmutated.
 	for _, compName := range componentOrder {
 		entry := byComponent[compName]
 		rules := buildTrafficRules(entry.collectors)
@@ -219,13 +396,38 @@ func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]component
 		if len(rules) == 0 {
 			continue
 		}
-		autoApp := stack.NewApplication(
-			compName+"-allow-ingress-traffic",
+		policyName := compName + "-allow-ingress-traffic"
+		reg.emitted[entry.namespace+"/"+policyName] = struct{}{}
+		reg.queue(bundle, stack.NewApplication(
+			policyName,
 			entry.namespace,
 			&componentAllowPolicyConfig{ComponentName: compName, Rules: rules, PodSelectorKey: labelKey},
-		)
-		bundle.Applications = append(bundle.Applications, autoApp)
+		))
 	}
+	return nil
+}
+
+// matchLabelsSelectorValid is the bool form of validateMatchLabelsSelector, for fail-closed
+// drop paths that must not surface a nil error (avoids a nilerr lint on Generate).
+func matchLabelsSelectorValid(sel *metav1.LabelSelector) bool {
+	return validateMatchLabelsSelector(sel) == nil
+}
+
+// matchLabelsSelectorEqual reports whether two matchLabels-only selectors are equal (both nil counts
+// as equal). Used to detect an external Service given two different backendSelector values.
+func matchLabelsSelectorEqual(a, b *metav1.LabelSelector) bool {
+	if a == nil || b == nil {
+		return a == nil && b == nil
+	}
+	if len(a.MatchLabels) != len(b.MatchLabels) {
+		return false
+	}
+	for k, v := range a.MatchLabels {
+		if b.MatchLabels[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // appendDedupTrafficRules appends extra rules to base, skipping any whose (sources, ports) key

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -6,11 +6,47 @@ import (
 	"github.com/go-kure/kure/pkg/stack"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/go-kure/launcher/pkg/oam/netpol"
 )
+
+// extBackendStub is a router collector (traffic sources + external backend targets, no self ports)
+// used to exercise external-backend synthesis across multiple leaf bundles.
+type extBackendStub struct {
+	component string
+	sources   []netpol.TrafficSource
+	targets   []netpol.BackendTarget
+}
+
+func (s *extBackendStub) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+func (s *extBackendStub) TrafficSources() []netpol.TrafficSource                  { return s.sources }
+func (s *extBackendStub) TargetComponentName() string                             { return s.component }
+func (s *extBackendStub) BackendPorts() []intstr.IntOrString                      { return nil }
+func (s *extBackendStub) BackendTargets() []netpol.BackendTarget                  { return s.targets }
+
+// twoLeafBundleCluster builds a cluster whose root node has two child leaf bundles, each holding one
+// application — the minimal multi-bundle shape a dependency-aware/hierarchical transform produces.
+func twoLeafBundleCluster(a, b *stack.Application) *stack.Cluster {
+	return &stack.Cluster{Node: &stack.Node{Children: []*stack.Node{
+		{Bundle: &stack.Bundle{Applications: []*stack.Application{a}}},
+		{Bundle: &stack.Bundle{Applications: []*stack.Application{b}}},
+	}}}
+}
+
+func countClusterApps(c *stack.Cluster, name string) int {
+	n := 0
+	walkLeafBundles(c.Node, func(bundle *stack.Bundle) {
+		for _, a := range bundle.Applications {
+			if a.Name == name {
+				n++
+			}
+		}
+	})
+	return n
+}
 
 // stubCollector implements trafficSourceCollector and stack.ApplicationConfig for synthesis tests.
 type stubCollector struct {
@@ -108,7 +144,11 @@ func TestSynthesizeForBundle_AddsNetworkPolicyApp(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle, nil, ComponentLabel)
+	reg := newNPSynthesisRegistry()
+	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	reg.flush()
 
 	if len(bundle.Applications) != 2 {
 		t.Fatalf("expected 2 applications after synthesis, got %d", len(bundle.Applications))
@@ -128,7 +168,11 @@ func TestSynthesizeForBundle_NoSynthesisWithoutSources(t *testing.T) {
 	app := stack.NewApplication("web-ingress", "default", col)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
-	synthesizeForBundle(bundle, nil, ComponentLabel)
+	reg := newNPSynthesisRegistry()
+	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	reg.flush()
 
 	if len(bundle.Applications) != 1 {
 		t.Errorf("expected no synthesis (no sources), got %d apps", len(bundle.Applications))
@@ -150,7 +194,11 @@ func TestSynthesizeForBundle_TwoCollectorsSameComponent(t *testing.T) {
 	app2 := stack.NewApplication("web-httproute", "default", col2)
 	bundle := &stack.Bundle{Applications: []*stack.Application{app1, app2}}
 
-	synthesizeForBundle(bundle, nil, ComponentLabel)
+	reg := newNPSynthesisRegistry()
+	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	reg.flush()
 
 	// One synthesized policy per component (not per collector).
 	count := 0
@@ -276,4 +324,85 @@ func generatedNetworkPolicy(t *testing.T, cfg interface {
 		t.Fatalf("expected *NetworkPolicy, got %T", *objs[0])
 	}
 	return np
+}
+
+// --- #239: external-backend synthesis is cluster-wide, not per-bundle ---
+
+// Two routers in DIFFERENT leaf bundles naming the same external Service (same namespace + selector)
+// must emit exactly ONE policy — a per-bundle accumulator would emit a duplicate resource id.
+func TestSynthesizeNetworkPolicies_ExternalBackend_MultiBundle_SameSelector_SinglePolicy(t *testing.T) {
+	mk := func(comp string) *stack.Application {
+		return stack.NewApplication(comp+"-ingress", "default", &extBackendStub{
+			component: comp,
+			sources:   []netpol.TrafficSource{{Namespace: "ingress-nginx"}},
+			targets: []netpol.BackendTarget{{
+				ServiceName: "external-svc",
+				Ports:       []intstr.IntOrString{intstr.FromInt32(8081)},
+				PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "external"}},
+			}},
+		})
+	}
+	cluster := twoLeafBundleCluster(mk("router-a"), mk("router-b"))
+	if err := synthesizeNetworkPolicies(cluster, nil, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	if got := countClusterApps(cluster, "external-svc-allow-ingress-traffic"); got != 1 {
+		t.Errorf("expected exactly one external-svc-allow-ingress-traffic across bundles, got %d", got)
+	}
+}
+
+// The same two routers with DIFFERENT selectors for one external Service must fail the transform —
+// a per-bundle check would miss the cross-bundle conflict and emit two colliding allows.
+func TestSynthesizeNetworkPolicies_ExternalBackend_MultiBundle_ConflictingSelectors_Errors(t *testing.T) {
+	mk := func(comp, label string) *stack.Application {
+		return stack.NewApplication(comp+"-ingress", "default", &extBackendStub{
+			component: comp,
+			sources:   []netpol.TrafficSource{{Namespace: "ingress-nginx"}},
+			targets: []netpol.BackendTarget{{
+				ServiceName: "external-svc",
+				Ports:       []intstr.IntOrString{intstr.FromInt32(8081)},
+				PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": label}},
+			}},
+		})
+	}
+	cluster := twoLeafBundleCluster(mk("router-a", "external"), mk("router-b", "other"))
+	if err := synthesizeNetworkPolicies(cluster, nil, ComponentLabel); err == nil {
+		t.Fatal("expected an error for one external Service given different selectors across bundles")
+	}
+}
+
+// On any synthesis error, every append is deferred past the failure point, so the cluster is left
+// completely unmutated — an earlier bundle's component policy must not survive a later conflict.
+func TestSynthesizeNetworkPolicies_ExternalConflict_LeavesClusterUnmutated(t *testing.T) {
+	web := stack.NewApplication("web-ingress", "default", &stubCollector{
+		component: "web",
+		sources:   []netpol.TrafficSource{{Namespace: "ingress-nginx"}},
+		ports:     []intstr.IntOrString{intstr.FromInt32(80)},
+	})
+	mkRouter := func(comp, label string) *stack.Application {
+		return stack.NewApplication(comp+"-ingress", "default", &extBackendStub{
+			component: comp,
+			sources:   []netpol.TrafficSource{{Namespace: "ingress-nginx"}},
+			targets: []netpol.BackendTarget{{
+				ServiceName: "external-svc",
+				Ports:       []intstr.IntOrString{intstr.FromInt32(8081)},
+				PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": label}},
+			}},
+		})
+	}
+	// Bundle A also carries a component (web) that would emit an inbound policy; bundle B triggers a
+	// cross-bundle external-selector conflict.
+	cluster := &stack.Cluster{Node: &stack.Node{Children: []*stack.Node{
+		{Bundle: &stack.Bundle{Applications: []*stack.Application{web, mkRouter("router-a", "external")}}},
+		{Bundle: &stack.Bundle{Applications: []*stack.Application{mkRouter("router-b", "other")}}},
+	}}}
+	if err := synthesizeNetworkPolicies(cluster, nil, ComponentLabel); err == nil {
+		t.Fatal("expected a cross-bundle selector conflict error")
+	}
+	if got := countClusterApps(cluster, "web-allow-ingress-traffic"); got != 0 {
+		t.Errorf("expected cluster unmutated after error, found %d web-allow-ingress-traffic", got)
+	}
+	if got := countClusterApps(cluster, "external-svc-allow-ingress-traffic"); got != 0 {
+		t.Errorf("expected no external policy after error, found %d", got)
+	}
 }

--- a/pkg/oam/transform.go
+++ b/pkg/oam/transform.go
@@ -407,7 +407,9 @@ func (t *Transformer) TransformWithPolicy(app *Application, ctx TransformContext
 	if labelKey == "" {
 		labelKey = ComponentLabelKeyForDomain(ctx.Domain)
 	}
-	synthesizeNetworkPolicies(cluster, componentMap, labelKey)
+	if err := synthesizeNetworkPolicies(cluster, componentMap, labelKey); err != nil {
+		return nil, nil, err
+	}
 	// Egress synthesis fails fast on a malformed non-authorable peer (ported but selector-less):
 	// a producer bug should fail the build, not silently emit a namespace-wide egress allow.
 	if err := synthesizeEgressNetworkPolicies(cluster, componentMap, ctx.EgressPeers, labelKey); err != nil {


### PR DESCRIPTION
## Summary

Closes #239. Extends NetworkPolicy synthesis to cover a routing trait's backend reference that names a **bare Service with no owning OAM component**. #227 already retargets a backendRef onto a sibling in-bundle *component*; this adds the *non-component external Service* case for both routing shapes (expose/Ingress `paths[].backend`, Gateway/HTTPRoute `backendRefs`).

Synthesis runs in Phase 4 from `componentMap` + `stack.Application` configs, before any Service is rendered, so the backend pods' selector is **not inferable** from the Service name. Per the issue, we do not guess — the fix adds an **authorable explicit selector**.

## Contract

A matchLabels-only `backendSelector` beside the backend ref:

```yaml
paths:
  - path: /
    backend: external-svc      # a Service with no OAM component
    port: 8081
    backendSelector:
      matchLabels:
        app.kubernetes.io/name: external
```

(and `rules[].backendRefs[].backendSelector` for HTTPRoute). When present on an unresolved backend, synthesis emits a `{service}-allow-ingress-traffic` policy in the router's namespace selecting those pods on the backend ports, preserving the namespace-wide routing `trafficSources`. Without a selector, the backend stays authored.

## Behavior / safety

- `netpol.BackendTarget` gains `PodSelector`; collectors key external targets by `(serviceName, selector)` so a selectorless occurrence never widens a selected one, and reject the same Service given two different selectors in one trait.
- New `backendIngressAllowPolicyConfig` (not the endpoint-ingress config, which drops namespace-wide sources).
- `synthesizeNetworkPolicies`/`synthesizeForBundle` now return `error` and **fail the transform** on conflicting selectors across routers or a policy-name collision with an *actually-emitted* component inbound policy; the bundle is fully validated before any mutation (`walkLeafBundles` can't abort).
- Selector on a self/implicit backend → rejected at parse; selector on a ref that resolves to a sibling component → ignored (#227 wins).
- Fail-closed: triple-gated so no policy can select all pods; same-namespace only (cross-namespace `ReferenceGrant` out of scope).

## Tests

12 new transform-level tests in `networkpolicy_auto_test.go` (generic fixtures, no downstream names): both routing shapes synthesize; without-selector stays authored; mixed selector presence doesn't widen ports; conflicting selectors (in-trait parse error + cross-router transform error); name collision with an emitted component policy fails, and the false-positive guard (same-named component with no policy still allowed); selector on sibling component ignored; self-backend + empty-matchLabels rejected; multiple services get distinct names.

## Verification

- `make precommit` (fmt, tidy, lint, test, kure-dep-sync) — pass
- `mise run build`, `check-doc-sync.sh`, `check-doc-gate.sh origin/main`, `check-forbidden-terms.sh --diff origin/main` — pass

## Downstream

Once shipped, a downstream consumer can retire its authored stopgap policy (crane#339). No crane change lands here.