### PR TITLE
fix(oam/netpol): resolve #227 backendRef retargeting across dependency/tier bundles

### DIFF
--- a/pkg/oam/README.md
+++ b/pkg/oam/README.md
@@ -34,10 +34,15 @@ each a **separate** additive resource (the authored `networkpolicy` /
 
 - **Inbound** (`{comp}-allow-ingress-traffic`) — routing-derived, from routing traits'
   platform-reserved `networkPolicy.trafficSources` capability rendering. When a routing trait's
-  `backendRef` names a **separate** in-bundle backend Service (not the exposing component's own),
+  `backendRef` names a **separate** backend Service (not the exposing component's own),
   the allow is **retargeted onto that backend component's pods** + the backendRef port — resolved
-  by matching the backend Service name to a sibling OAM component in the same bundle. A backendRef
-  that resolves to no in-bundle component (a **bare external Service**) is left authored **unless**
+  by matching the backend Service name to a sibling OAM component **cluster-wide**, and the
+  retargeted policy is emitted in the **backend component's own leaf bundle**. Resolution spans
+  bundles: components of one Application share a namespace but are split across leaf bundles
+  (dependency-aware = one per component, hierarchical = one per tier), so a router in one bundle
+  correctly retargets onto a backend in another. Two components resolving to the **same** Service
+  name is ambiguous and **fails the transform**. A backendRef
+  that resolves to no component (a **bare external Service**) is left authored **unless**
   it carries an explicit authored `backendSelector` (matchLabels only, on the routing trait's
   `paths[].backend` / `backendRefs[]` — the selector is not inferable from a Service name): that
   emits a separate `{service}-allow-ingress-traffic` policy in the router's namespace selecting the

--- a/pkg/oam/builtin/traits/networkpolicy_auto_test.go
+++ b/pkg/oam/builtin/traits/networkpolicy_auto_test.go
@@ -1213,3 +1213,63 @@ func TestTransform_ExternalBackend_MultipleServices_DistinctNames(t *testing.T) 
 		}
 	}
 }
+
+// #242: a backendRef whose backend component lands in a DIFFERENT tier bundle (hierarchical cluster)
+// still retargets — the allow is synthesized on the backend's pods in the backend's tier bundle.
+func TestTransform_BackendRef_RetargetsAcrossTierBundles(t *testing.T) {
+	tr := oam.NewTransformer(nil, nil)
+	tr.RegisterComponent("webservice", &components.WebserviceHandler{})
+	tr.RegisterComponent("statefulset", &components.StatefulsetHandler{})
+	tr.RegisterBuiltinTrait("httproute", &traits.HTTPRouteHandler{})
+
+	app := &oam.Application{
+		Metadata: oam.Metadata{Name: "myapp", Namespace: "default"},
+		Spec: oam.ApplicationSpec{
+			Components: []oam.Component{
+				{
+					Name:       "router",
+					Type:       "webservice",
+					Properties: map[string]any{"image": "nginx:1.25", "port": 8080},
+					Traits: []oam.Trait{{
+						Type: "httproute",
+						Properties: map[string]any{
+							"parentRefs": []any{map[string]any{"name": "gw"}},
+							"rules": []any{map[string]any{
+								"backendRefs": []any{map[string]any{"name": "db-headless", "port": 5432}},
+							}},
+							"networkPolicy": map[string]any{
+								"trafficSources": []any{map[string]any{"namespace": "gateway-system"}},
+							},
+						},
+					}},
+				},
+				{
+					// Annotated into the services tier so router (apps) and db (services) land in
+					// separate leaf bundles → forces the cross-bundle resolution path.
+					Name:        "db",
+					Type:        "statefulset",
+					Annotations: map[string]string{"gokure.dev/tier": "services"},
+					Properties:  map[string]any{"image": "postgres:16", "port": 5432, "serviceName": "db-headless"},
+				},
+			},
+		},
+	}
+
+	cluster, _, err := tr.TransformWithPolicy(app, oam.TransformContext{Namespace: "default"})
+	if err != nil {
+		t.Fatalf("TransformWithPolicy: %v", err)
+	}
+	if !clusterHasApp(cluster, "db-allow-ingress-traffic") {
+		t.Fatalf("expected db-allow-ingress-traffic across tier bundles; apps: %v", clusterAppNames(cluster))
+	}
+	np := synthesizedNetworkPolicy(t, cluster, "db-allow-ingress-traffic")
+	if got := np.Spec.PodSelector.MatchLabels["gokure.dev/component"]; got != "db" {
+		t.Errorf("target selector = %v, want gokure.dev/component=db", np.Spec.PodSelector.MatchLabels)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 5432 {
+		t.Errorf("expected a single ingress rule on port 5432, got %+v", np.Spec.Ingress)
+	}
+	if clusterHasApp(cluster, "router-allow-ingress-traffic") {
+		t.Errorf("router-only exposer should get no self policy; apps: %v", clusterAppNames(cluster))
+	}
+}

--- a/pkg/oam/netpol/README.md
+++ b/pkg/oam/netpol/README.md
@@ -18,8 +18,9 @@ Package `netpol` contains shared types for automatic `NetworkPolicy` synthesis:
   escape hatch and is silently skipped (destination stays authored).
 - `BackendTarget` — one routing `backendRef` that targets a **separate** in-cluster backend
   Service (not the exposing component's own): a Service name + ports + an optional `PodSelector`.
-  When the Service name resolves to a sibling in-bundle component, ingress synthesis retargets the
-  `{comp}-allow-ingress-traffic` allow onto that component's pods (#227) and the `PodSelector` is
+  When the Service name resolves to a sibling component — **cluster-wide**, across leaf bundles in
+  the same namespace — ingress synthesis retargets the `{comp}-allow-ingress-traffic` allow onto that
+  component's pods in the component's own bundle (#227/#242) and the `PodSelector` is
   ignored. When it does **not** resolve (a bare external Service), the selector is not inferable
   from the name: an explicit matchLabels `PodSelector` (the authored `backendSelector`) synthesizes
   a `{service}-allow-ingress-traffic` allow onto those pods, while a nil selector leaves the backend

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -40,6 +40,29 @@ type serviceBackendNamer interface {
 	BackendServiceName() string
 }
 
+// servicePortProvider is optionally implemented by a component config that exposes a Service port
+// (the webservice/statefulset convention: Service name == component name). Used to decide whether a
+// component actually owns a routable Service.
+type servicePortProvider interface {
+	ServicePort() int32
+}
+
+// componentServiceName returns the Kubernetes Service name a component owns and whether it owns one.
+// A component is a valid backendRef target only if it declares an explicit BackendServiceName or a
+// positive ServicePort; a Service-less component (e.g. a worker, or a daemonset with no port) owns
+// no Service, so its name must NOT enter serviceToComponent — otherwise it would shadow a bare
+// external Service of the same name (misrouting a #239 backendSelector target) or fabricate a false
+// R3 ambiguity against another component's real Service name.
+func componentServiceName(app *stack.Application) (string, bool) {
+	if sn, ok := app.Config.(serviceBackendNamer); ok && sn.BackendServiceName() != "" {
+		return sn.BackendServiceName(), true
+	}
+	if pp, ok := app.Config.(servicePortProvider); ok && pp.ServicePort() > 0 {
+		return app.Name, true
+	}
+	return "", false
+}
+
 // componentAllowPolicyConfig is the ApplicationConfig for an auto-generated
 // NetworkPolicy that allows ingress from routing controller traffic sources to
 // the component's pods. The resource name is {component}-allow-ingress-traffic,
@@ -217,9 +240,9 @@ func (r *npSynthesisRegistry) buildLookups(cluster *stack.Cluster, componentMap 
 	for _, name := range names {
 		entry := componentMap[name]
 		r.componentPlacement[name] = componentPlacement{bundle: appToBundle[entry.app], namespace: entry.app.Namespace}
-		svc := name
-		if sn, ok := entry.app.Config.(serviceBackendNamer); ok && sn.BackendServiceName() != "" {
-			svc = sn.BackendServiceName()
+		svc, owns := componentServiceName(entry.app)
+		if !owns {
+			continue // Service-less component: not a backendRef target, must not claim a Service name
 		}
 		if prev, dup := svcOwner[svc]; dup {
 			a, b := prev, name

--- a/pkg/oam/netpol_synthesis.go
+++ b/pkg/oam/netpol_synthesis.go
@@ -160,24 +160,32 @@ func synthesizeNetworkPolicies(cluster *stack.Cluster, componentMap map[string]c
 	if cluster == nil {
 		return nil
 	}
-	// External-backend accumulation and name-collision detection are CLUSTER-wide, not per-bundle:
-	// two routers in different leaf bundles can name the same external Service in the same namespace,
-	// which would otherwise emit duplicate NetworkPolicy resource ids (or miss a cross-bundle
-	// selector conflict). Component policies stay per-bundle (a component lives in exactly one
-	// bundle, so its name is already cluster-unique).
+	// Synthesis is entirely CLUSTER-wide (not per-bundle): components of one Application share a
+	// namespace but are split across leaf bundles (dependency-aware: one per component; hierarchical:
+	// one per tier). Resolving a backendRef to its sibling component, and merging a router's injected
+	// allow onto that component's own bundle, therefore requires cluster-wide lookups (#242) — the
+	// same model #239 uses for external backends.
 	reg := newNPSynthesisRegistry()
+	if err := reg.buildLookups(cluster, componentMap); err != nil {
+		return err
+	}
 	// walkLeafBundles cannot abort traversal, so capture the first error and guard the callback.
 	var firstErr error
 	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
 		if firstErr != nil {
 			return
 		}
-		if err := synthesizeForBundle(bundle, componentMap, labelKey, reg); err != nil {
+		if err := synthesizeForBundle(bundle, reg); err != nil {
 			firstErr = err
 		}
 	})
 	if firstErr != nil {
 		return firstErr
+	}
+	// Emit component policies first so the external-vs-component collision check (emitExternalBackends)
+	// sees every component name; both only queue apps.
+	if err := reg.emitComponents(labelKey); err != nil {
+		return err
 	}
 	if err := reg.emitExternalBackends(); err != nil {
 		return err
@@ -185,6 +193,70 @@ func synthesizeNetworkPolicies(cluster *stack.Cluster, componentMap map[string]c
 	// Every append is deferred to here, so an error at any point above leaves the cluster
 	// completely unmutated (no partially-decorated bundle observable by a direct caller).
 	reg.flush()
+	return nil
+}
+
+// buildLookups populates the registry's cluster-wide read-only maps: appToBundle (via a leaf-bundle
+// walk), componentPlacement (each component's own bundle + namespace), and serviceToComponent (each
+// component's Service name → its name). It fails fast (R3) when two components resolve to the same
+// Service name — an ambiguous #227/#242 routing target must error, not silently misroute.
+func (r *npSynthesisRegistry) buildLookups(cluster *stack.Cluster, componentMap map[string]componentEntry) error {
+	appToBundle := map[*stack.Application]*stack.Bundle{}
+	walkLeafBundles(cluster.Node, func(bundle *stack.Bundle) {
+		for _, a := range bundle.Applications {
+			appToBundle[a] = bundle
+		}
+	})
+	// Sort component names so the R3 error (and any map build) is deterministic.
+	names := make([]string, 0, len(componentMap))
+	for name := range componentMap {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	svcOwner := map[string]string{} // svc name → first component that claimed it
+	for _, name := range names {
+		entry := componentMap[name]
+		r.componentPlacement[name] = componentPlacement{bundle: appToBundle[entry.app], namespace: entry.app.Namespace}
+		svc := name
+		if sn, ok := entry.app.Config.(serviceBackendNamer); ok && sn.BackendServiceName() != "" {
+			svc = sn.BackendServiceName()
+		}
+		if prev, dup := svcOwner[svc]; dup {
+			a, b := prev, name
+			if a > b {
+				a, b = b, a
+			}
+			return errors.Errorf(
+				"components %q and %q resolve to the same Service name %q — ambiguous backendRef target",
+				a, b, svc)
+		}
+		svcOwner[svc] = name
+		r.serviceToComponent[svc] = name
+	}
+	return nil
+}
+
+// emitComponents queues one {comp}-allow-ingress-traffic policy per accumulated component, in its own
+// bundle, merging the component's own routing collectors with any injected backendRef rules. Runs
+// after the walk; queued apps are appended only by flush().
+func (r *npSynthesisRegistry) emitComponents(labelKey string) error {
+	for _, compName := range r.componentOrder {
+		ce := r.components[compName]
+		rules := buildTrafficRules(ce.collectors)
+		rules = appendDedupTrafficRules(rules, ce.injected)
+		if len(rules) == 0 {
+			continue
+		}
+		policyName := compName + "-allow-ingress-traffic"
+		// Key by namespace/name (not bare name) to preserve the #239 external-vs-component collision
+		// check and avoid future cross-namespace false positives.
+		r.emitted[ce.namespace+"/"+policyName] = struct{}{}
+		r.queue(ce.bundle, stack.NewApplication(
+			policyName,
+			ce.namespace,
+			&componentAllowPolicyConfig{ComponentName: compName, Rules: rules, PodSelectorKey: labelKey},
+		))
+	}
 	return nil
 }
 
@@ -206,21 +278,67 @@ type pendingSynthApp struct {
 	app    *stack.Application
 }
 
-// npSynthesisRegistry holds cluster-wide synthesis state: every emitted policy's namespace/name (to
-// detect external-vs-component collisions), the external-backend accumulator, and the deferred
-// append queue.
+// componentPlacement records where a component's synthesized inbound policy must land: its own leaf
+// bundle and namespace. Built cluster-wide so a router in one bundle can inject an allow onto a
+// backend component in another bundle (#242).
+type componentPlacement struct {
+	bundle    *stack.Bundle
+	namespace string
+}
+
+// componentInboundEntry accumulates one component's inbound-policy inputs CLUSTER-wide: its own
+// routing collectors plus rules injected by backendRefs from routers in any bundle (#227/#242).
+// bundle/namespace are the component's own (set once), so the merged {comp}-allow-ingress-traffic
+// policy is emitted exactly once in the component's bundle regardless of walk order.
+type componentInboundEntry struct {
+	collectors []trafficSourceCollector
+	injected   []trafficRule
+	namespace  string
+	bundle     *stack.Bundle
+}
+
+// npSynthesisRegistry holds cluster-wide synthesis state: read-only lookups (Service name →
+// component, component → placement), the per-component and external-backend accumulators, every
+// emitted policy's namespace/name (to detect collisions), and the deferred append queue.
 type npSynthesisRegistry struct {
-	emitted          map[string]struct{}              // namespace/name of every synthesized policy
-	externalBackends map[string]*externalBackendEntry // key: namespace\x00service
-	externalOrder    []string
-	pending          []pendingSynthApp
+	serviceToComponent map[string]string             // svc name → component name (cluster-wide, ambiguity-checked)
+	componentPlacement map[string]componentPlacement // component name → its own bundle + namespace
+	components         map[string]*componentInboundEntry
+	componentOrder     []string
+	emitted            map[string]struct{}              // namespace/name of every synthesized policy
+	externalBackends   map[string]*externalBackendEntry // key: namespace\x00service
+	externalOrder      []string
+	pending            []pendingSynthApp
 }
 
 func newNPSynthesisRegistry() *npSynthesisRegistry {
 	return &npSynthesisRegistry{
-		emitted:          map[string]struct{}{},
-		externalBackends: map[string]*externalBackendEntry{},
+		serviceToComponent: map[string]string{},
+		componentPlacement: map[string]componentPlacement{},
+		components:         map[string]*componentInboundEntry{},
+		emitted:            map[string]struct{}{},
+		externalBackends:   map[string]*externalBackendEntry{},
 	}
+}
+
+// ensureComponent returns the accumulator for a component, creating it (and recording insertion
+// order) on first use. bundle/namespace are set only on creation. A later call that disagrees on
+// bundle/namespace is a producer bug (a real component has one placement) — error rather than
+// silently queue the policy into the wrong bundle.
+func (r *npSynthesisRegistry) ensureComponent(name string, bundle *stack.Bundle, namespace string) (*componentInboundEntry, error) {
+	ce, ok := r.components[name]
+	if !ok {
+		ce = &componentInboundEntry{namespace: namespace, bundle: bundle}
+		r.components[name] = ce
+		r.componentOrder = append(r.componentOrder, name)
+		return ce, nil
+	}
+	if ce.bundle != bundle || ce.namespace != namespace {
+		return nil, errors.Errorf(
+			"component %q resolved to inconsistent placement (namespace %q vs %q)",
+			name, ce.namespace, namespace)
+	}
+	return ce, nil
 }
 
 // queue records a synthesized app for deferred append to its bundle.
@@ -274,49 +392,14 @@ type backendRefTargetCollector interface {
 	BackendTargets() []netpol.BackendTarget
 }
 
-func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]componentEntry, labelKey string, reg *npSynthesisRegistry) error {
+// synthesizeForBundle accumulates one leaf bundle's routing collectors into the cluster-wide
+// registry (reg): each component's own collectors, plus rules injected onto a backend component
+// (resolved cluster-wide, landing on the backend's OWN bundle — #242) or onto an external bare
+// Service (#239). It never emits — emitComponents/emitExternalBackends do that after the whole
+// cluster is walked, so nothing is appended to any bundle until every bundle validates.
+func synthesizeForBundle(bundle *stack.Bundle, reg *npSynthesisRegistry) error {
 	if bundle == nil {
 		return nil
-	}
-
-	// Group collectors by component name, preserving insertion order for determinism. injected
-	// carries retargeted rules for a backend component that a routing trait points at via an
-	// external backendRef (#227) — kept separate from the component's own collectors because its
-	// ports come from the backendRef, not the collector's own BackendPorts.
-	type groupEntry struct {
-		collectors []trafficSourceCollector
-		injected   []trafficRule
-		namespace  string
-	}
-	byComponent := map[string]*groupEntry{}
-	var componentOrder []string
-	ensureGroup := func(name string) *groupEntry {
-		g, exists := byComponent[name]
-		if !exists {
-			g = &groupEntry{}
-			byComponent[name] = g
-			componentOrder = append(componentOrder, name)
-		}
-		return g
-	}
-
-	// Map each in-bundle component's Service name to its component name, for backendRef
-	// resolution. A component's Service name is its BackendServiceName() when it declares one
-	// (e.g. statefulset's headless service), else its component name (webservice's convention).
-	inBundle := map[*stack.Application]bool{}
-	for _, a := range bundle.Applications {
-		inBundle[a] = true
-	}
-	serviceToComponent := map[string]string{}
-	for name, entry := range componentMap {
-		if !inBundle[entry.app] {
-			continue
-		}
-		svc := name
-		if sn, ok := entry.app.Config.(serviceBackendNamer); ok && sn.BackendServiceName() != "" {
-			svc = sn.BackendServiceName()
-		}
-		serviceToComponent[svc] = name
 	}
 
 	for _, appPtr := range bundle.Applications {
@@ -324,14 +407,15 @@ func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]component
 		if !ok {
 			continue
 		}
-		name := col.TargetComponentName()
-		g := ensureGroup(name)
-		g.collectors = append(g.collectors, col)
-		g.namespace = appPtr.Namespace
+		routerComp := col.TargetComponentName()
+		// The router's own collectors accumulate under its component, in this (the router's) bundle.
+		if _, err := reg.ensureComponent(routerComp, bundle, appPtr.Namespace); err != nil {
+			return err
+		}
+		reg.components[routerComp].collectors = append(reg.components[routerComp].collectors, col)
 
-		// #227: an external backendRef routes to a separate backend. Retarget its allow onto the
-		// backend component's pods (resolved from the backend Service name to a sibling
-		// component). Unresolvable refs (no owning component in the bundle) stay authored.
+		// #227/#242: an external backendRef routes to a separate backend. Retarget its allow onto the
+		// backend component's pods, resolved cluster-wide so the backend may live in another bundle.
 		bt, ok := appPtr.Config.(backendRefTargetCollector)
 		if !ok {
 			continue
@@ -341,26 +425,27 @@ func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]component
 			continue // no traffic sources → nothing to allow
 		}
 		for _, target := range bt.BackendTargets() {
-			backendComp, resolved := serviceToComponent[target.ServiceName]
+			backendComp, resolved := reg.serviceToComponent[target.ServiceName]
 			if resolved {
-				if backendComp == name {
+				if backendComp == routerComp {
 					continue // self (already handled above)
 				}
-				// #227: retarget onto the in-bundle backend component's pods. An authored
+				// Retarget onto the backend component's pods, in the backend's OWN bundle. An authored
 				// backendSelector on a resolvable ref is ignored — component-label targeting wins.
-				bg := ensureGroup(backendComp)
-				// The backend group's namespace must come from the backend's own app, not the
-				// router-bearing collector's; source it from componentMap.
-				if entry, ok := componentMap[backendComp]; ok {
-					bg.namespace = entry.app.Namespace
+				pl, ok := reg.componentPlacement[backendComp]
+				if !ok {
+					continue // backend has no known placement (defensive) → leave authored
 				}
-				bg.injected = append(bg.injected, trafficRule{Sources: sources, Ports: target.Ports})
+				bce, err := reg.ensureComponent(backendComp, pl.bundle, pl.namespace)
+				if err != nil {
+					return err
+				}
+				bce.injected = append(bce.injected, trafficRule{Sources: sources, Ports: target.Ports})
 				continue
 			}
-			// #239: external bare Service. Synthesize only with an explicit, valid authored
-			// selector; otherwise leave authored (current behavior — no name-based inference).
-			// Accumulate cluster-wide (in reg) so a Service named across bundles is deduped/merged
-			// and a cross-bundle selector conflict is still caught.
+			// #239: external bare Service. Synthesize only with an explicit, valid authored selector;
+			// otherwise leave authored (no name-based inference). Accumulate cluster-wide so a Service
+			// named across bundles is deduped/merged and a cross-bundle selector conflict is caught.
 			if target.PodSelector == nil || !matchLabelsSelectorValid(target.PodSelector) {
 				continue
 			}
@@ -382,27 +467,6 @@ func synthesizeForBundle(bundle *stack.Bundle, componentMap map[string]component
 			}
 			eb.rules = append(eb.rules, trafficRule{Sources: sources, Ports: target.Ports})
 		}
-	}
-
-	// Queue the per-component inbound policies for this bundle, recording their names in the
-	// cluster-wide registry so external-backend collisions can be detected against the full set.
-	// Nothing is appended here — every synthesized app (component + external) is flushed only after
-	// the whole cluster is walked and validated (synthesizeNetworkPolicies), so any error leaves the
-	// cluster unmutated.
-	for _, compName := range componentOrder {
-		entry := byComponent[compName]
-		rules := buildTrafficRules(entry.collectors)
-		rules = appendDedupTrafficRules(rules, entry.injected)
-		if len(rules) == 0 {
-			continue
-		}
-		policyName := compName + "-allow-ingress-traffic"
-		reg.emitted[entry.namespace+"/"+policyName] = struct{}{}
-		reg.queue(bundle, stack.NewApplication(
-			policyName,
-			entry.namespace,
-			&componentAllowPolicyConfig{ComponentName: compName, Rules: rules, PodSelectorKey: labelKey},
-		))
 	}
 	return nil
 }

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -49,16 +49,20 @@ func countClusterApps(c *stack.Cluster, name string) int {
 }
 
 // stubCollector implements trafficSourceCollector and stack.ApplicationConfig for synthesis tests.
+// servicePort > 0 makes it also own a Service (a valid backendRef target); 0 (the default) leaves it
+// Service-less.
 type stubCollector struct {
-	component string
-	sources   []netpol.TrafficSource
-	ports     []intstr.IntOrString
+	component   string
+	sources     []netpol.TrafficSource
+	ports       []intstr.IntOrString
+	servicePort int32
 }
 
 func (s *stubCollector) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
 func (s *stubCollector) TrafficSources() []netpol.TrafficSource                  { return s.sources }
 func (s *stubCollector) TargetComponentName() string                             { return s.component }
 func (s *stubCollector) BackendPorts() []intstr.IntOrString                      { return s.ports }
+func (s *stubCollector) ServicePort() int32                                      { return s.servicePort }
 
 // --- buildTrafficRules ---
 
@@ -430,6 +434,13 @@ type svcNamerConfig struct{ svc string }
 func (svcNamerConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
 func (c svcNamerConfig) BackendServiceName() string                            { return c.svc }
 
+// svcPortConfig implements servicePortProvider: a component that owns a Service named after itself
+// (webservice convention) when port > 0, and owns none when port == 0 (e.g. a port-less daemonset).
+type svcPortConfig struct{ port int32 }
+
+func (svcPortConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+func (c svcPortConfig) ServicePort() int32                                    { return c.port }
+
 func bundleAppNames(b *stack.Bundle) []string {
 	out := make([]string, 0, len(b.Applications))
 	for _, a := range b.Applications {
@@ -483,7 +494,7 @@ func crossBundleCluster(router, backend *stack.Application) (*stack.Cluster, *st
 // A backendRef to a component in a DIFFERENT leaf bundle now retargets — the allow lands on the
 // backend's pods in the BACKEND's bundle (pre-fix: nothing was synthesized).
 func TestSynthesizeNetworkPolicies_CrossBundleRetarget_LandsInBackendBundle(t *testing.T) {
-	backend := stack.NewApplication("backend", "default", noopConfig{})
+	backend := stack.NewApplication("backend", "default", svcPortConfig{port: 9000}) // owns Service "backend"
 	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
 		component: "router",
 		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
@@ -514,10 +525,11 @@ func TestSynthesizeNetworkPolicies_CrossBundleRetarget_LandsInBackendBundle(t *t
 // When the backend also has its own inbound rule (its bundle) AND receives a cross-bundle injection,
 // exactly ONE merged policy is emitted in the backend's bundle carrying both sources (anti-duplicate).
 func TestSynthesizeNetworkPolicies_CrossBundle_MergesWithBackendOwnRules(t *testing.T) {
-	backend := stack.NewApplication("backend-ingress", "default", &stubCollector{
-		component: "backend",
-		sources:   []netpol.TrafficSource{{Namespace: "mesh"}},
-		ports:     []intstr.IntOrString{intstr.FromInt32(9000)},
+	backend := stack.NewApplication("backend", "default", &stubCollector{
+		component:   "backend",
+		sources:     []netpol.TrafficSource{{Namespace: "mesh"}},
+		ports:       []intstr.IntOrString{intstr.FromInt32(9000)},
+		servicePort: 9000, // also owns Service "backend" so the router's ref resolves
 	})
 	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
 		component: "router",
@@ -566,7 +578,7 @@ func TestSynthesizeNetworkPolicies_CrossBundle_UnresolvedNoSelector_LeavesAuthor
 // A cross-bundle backendRef carrying an authored backendSelector now resolves to the component and
 // ignores the selector — component-label targeting wins (intended #239→#242 precedence).
 func TestSynthesizeNetworkPolicies_CrossBundleBackendSelector_Ignored(t *testing.T) {
-	backend := stack.NewApplication("backend", "default", noopConfig{})
+	backend := stack.NewApplication("backend", "default", svcPortConfig{port: 9000}) // owns Service "backend"
 	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
 		component: "router",
 		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
@@ -601,14 +613,76 @@ func TestSynthesizeNetworkPolicies_AmbiguousServiceName_SameBackendServiceName_E
 	}
 }
 
-// R3: a component's name equals another component's BackendServiceName() → same ambiguity → error.
+// R3: a Service-owning component's name equals another component's BackendServiceName() → same
+// ambiguity → error.
 func TestSynthesizeNetworkPolicies_AmbiguousServiceName_NameEqualsOtherBackendServiceName_Errors(t *testing.T) {
-	appA := stack.NewApplication("shared", "default", noopConfig{})                  // Service name = its own name
+	appA := stack.NewApplication("shared", "default", svcPortConfig{port: 8080})     // owns Service "shared"
 	appB := stack.NewApplication("comp-b", "default", svcNamerConfig{svc: "shared"}) // BackendServiceName = "shared"
 	bundle := &stack.Bundle{Applications: []*stack.Application{appA, appB}}
 	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
 	componentMap := map[string]componentEntry{"shared": {app: appA}, "comp-b": {app: appB}}
 	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err == nil {
 		t.Fatal("expected an error: component name collides with another's BackendServiceName")
+	}
+}
+
+// A Service-LESS component (e.g. a worker) named the same as a bare external Service must NOT shadow
+// it: the router's backendRef stays external and is synthesized from its authored backendSelector,
+// not resolved to the worker's component-label pods.
+func TestSynthesizeNetworkPolicies_ServicelessComponent_DoesNotShadowExternalBackend(t *testing.T) {
+	worker := stack.NewApplication("worker", "default", noopConfig{}) // Service-less
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets: []netpol.BackendTarget{{
+			ServiceName: "worker",
+			Ports:       []intstr.IntOrString{intstr.FromInt32(9000)},
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "external"}},
+		}},
+	})
+	cluster, bundleA, _, componentMap := crossBundleCluster(router, worker) // maps "backend"→worker; add "worker" too
+	componentMap["worker"] = componentEntry{app: worker}
+	delete(componentMap, "backend")
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	np := synthesizedNPInBundle(t, bundleA, "worker-allow-ingress-traffic") // external → router's bundle
+	if np.Spec.PodSelector.MatchLabels["app.kubernetes.io/name"] != "external" || len(np.Spec.PodSelector.MatchLabels) != 1 {
+		t.Errorf("expected the authored external selector, got %v (Service-less component wrongly shadowed the external backend)", np.Spec.PodSelector.MatchLabels)
+	}
+}
+
+// A Service-LESS component name must NOT fabricate an R3 ambiguity with another component's real
+// BackendServiceName().
+func TestSynthesizeNetworkPolicies_ServicelessComponent_NoFalseAmbiguity(t *testing.T) {
+	// "db-headless" is a Service-less component; "db" is a statefulset whose Service is "db-headless".
+	appA := stack.NewApplication("db-headless", "default", noopConfig{})
+	appB := stack.NewApplication("db", "default", svcNamerConfig{svc: "db-headless"})
+	bundle := &stack.Bundle{Applications: []*stack.Application{appA, appB}}
+	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
+	componentMap := map[string]componentEntry{"db-headless": {app: appA}, "db": {app: appB}}
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("a Service-less component name must not collide with a real Service name: %v", err)
+	}
+}
+
+// A component with an optional Service but no port (ServicePort() == 0, e.g. a port-less daemonset)
+// owns no Service and must not be a backendRef target.
+func TestSynthesizeNetworkPolicies_ZeroPortComponent_NotAServiceOwner(t *testing.T) {
+	backend := stack.NewApplication("zero", "default", svcPortConfig{port: 0}) // no Service
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets:   []netpol.BackendTarget{{ServiceName: "zero", Ports: []intstr.IntOrString{intstr.FromInt32(9000)}}}, // no selector
+	})
+	cluster, _, _, componentMap := crossBundleCluster(router, backend)
+	componentMap["zero"] = componentEntry{app: backend}
+	delete(componentMap, "backend")
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	// Not registered as a Service owner → backendRef unresolved → no selector → nothing synthesized.
+	if countClusterApps(cluster, "zero-allow-ingress-traffic") != 0 {
+		t.Errorf("a port-less component must not be a backendRef target")
 	}
 }

--- a/pkg/oam/netpol_synthesis_test.go
+++ b/pkg/oam/netpol_synthesis_test.go
@@ -145,8 +145,11 @@ func TestSynthesizeForBundle_AddsNetworkPolicyApp(t *testing.T) {
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
 	reg := newNPSynthesisRegistry()
-	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+	if err := synthesizeForBundle(bundle, reg); err != nil {
 		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	if err := reg.emitComponents(ComponentLabel); err != nil {
+		t.Fatalf("emitComponents: %v", err)
 	}
 	reg.flush()
 
@@ -169,8 +172,11 @@ func TestSynthesizeForBundle_NoSynthesisWithoutSources(t *testing.T) {
 	bundle := &stack.Bundle{Applications: []*stack.Application{app}}
 
 	reg := newNPSynthesisRegistry()
-	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+	if err := synthesizeForBundle(bundle, reg); err != nil {
 		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	if err := reg.emitComponents(ComponentLabel); err != nil {
+		t.Fatalf("emitComponents: %v", err)
 	}
 	reg.flush()
 
@@ -195,8 +201,11 @@ func TestSynthesizeForBundle_TwoCollectorsSameComponent(t *testing.T) {
 	bundle := &stack.Bundle{Applications: []*stack.Application{app1, app2}}
 
 	reg := newNPSynthesisRegistry()
-	if err := synthesizeForBundle(bundle, nil, ComponentLabel, reg); err != nil {
+	if err := synthesizeForBundle(bundle, reg); err != nil {
 		t.Fatalf("synthesizeForBundle: %v", err)
+	}
+	if err := reg.emitComponents(ComponentLabel); err != nil {
+		t.Fatalf("emitComponents: %v", err)
 	}
 	reg.flush()
 
@@ -404,5 +413,202 @@ func TestSynthesizeNetworkPolicies_ExternalConflict_LeavesClusterUnmutated(t *te
 	}
 	if got := countClusterApps(cluster, "external-svc-allow-ingress-traffic"); got != 0 {
 		t.Errorf("expected no external policy after error, found %d", got)
+	}
+}
+
+// --- #242: backendRef retargeting resolves and emits across leaf bundles ---
+
+// noopConfig is a minimal ApplicationConfig for a component that is neither a router nor emits a
+// policy of its own — it just occupies a bundle so it can be a cross-bundle backend target.
+type noopConfig struct{}
+
+func (noopConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+
+// svcNamerConfig implements serviceBackendNamer to exercise Service-name resolution/collision.
+type svcNamerConfig struct{ svc string }
+
+func (svcNamerConfig) Generate(_ *stack.Application) ([]*client.Object, error) { return nil, nil }
+func (c svcNamerConfig) BackendServiceName() string                            { return c.svc }
+
+func bundleAppNames(b *stack.Bundle) []string {
+	out := make([]string, 0, len(b.Applications))
+	for _, a := range b.Applications {
+		out = append(out, a.Name)
+	}
+	return out
+}
+
+func bundleHasApp(b *stack.Bundle, name string) bool {
+	for _, a := range b.Applications {
+		if a.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func synthesizedNPInBundle(t *testing.T, b *stack.Bundle, name string) *networkingv1.NetworkPolicy {
+	t.Helper()
+	for _, a := range b.Applications {
+		if a.Name != name {
+			continue
+		}
+		objs, err := a.Config.Generate(a)
+		if err != nil {
+			t.Fatalf("Generate %q: %v", name, err)
+		}
+		if len(objs) != 1 {
+			t.Fatalf("expected 1 object from %q, got %d", name, len(objs))
+		}
+		np, ok := (*objs[0]).(*networkingv1.NetworkPolicy)
+		if !ok {
+			t.Fatalf("expected *NetworkPolicy from %q, got %T", name, *objs[0])
+		}
+		return np
+	}
+	t.Fatalf("app %q not found in bundle; apps: %v", name, bundleAppNames(b))
+	return nil
+}
+
+// crossBundleCluster wires router (bundle A) and backend (bundle B) into a two-leaf-bundle cluster
+// with a matching componentMap — the shape a dependency-aware/hierarchical transform produces.
+func crossBundleCluster(router, backend *stack.Application) (*stack.Cluster, *stack.Bundle, *stack.Bundle, map[string]componentEntry) {
+	bundleA := &stack.Bundle{Applications: []*stack.Application{router}}
+	bundleB := &stack.Bundle{Applications: []*stack.Application{backend}}
+	cluster := &stack.Cluster{Node: &stack.Node{Children: []*stack.Node{{Bundle: bundleA}, {Bundle: bundleB}}}}
+	componentMap := map[string]componentEntry{"router": {app: router}, "backend": {app: backend}}
+	return cluster, bundleA, bundleB, componentMap
+}
+
+// A backendRef to a component in a DIFFERENT leaf bundle now retargets — the allow lands on the
+// backend's pods in the BACKEND's bundle (pre-fix: nothing was synthesized).
+func TestSynthesizeNetworkPolicies_CrossBundleRetarget_LandsInBackendBundle(t *testing.T) {
+	backend := stack.NewApplication("backend", "default", noopConfig{})
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets:   []netpol.BackendTarget{{ServiceName: "backend", Ports: []intstr.IntOrString{intstr.FromInt32(9000)}}},
+	})
+	cluster, bundleA, bundleB, componentMap := crossBundleCluster(router, backend)
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	if !bundleHasApp(bundleB, "backend-allow-ingress-traffic") {
+		t.Fatalf("expected backend-allow-ingress-traffic in the backend bundle; got %v", bundleAppNames(bundleB))
+	}
+	if bundleHasApp(bundleA, "backend-allow-ingress-traffic") {
+		t.Errorf("backend policy must not land in the router's bundle; got %v", bundleAppNames(bundleA))
+	}
+	if countClusterApps(cluster, "router-allow-ingress-traffic") != 0 {
+		t.Errorf("router (pure exposer, no self ports) must get no self policy")
+	}
+	np := synthesizedNPInBundle(t, bundleB, "backend-allow-ingress-traffic")
+	if np.Spec.PodSelector.MatchLabels[ComponentLabel] != "backend" {
+		t.Errorf("podSelector = %v, want %s=backend", np.Spec.PodSelector.MatchLabels, ComponentLabel)
+	}
+	if len(np.Spec.Ingress) != 1 || len(np.Spec.Ingress[0].Ports) != 1 || np.Spec.Ingress[0].Ports[0].Port.IntVal != 9000 {
+		t.Errorf("expected ingress on port 9000, got %+v", np.Spec.Ingress)
+	}
+}
+
+// When the backend also has its own inbound rule (its bundle) AND receives a cross-bundle injection,
+// exactly ONE merged policy is emitted in the backend's bundle carrying both sources (anti-duplicate).
+func TestSynthesizeNetworkPolicies_CrossBundle_MergesWithBackendOwnRules(t *testing.T) {
+	backend := stack.NewApplication("backend-ingress", "default", &stubCollector{
+		component: "backend",
+		sources:   []netpol.TrafficSource{{Namespace: "mesh"}},
+		ports:     []intstr.IntOrString{intstr.FromInt32(9000)},
+	})
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets:   []netpol.BackendTarget{{ServiceName: "backend", Ports: []intstr.IntOrString{intstr.FromInt32(9000)}}},
+	})
+	cluster, _, bundleB, componentMap := crossBundleCluster(router, backend)
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	if got := countClusterApps(cluster, "backend-allow-ingress-traffic"); got != 1 {
+		t.Fatalf("expected exactly one merged backend policy, got %d", got)
+	}
+	np := synthesizedNPInBundle(t, bundleB, "backend-allow-ingress-traffic")
+	if len(np.Spec.Ingress) != 2 {
+		t.Fatalf("expected 2 merged ingress rules (own + injected), got %d", len(np.Spec.Ingress))
+	}
+	seen := map[string]bool{}
+	for _, r := range np.Spec.Ingress {
+		if len(r.From) == 1 {
+			seen[r.From[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]] = true
+		}
+	}
+	if !seen["mesh"] || !seen["gateway-system"] {
+		t.Errorf("expected both mesh (own) and gateway-system (injected) sources, got %v", seen)
+	}
+}
+
+// A cross-bundle backendRef to a Service with no owning component and no selector stays authored.
+func TestSynthesizeNetworkPolicies_CrossBundle_UnresolvedNoSelector_LeavesAuthored(t *testing.T) {
+	backend := stack.NewApplication("backend", "default", noopConfig{})
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets:   []netpol.BackendTarget{{ServiceName: "nonexistent", Ports: []intstr.IntOrString{intstr.FromInt32(9000)}}},
+	})
+	cluster, _, _, componentMap := crossBundleCluster(router, backend)
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	if countClusterApps(cluster, "nonexistent-allow-ingress-traffic") != 0 {
+		t.Errorf("unresolved backendRef with no selector must stay authored")
+	}
+}
+
+// A cross-bundle backendRef carrying an authored backendSelector now resolves to the component and
+// ignores the selector — component-label targeting wins (intended #239→#242 precedence).
+func TestSynthesizeNetworkPolicies_CrossBundleBackendSelector_Ignored(t *testing.T) {
+	backend := stack.NewApplication("backend", "default", noopConfig{})
+	router := stack.NewApplication("router-ingress", "default", &extBackendStub{
+		component: "router",
+		sources:   []netpol.TrafficSource{{Namespace: "gateway-system"}},
+		targets: []netpol.BackendTarget{{
+			ServiceName: "backend",
+			Ports:       []intstr.IntOrString{intstr.FromInt32(9000)},
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app.kubernetes.io/name": "external"}},
+		}},
+	})
+	cluster, bundleA, bundleB, componentMap := crossBundleCluster(router, backend)
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err != nil {
+		t.Fatalf("synthesizeNetworkPolicies: %v", err)
+	}
+	np := synthesizedNPInBundle(t, bundleB, "backend-allow-ingress-traffic")
+	if np.Spec.PodSelector.MatchLabels[ComponentLabel] != "backend" || len(np.Spec.PodSelector.MatchLabels) != 1 {
+		t.Errorf("resolvable cross-bundle ref must use component-label, got %v", np.Spec.PodSelector.MatchLabels)
+	}
+	if bundleHasApp(bundleA, "backend-allow-ingress-traffic") || countClusterApps(cluster, "backend-allow-ingress-traffic") != 1 {
+		t.Errorf("expected exactly one backend policy, in the backend bundle")
+	}
+}
+
+// R3: two components whose BackendServiceName() collide → ambiguous backendRef target → error.
+func TestSynthesizeNetworkPolicies_AmbiguousServiceName_SameBackendServiceName_Errors(t *testing.T) {
+	appA := stack.NewApplication("comp-a", "default", svcNamerConfig{svc: "shared"})
+	appB := stack.NewApplication("comp-b", "default", svcNamerConfig{svc: "shared"})
+	bundle := &stack.Bundle{Applications: []*stack.Application{appA, appB}}
+	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
+	componentMap := map[string]componentEntry{"comp-a": {app: appA}, "comp-b": {app: appB}}
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err == nil {
+		t.Fatal("expected an error for two components sharing a Service name")
+	}
+}
+
+// R3: a component's name equals another component's BackendServiceName() → same ambiguity → error.
+func TestSynthesizeNetworkPolicies_AmbiguousServiceName_NameEqualsOtherBackendServiceName_Errors(t *testing.T) {
+	appA := stack.NewApplication("shared", "default", noopConfig{})                  // Service name = its own name
+	appB := stack.NewApplication("comp-b", "default", svcNamerConfig{svc: "shared"}) // BackendServiceName = "shared"
+	bundle := &stack.Bundle{Applications: []*stack.Application{appA, appB}}
+	cluster := &stack.Cluster{Node: &stack.Node{Bundle: bundle}}
+	componentMap := map[string]componentEntry{"shared": {app: appA}, "comp-b": {app: appB}}
+	if err := synthesizeNetworkPolicies(cluster, componentMap, ComponentLabel); err == nil {
+		t.Fatal("expected an error: component name collides with another's BackendServiceName")
 	}
 }


### PR DESCRIPTION
## Summary

Closes #242. #227 backendRef retargeting (land a routing trait's allow on a sibling component's pods when a `backendRef`/`paths[].backend` names that component's Service) only resolved when the backend component was in the **same leaf bundle** as the router — `serviceToComponent` was built bundle-local (the `inBundle` filter). But components of one Application share **one namespace** while being split across leaf bundles (dependency-aware = one per component, hierarchical = one per tier), so a cross-bundle backendRef silently failed to resolve and the intended `{backend}-allow-ingress-traffic` allow was never synthesized (under default-deny, router→backend traffic dropped).

## Fix

Lift per-component inbound synthesis to **cluster scope** (mirroring #239's external-backend model):

- `synthesizeNetworkPolicies` builds cluster-wide lookups on the registry (`buildLookups`): `appToBundle`, `serviceToComponent` (from the full `componentMap`, no bundle filter), `componentPlacement` (each component's own bundle + namespace).
- `synthesizeForBundle(bundle, reg)` becomes **pure accumulation**: own collectors under the router's component; injected backendRef rules under the backend component keyed by its **own** bundle/namespace; external bare Services unchanged (#239). `ensureComponent` errors on inconsistent placement.
- `reg.emitComponents(labelKey)` emits each component's policy **once in its own bundle**, merging own + injected rules; runs before `emitExternalBackends` so the external-vs-component collision check sees every component. `flush()` stays the only bundle mutation → any error leaves the cluster unmutated.
- **R3 fail-fast**: two components resolving to the same Service name is an ambiguous retarget target and errors, instead of a nondeterministic silent misroute.

## Behavior changes (intended)

- A cross-bundle backendRef carrying an authored `backendSelector` (#239) now **resolves to the component and ignores the selector** (component-label targeting wins) — extends the documented `BackendTarget` precedence across bundles.
- Ambiguous Service names now **fail the transform**.

## Tests

Stub harness (dependency-aware shape — launcher has no dependency-policy handler to build it via a real transform) + one real-handler cross-tier test:
- cross-bundle retarget lands the allow in the **backend's** bundle (not the router's);
- backend with its own inbound rule + a cross-bundle injection → exactly **one** merged policy (anti-duplicate);
- unresolved-no-selector stays authored; `backendSelector` on a resolvable ref is ignored;
- both R3 ambiguity shapes error;
- real handlers: `webservice` (httproute backendRef) → `statefulset` annotated into the `services` tier → two leaf bundles → allow retargets onto the statefulset's pods in its tier bundle.

## Verification

`make precommit`, `mise run build`, `check-doc-sync.sh`, `check-doc-gate.sh origin/main`, `check-forbidden-terms.sh --diff origin/main` — all pass. A correctness review pass over the 8 risk areas (bundle placement, determinism, R3 both shapes, atomicity, emit ordering, placement guard, nil paths, behavior changes) found no material bug.

## Downstream

Same-namespace only (no cross-namespace `ReferenceGrant`); `serviceToComponent` is not namespace-qualified, so this is correct under today's single-namespace-per-Application model. No crane change.